### PR TITLE
feat: NVIDIA support for the Schwab Equity Award JSON parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,75 +145,68 @@ possible._
 
 #### NVIDIA equity awards
 
-The JSON parser handles NVDA as well as GOOG/GOOGL. Schwab reports NVDA history
-in mixed units, and which fields are restated for the 4:1 split of 20 July 2021
-and the 10:1 of 10 June 2024 varies by record type.
+The JSON parser handles NVDA as well as GOOG/GOOGL. Schwab reports NVDA history in mixed units, and
+which fields are restated for the 4:1 split of 20 July 2021 and the 10:1 of 10 June 2024 varies by
+record type.
 
-| Record | Read as |
-|---|---|
-| `Deposit` / `RS` — vest | `Quantity` and `VestFairMarketValue` as recorded; both are already restated and agree |
-| `Deposit` / `ESPP` | `NetSharesDeposited` when tax was settled in shares, else `Quantity`, priced at `PurchaseFairMarketValue` |
-| `Lapse` | checked for consistency, then skipped |
-| `Sale` | multiplied by the split factor for the trade date, priced from `(Amount + fees) / Quantity` |
+| Record                  | Read as                                                                                                   |
+| ----------------------- | --------------------------------------------------------------------------------------------------------- |
+| `Deposit` / `RS` — vest | `Quantity` and `VestFairMarketValue` as recorded; both are already restated and agree                     |
+| `Deposit` / `ESPP`      | `NetSharesDeposited` when tax was settled in shares, else `Quantity`, priced at `PurchaseFairMarketValue` |
+| `Lapse`                 | checked for consistency, then skipped                                                                     |
+| `Sale`                  | multiplied by the split factor for the trade date, priced from `(Amount + fees) / Quantity`               |
 
 Three of these are worth spelling out.
 
-**ESPP cost basis is the market value, not the price paid.** The discount is
-taxed as employment income through payroll, so the shares enter the pool at
-what they were worth on the purchase date. Using `PurchasePrice` understates
-the basis by roughly tenfold on the older purchases. Since August 2025 the tax
-on a purchase is settled by holding back shares, and only the net reaches the
-pool.
+**ESPP cost basis is the market value, not the price paid.** The discount is taxed as employment
+income through payroll, so the shares enter the pool at what they were worth on the purchase date.
+Using `PurchasePrice` understates the basis by roughly tenfold on the older purchases. Since August
+2025 the tax on a purchase is settled by holding back shares, and only the net reaches the pool.
 
-**A `Lapse` is not an acquisition.** It duplicates its `Deposit`, and its
-`NetSharesDeposited` is in the units of the day while its price is restated.
-Pairing the two puts a tenth of the shares in the pool at the full price.
+**A `Lapse` is not an acquisition.** It duplicates its `Deposit`, and its `NetSharesDeposited` is in
+the units of the day while its price is restated. Pairing the two puts a tenth of the shares in the
+pool at the full price.
 
-**Disposals need the split multiplier and acquisitions do not.** Missing it
-costs 54 shares across two 2023 disposals, and the pool stays wrong by that
-much for every year afterwards. The factor comes from the split dates rather
-than from comparing the recorded price against a market price, which would need
-a network call and would stop working once the real price passed the threshold.
+**Disposals need the split multiplier and acquisitions do not.** Missing it costs 54 shares across
+two 2023 disposals, and the pool stays wrong by that much for every year afterwards. The factor
+comes from the split dates rather than from comparing the recorded price against a market price,
+which would need a network call and would stop working once the real price passed the threshold.
 
-The disposal price is derived from the money rather than the per-lot
-`SalePrice`, which is what allows a disposal to span lots sold at different
-prices.
+The disposal price is derived from the money rather than the per-lot `SalePrice`, which is what
+allows a disposal to span lots sold at different prices.
 
-`SPLITS` has to gain a row when NVDA next splits, and gains an entry when a
-stock the parser has not met before turns out to have split. Schwab restates
-acquisitions retroactively, so a stale export becomes a mix of old and new
-units and has to be downloaded again in full.
+`SPLITS` has to gain a row when NVDA next splits, and gains an entry when a stock the parser has not
+met before turns out to have split. Schwab restates acquisitions retroactively, so a stale export
+becomes a mix of old and new units and has to be downloaded again in full.
 
 ##### What the parser refuses to guess about
 
-Getting the units wrong does not change any amount of money, so nothing fails
-to balance and the run finishes on a different answer. Only the share count
-moves, and it surfaces years later as a pool that no longer matches the broker.
-Three things are therefore checked rather than assumed, and each raises:
+Getting the units wrong does not change any amount of money, so nothing fails to balance and the run
+finishes on a different answer. Only the share count moves, and it surfaces years later as a pool
+that no longer matches the broker. Three things are therefore checked rather than assumed, and each
+raises:
 
-- **The split table, against a `Lapse`.** A `Lapse` states both units at once —
-  its `Quantity` is restated while the counts inside it are in the units of
-  their own day — so `Quantity == (NetSharesDeposited +
-  SharesSoldWithheldForTaxes) × multiplier` has to hold. A missing or misdated
-  split breaks it, from the file alone, before any disposal is converted.
-- **That a disposal really was in the units of its day**, against the
-  acquisitions around it. Acquisitions are restated and sit in the same file,
-  so once a disposal is converted the two are comparable. Converting one Schwab
-  had already converted leaves it cheaper by the whole multiplier — 4, 10 or 40
-  — which the market does not manage between neighbouring vests. Upstream's
-  GOOG handling exists because Schwab restated some records and not others for
-  that split; whether NVDA is uniform is an observation, not a guarantee.
-- **That an ESPP purchase adds up.** Where tax is settled out of the shares,
-  deposited plus withheld plus sold has to equal what was bought. An empty
-  `NetSharesDeposited` and a `"0"` mean opposite things and both look like a
-  value, so the counts decide it rather than the field's emptiness.
+- **The split table, against a `Lapse`.** A `Lapse` states both units at once — its `Quantity` is
+  restated while the counts inside it are in the units of their own day — so
+  `Quantity == (NetSharesDeposited +
+  SharesSoldWithheldForTaxes) × multiplier` has to hold. A
+  missing or misdated split breaks it, from the file alone, before any disposal is converted.
+- **That a disposal really was in the units of its day**, against the acquisitions around it.
+  Acquisitions are restated and sit in the same file, so once a disposal is converted the two are
+  comparable. Converting one Schwab had already converted leaves it cheaper by the whole multiplier
+  — 4, 10 or 40 — which the market does not manage between neighbouring vests. Upstream's GOOG
+  handling exists because Schwab restated some records and not others for that split; whether NVDA
+  is uniform is an observation, not a guarantee.
+- **That an ESPP purchase adds up.** Where tax is settled out of the shares, deposited plus withheld
+  plus sold has to equal what was bought. An empty `NetSharesDeposited` and a `"0"` mean opposite
+  things and both look like a value, so the counts decide it rather than the field's emptiness.
 
-None of these has fired on a real export. They exist because the failure they
-describe is silent, and a silent wrong answer is worse than a loud refusal.
+None of these has fired on a real export. They exist because the failure they describe is silent,
+and a silent wrong answer is worse than a loud refusal.
 
-Covered by [tests/schwab/test_schwab_equity_award_nvda.py](tests/schwab/test_schwab_equity_award_nvda.py),
-against a synthetic portfolio with real dates and prices and invented share
-counts.
+Covered by
+[tests/schwab/test_schwab_equity_award_nvda.py](tests/schwab/test_schwab_equity_award_nvda.py),
+against a synthetic portfolio with real dates and prices and invented share counts.
 
 </details>
  <br />

--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ and the 10:1 of 10 June 2024 varies by record type.
 | Record | Read as |
 |---|---|
 | `Deposit` / `RS` — vest | `Quantity` and `VestFairMarketValue` as recorded; both are already restated and agree |
-| `Deposit` / `ESPP` | `NetSharesDeposited` when present, else `Quantity`, priced at `PurchaseFairMarketValue` |
-| `Lapse` | skipped |
+| `Deposit` / `ESPP` | `NetSharesDeposited` when tax was settled in shares, else `Quantity`, priced at `PurchaseFairMarketValue` |
+| `Lapse` | checked for consistency, then skipped |
 | `Sale` | multiplied by the split factor for the trade date, priced from `(Amount + fees) / Quantity` |
 
 Three of these are worth spelling out.
@@ -182,6 +182,33 @@ prices.
 `NVIDIA_SPLITS` has to gain a row when NVDA next splits. Schwab restates
 acquisitions retroactively, so a stale export becomes a mix of old and new
 units and has to be downloaded again in full.
+
+##### What the parser refuses to guess about
+
+Getting the units wrong does not change any amount of money, so nothing fails
+to balance and the run finishes on a different answer. Only the share count
+moves, and it surfaces years later as a pool that no longer matches the broker.
+Three things are therefore checked rather than assumed, and each raises:
+
+- **The split table, against a `Lapse`.** A `Lapse` states both units at once —
+  its `Quantity` is restated while the counts inside it are in the units of
+  their own day — so `Quantity == (NetSharesDeposited +
+  SharesSoldWithheldForTaxes) × multiplier` has to hold. A missing or misdated
+  split breaks it, from the file alone, before any disposal is converted.
+- **That a disposal really was in the units of its day**, against the
+  acquisitions around it. Acquisitions are restated and sit in the same file,
+  so once a disposal is converted the two are comparable. Converting one Schwab
+  had already converted leaves it cheaper by the whole multiplier — 4, 10 or 40
+  — which the market does not manage between neighbouring vests. Upstream's
+  GOOG handling exists because Schwab restated some records and not others for
+  that split; whether NVDA is uniform is an observation, not a guarantee.
+- **That an ESPP purchase adds up.** Where tax is settled out of the shares,
+  deposited plus withheld plus sold has to equal what was bought. An empty
+  `NetSharesDeposited` and a `"0"` mean opposite things and both look like a
+  value, so the counts decide it rather than the field's emptiness.
+
+None of these has fired on a real export. They exist because the failure they
+describe is silent, and a silent wrong answer is worse than a loud refusal.
 
 Covered by [tests/schwab/test_schwab_equity_award_nvda.py](tests/schwab/test_schwab_equity_award_nvda.py),
 against a synthetic portfolio with real dates and prices and invented share

--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ The disposal price is derived from the money rather than the per-lot
 `SalePrice`, which is what allows a disposal to span lots sold at different
 prices.
 
-`NVIDIA_SPLITS` has to gain a row when NVDA next splits. Schwab restates
+`SPLITS` has to gain a row when NVDA next splits, and gains an entry when a
+stock the parser has not met before turns out to have split. Schwab restates
 acquisitions retroactively, so a stale export becomes a mix of old and new
 units and has to be downloaded again in full.
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,50 @@ _Note: For historic reasons, it is possible to provide the Equity Awards history
 [parser file](cgt_calc/parsers/schwab_equity_award_json.py). Please use the CSV method above if
 possible._
 
+#### NVIDIA equity awards
+
+The JSON parser handles NVDA as well as GOOG/GOOGL. Schwab reports NVDA history
+in mixed units, and which fields are restated for the 4:1 split of 20 July 2021
+and the 10:1 of 10 June 2024 varies by record type.
+
+| Record | Read as |
+|---|---|
+| `Deposit` / `RS` — vest | `Quantity` and `VestFairMarketValue` as recorded; both are already restated and agree |
+| `Deposit` / `ESPP` | `NetSharesDeposited` when present, else `Quantity`, priced at `PurchaseFairMarketValue` |
+| `Lapse` | skipped |
+| `Sale` | multiplied by the split factor for the trade date, priced from `(Amount + fees) / Quantity` |
+
+Three of these are worth spelling out.
+
+**ESPP cost basis is the market value, not the price paid.** The discount is
+taxed as employment income through payroll, so the shares enter the pool at
+what they were worth on the purchase date. Using `PurchasePrice` understates
+the basis by roughly tenfold on the older purchases. Since August 2025 the tax
+on a purchase is settled by holding back shares, and only the net reaches the
+pool.
+
+**A `Lapse` is not an acquisition.** It duplicates its `Deposit`, and its
+`NetSharesDeposited` is in the units of the day while its price is restated.
+Pairing the two puts a tenth of the shares in the pool at the full price.
+
+**Disposals need the split multiplier and acquisitions do not.** Missing it
+costs 54 shares across two 2023 disposals, and the pool stays wrong by that
+much for every year afterwards. The factor comes from the split dates rather
+than from comparing the recorded price against a market price, which would need
+a network call and would stop working once the real price passed the threshold.
+
+The disposal price is derived from the money rather than the per-lot
+`SalePrice`, which is what allows a disposal to span lots sold at different
+prices.
+
+`NVIDIA_SPLITS` has to gain a row when NVDA next splits. Schwab restates
+acquisitions retroactively, so a stale export becomes a mix of old and new
+units and has to be downloaded again in full.
+
+Covered by [tests/schwab/test_schwab_equity_award_nvda.py](tests/schwab/test_schwab_equity_award_nvda.py),
+against a synthetic portfolio with real dates and prices and invented share
+counts.
+
 </details>
  <br />
 <details>

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ possible._
 
 #### NVIDIA equity awards
 
-The JSON parser handles NVDA as well as GOOG/GOOGL. Schwab reports NVDA history in mixed units, and
+The JSON parser handles NVDA as well as GOOG/GOOGL. Schwab reports NVDA history in mixed units:
 which fields are restated for the 4:1 split of 20 July 2021 and the 10:1 of 10 June 2024 varies by
 record type.
 
@@ -156,53 +156,28 @@ record type.
 | `Lapse`                 | checked for consistency, then skipped                                                                     |
 | `Sale`                  | multiplied by the split factor for the trade date, priced from `(Amount + fees) / Quantity`               |
 
-Three of these are worth spelling out.
+Three of these change a number:
 
-**ESPP cost basis is the market value, not the price paid.** The discount is taxed as employment
-income through payroll, so the shares enter the pool at what they were worth on the purchase date.
-Using `PurchasePrice` understates the basis by roughly tenfold on the older purchases. Since August
-2025 the tax on a purchase is settled by holding back shares, and only the net reaches the pool.
+- **ESPP enters the pool at market value, not the price paid.** The discount is taxed as employment
+  income through payroll. Using `PurchasePrice` understates the basis roughly tenfold on the older
+  purchases.
+- **A `Lapse` is not an acquisition.** It duplicates its `Deposit`, and its counts are in the units
+  of their own day while its price is restated; pairing them pools a tenth of the shares at the full
+  price.
+- **Disposals need the split multiplier and acquisitions do not.** Missing it costs 54 shares across
+  two 2023 disposals, and the pool stays wrong by that much every year after.
 
-**A `Lapse` is not an acquisition.** It duplicates its `Deposit`, and its `NetSharesDeposited` is in
-the units of the day while its price is restated. Pairing the two puts a tenth of the shares in the
-pool at the full price.
+Getting the units wrong changes no amount of money, so nothing fails to balance and only the share
+count moves. Two things are therefore checked and raise `ParsingError`: the split table against a
+`Lapse`, which states both units at once so
+`Quantity == (NetSharesDeposited +
+SharesSoldWithheldForTaxes) × multiplier` has to hold; and that
+an ESPP purchase adds up, deposited plus withheld plus sold against what was bought. A third only
+warns — a disposal priced far below the acquisitions around it has usually been restated twice, but
+a share that fell that far looks the same.
 
-**Disposals need the split multiplier and acquisitions do not.** Missing it costs 54 shares across
-two 2023 disposals, and the pool stays wrong by that much for every year afterwards. The factor
-comes from the split dates rather than from comparing the recorded price against a market price,
-which would need a network call and would stop working once the real price passed the threshold.
-
-The disposal price is derived from the money rather than the per-lot `SalePrice`, which is what
-allows a disposal to span lots sold at different prices.
-
-`SPLITS` has to gain a row when NVDA next splits, and gains an entry when a stock the parser has not
-met before turns out to have split. Schwab restates acquisitions retroactively, so a stale export
-becomes a mix of old and new units and has to be downloaded again in full.
-
-##### What the parser refuses to guess about
-
-Getting the units wrong does not change any amount of money, so nothing fails to balance and the run
-finishes on a different answer. Only the share count moves, and it surfaces years later as a pool
-that no longer matches the broker. Three things are therefore checked rather than assumed, and each
-raises:
-
-- **The split table, against a `Lapse`.** A `Lapse` states both units at once — its `Quantity` is
-  restated while the counts inside it are in the units of their own day — so
-  `Quantity == (NetSharesDeposited +
-  SharesSoldWithheldForTaxes) × multiplier` has to hold. A
-  missing or misdated split breaks it, from the file alone, before any disposal is converted.
-- **That a disposal really was in the units of its day**, against the acquisitions around it.
-  Acquisitions are restated and sit in the same file, so once a disposal is converted the two are
-  comparable. Converting one Schwab had already converted leaves it cheaper by the whole multiplier
-  — 4, 10 or 40 — which the market does not manage between neighbouring vests. Upstream's GOOG
-  handling exists because Schwab restated some records and not others for that split; whether NVDA
-  is uniform is an observation, not a guarantee.
-- **That an ESPP purchase adds up.** Where tax is settled out of the shares, deposited plus withheld
-  plus sold has to equal what was bought. An empty `NetSharesDeposited` and a `"0"` mean opposite
-  things and both look like a value, so the counts decide it rather than the field's emptiness.
-
-None of these has fired on a real export. They exist because the failure they describe is silent,
-and a silent wrong answer is worse than a loud refusal.
+`SPLITS` gains a row when NVDA next splits. Schwab restates acquisitions retroactively, so a stale
+export becomes a mix of units and has to be downloaded again in full.
 
 Covered by
 [tests/schwab/test_schwab_equity_award_nvda.py](tests/schwab/test_schwab_equity_award_nvda.py),

--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -129,6 +129,22 @@ def _restates_acquisitions_only(symbol: str | None) -> bool:
     return history is not None and history.restatement is Restatement.ACQUISITIONS_ONLY
 
 
+def _detail_counts_multiplier(symbol: str | None, on: datetime.date) -> int:
+    """Factor turning counts inside a row's details into current units.
+
+    A row's own `Quantity` is restated for later splits while the counts inside
+    its `TransactionDetails` are in the units of their own day. The two are
+    therefore only comparable through this factor, and a count taken from the
+    details only reaches the pool through it.
+
+    Returns 1 where the export does not restate uniformly, because there the
+    difference cannot be told apart in the first place.
+    """
+    if not _restates_acquisitions_only(symbol):
+        return 1
+    return split_multiplier(symbol, on)
+
+
 @dataclass
 class FieldNames:
     """Names of the fields in the Schwab JSON data, depending on the schema version."""
@@ -322,6 +338,7 @@ def _espp_net_shares(
     details: JsonRowType,
     names: FieldNames,
     quantity: Decimal,
+    multiplier: int,
     file: Path,
 ) -> Decimal:
     """How many of an ESPP purchase's shares reach the pool.
@@ -330,6 +347,11 @@ def _espp_net_shares(
     case what was deposited, withheld and sold has to add back up to what was
     bought. Shares taken for tax were never acquired, so they are not a
     disposal and produce no gain; they simply never enter the pool.
+
+    The counts are in the units of the purchase date and `quantity` is
+    restated, so both the identity and the pooled figure go through
+    `multiplier`. Without it a purchase made before a later split reads as one
+    that does not add up, and the file stops parsing.
     """
     deposited = _optional_decimal(details, names.net_shares_deposited)
     withheld = _optional_decimal(details, names.shares_withheld)
@@ -348,17 +370,20 @@ def _espp_net_shares(
             "does not say how many were deposited",
         )
 
-    accounted = deposited + (withheld or Decimal(0)) + (sold or Decimal(0))
+    accounted = (
+        deposited + (withheld or Decimal(0)) + (sold or Decimal(0))
+    ) * multiplier
     if accounted != quantity:
         raise ParsingError(
             file,
             f"ESPP purchase on {when} bought {quantity} shares but accounts "
             f"for {accounted}: {deposited} deposited, {withheld or 0} "
-            f"withheld, {sold or 0} sold. Pooling the deposited count alone "
-            "would drop the difference without saying so",
+            f"withheld, {sold or 0} sold, at a split multiplier of "
+            f"{multiplier}. Pooling the deposited count alone would drop the "
+            "difference without saying so",
         )
 
-    return deposited
+    return deposited * multiplier
 
 
 def _check_lapse_units(
@@ -395,7 +420,7 @@ def _check_lapse_units(
             continue
 
         date = datetime.datetime.strptime(row[names.date], "%m/%d/%Y").date()
-        multiplier = split_multiplier(symbol, date)
+        multiplier = _detail_counts_multiplier(symbol, date)
         quantity = _decimal_from_number_or_str(row, names.quantity)
         expected = (deposited + withheld) * multiplier
 
@@ -558,7 +583,13 @@ class SchwabTransaction(BrokerTransaction):
                 # So the counts have to account for every share bought. That
                 # settles it either way, and it is the same identity a Lapse
                 # has to satisfy.
-                quantity = _espp_net_shares(details, names, quantity, file)
+                quantity = _espp_net_shares(
+                    details,
+                    names,
+                    quantity,
+                    _detail_counts_multiplier(symbol, date),
+                    file,
+                )
 
                 amount = price * quantity
                 description = f"ESPP purchase on {details[names.purchase_date]}"

--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from dataclasses import InitVar, dataclass
 import datetime
 from decimal import Decimal
+from enum import Enum, auto
 import json
 import logging
 from typing import TYPE_CHECKING, Any, ClassVar, Final, TextIO, override
@@ -35,32 +36,97 @@ if TYPE_CHECKING:
 OPTIONAL_DETAILS_NAME: Final = "Details"
 FIELD_TO_SCHEMA: Final = {"transactions": 1, "Transactions": 2}
 LOGGER = logging.getLogger(__name__)
-GOOGLE_SYMBOLS = {"GOOG", "GOOGL"}
-NVIDIA_SYMBOLS = {"NVDA"}
 
-# NVDA splits, dated to the first day the new shares traded.
+
+class Restatement(Enum):
+    """What the export did to records that predate a split."""
+
+    ACQUISITIONS_ONLY = auto()
+    """Acquisitions restated into current units, disposals left in their own.
+
+    Only disposals need converting, and the split dates alone say by how much.
+    """
+
+    UNRELIABLE = auto()
+    """Some records restated and some not, with nothing in the file saying which.
+
+    The price has to give the units away, so this needs `presplit_price_floor`.
+    """
+
+
+@dataclass(frozen=True)
+class SplitHistory:
+    """Splits for one symbol, and what the export did to records before them."""
+
+    splits: tuple[tuple[datetime.date, int], ...]
+    """Ratios against the first day on which counts are in the new units."""
+
+    restatement: Restatement
+
+    presplit_price_floor: Decimal | None = None
+    """A price above which a row is certainly still in pre-split units.
+
+    Set it above the highest price the share reached before its earliest split
+    and below the lowest price it can plausibly reach after: everything in
+    between is indistinguishable. Only meaningful with UNRELIABLE.
+    """
+
+    def __post_init__(self) -> None:
+        """Reject a table that cannot be applied."""
+        if (self.restatement is Restatement.UNRELIABLE) != (
+            self.presplit_price_floor is not None
+        ):
+            raise ValueError(
+                "presplit_price_floor is required for UNRELIABLE and "
+                "meaningless otherwise"
+            )
+
+
+# Splits dated to the first day on which the export states counts in the new
+# units, which is the day after a split effective at the close.
 #
-# Schwab restates acquisitions for later splits but leaves sales in the units
-# of their own day, so sales need converting and acquisitions do not. Dates
-# rather than a price heuristic: a heuristic needs the market price of the day,
-# which means a network call, and it stops working as soon as the real price
-# passes the threshold it guesses with.
-NVIDIA_SPLITS: Final = (
-    (datetime.date(2021, 7, 20), 4),
-    (datetime.date(2024, 6, 10), 10),
-)
+# Dates rather than a price heuristic wherever the export allows it: a
+# heuristic needs the market price of the day, which means a network call, and
+# it stops working as soon as the real price passes the threshold it guesses
+# with. GOOG is UNRELIABLE only because its export leaves nothing better.
+SPLITS: Final = {
+    "NVDA": SplitHistory(
+        ((datetime.date(2021, 7, 20), 4), (datetime.date(2024, 6, 10), 10)),
+        Restatement.ACQUISITIONS_ONLY,
+    ),
+    "GOOG": SplitHistory(
+        ((datetime.date(2022, 7, 16), 20),),
+        Restatement.UNRELIABLE,
+        # GOOG never traded above $175 * 20 = $3500 before the split.
+        presplit_price_floor=Decimal(175),
+    ),
+    "GOOGL": SplitHistory(
+        ((datetime.date(2022, 7, 16), 20),),
+        Restatement.UNRELIABLE,
+        presplit_price_floor=Decimal(175),
+    ),
+}
 
 
-def nvidia_split_multiplier(on: datetime.date) -> int:
+def split_multiplier(symbol: str | None, on: datetime.date) -> int:
     """Factor turning a share count printed on `on` into current units.
 
     Prices divide by the same factor, so the money is unchanged.
     """
+    history = SPLITS.get(symbol or "")
+    if history is None:
+        return 1
     factor = 1
-    for effective, ratio in NVIDIA_SPLITS:
+    for effective, ratio in history.splits:
         if on < effective:
             factor *= ratio
     return factor
+
+
+def _restates_acquisitions_only(symbol: str | None) -> bool:
+    """Whether disposals of `symbol` are the only records left un-restated."""
+    history = SPLITS.get(symbol or "")
+    return history is not None and history.restatement is Restatement.ACQUISITIONS_ONLY
 
 
 @dataclass
@@ -313,9 +379,9 @@ def _check_lapse_units(
     for row in rows:
         if row.get(names.action) != "Lapse":
             continue
-        if TICKER_RENAMES.get(row.get(names.symbol), row.get(names.symbol)) not in (
-            NVIDIA_SYMBOLS
-        ):
+        symbol = row.get(names.symbol)
+        symbol = TICKER_RENAMES.get(symbol, symbol)
+        if not _restates_acquisitions_only(symbol):
             continue
 
         detail_rows = row.get(names.transac_details) or []
@@ -329,7 +395,7 @@ def _check_lapse_units(
             continue
 
         date = datetime.datetime.strptime(row[names.date], "%m/%d/%Y").date()
-        multiplier = nvidia_split_multiplier(date)
+        multiplier = split_multiplier(symbol, date)
         quantity = _decimal_from_number_or_str(row, names.quantity)
         expected = (deposited + withheld) * multiplier
 
@@ -372,7 +438,7 @@ def _check_disposal_units(
         for transaction in transactions
         if transaction.action == ActionType.STOCK_ACTIVITY
         and transaction.price
-        and transaction.symbol in NVIDIA_SYMBOLS
+        and _restates_acquisitions_only(transaction.symbol)
     ]
     if not acquisitions:
         return
@@ -380,17 +446,25 @@ def _check_disposal_units(
     for transaction in transactions:
         if (
             transaction.action != ActionType.SELL
-            or transaction.symbol not in NVIDIA_SYMBOLS
+            or not _restates_acquisitions_only(transaction.symbol)
             or not transaction.price
         ):
             continue
 
-        multiplier = nvidia_split_multiplier(transaction.date)
+        multiplier = split_multiplier(transaction.symbol, transaction.date)
         if multiplier == 1:
             continue
 
+        same_symbol = [
+            acquisition
+            for acquisition in acquisitions
+            if acquisition.symbol == transaction.symbol
+        ]
+        if not same_symbol:
+            continue
+
         nearest = min(
-            acquisitions,
+            same_symbol,
             key=lambda acquisition: abs((acquisition.date - transaction.date).days),
         )
         if not nearest.price:
@@ -428,16 +502,16 @@ class SchwabTransaction(BrokerTransaction):
         action = action_from_str(self.raw_action, file)
         symbol = row.get(names.symbol)
         symbol = TICKER_RENAMES.get(symbol, symbol)
-        if symbol not in GOOGLE_SYMBOLS | NVIDIA_SYMBOLS:
+        if symbol not in SPLITS:
             LOGGER.warning(
-                "The Schwab Equity Award JSON parser was only tested for "
-                "Google and NVIDIA stocks (%s), but found symbol '%s'. "
+                "The Schwab Equity Award JSON parser was only tested for the "
+                "stocks whose splits it knows (%s), but found symbol '%s'. "
                 "Everything else is parsed as usual; what is not applied is "
                 "stock split normalization, which this parser only knows for "
                 "the symbols above. If '%s' has split since the earliest "
                 "transaction here, check the share counts against a broker "
                 "statement before filing.",
-                ", ".join(sorted(GOOGLE_SYMBOLS | NVIDIA_SYMBOLS)),
+                ", ".join(sorted(SPLITS)),
                 symbol,
                 symbol,
             )
@@ -502,7 +576,7 @@ class SchwabTransaction(BrokerTransaction):
         elif row[names.action] == "Sale":
             date = datetime.datetime.strptime(row[names.date], "%m/%d/%Y").date()
 
-            if symbol in NVIDIA_SYMBOLS:
+            if _restates_acquisitions_only(symbol):
                 # Derive the price from the money rather than from the per-lot
                 # SalePrice. Amount is net of fees, so the gross is rebuilt
                 # first. Two reasons this is not just a shortcut:
@@ -605,16 +679,19 @@ class SchwabTransaction(BrokerTransaction):
             broker,
         )
 
-        if symbol in GOOGLE_SYMBOLS:
-            self._normalize_google_split()
-        elif symbol in NVIDIA_SYMBOLS:
-            self._normalize_nvidia_split()
+        history = SPLITS.get(symbol or "")
+        if history is None:
+            return
+        if history.restatement is Restatement.ACQUISITIONS_ONLY:
+            self._convert_disposal_to_current_units()
+        else:
+            self._convert_row_priced_before_a_split(history)
 
-    def _normalize_nvidia_split(self) -> None:
+    def _convert_disposal_to_current_units(self) -> None:
         """Convert a disposal into current share units.
 
-        Schwab restates acquisitions for later splits — a vest of 3,000 at
-        $22.341 is recorded that way even though 300 at $223.41 is what
+        Schwab restates acquisitions for later splits — an NVDA vest of 3,000
+        at $22.341 is recorded that way even though 300 at $223.41 is what
         happened — but leaves disposals in the units of their own day. Only
         disposals need converting.
 
@@ -624,37 +701,29 @@ class SchwabTransaction(BrokerTransaction):
         if self.action != ActionType.SELL:
             return
 
-        multiplier = nvidia_split_multiplier(self.date)
+        self._rescale(split_multiplier(self.symbol, self.date))
+
+    def _convert_row_priced_before_a_split(self, history: SplitHistory) -> None:
+        """Convert a row whose price shows it was never restated.
+
+        Where the export restates some records and not others, with nothing
+        saying which, the price is the only witness left: above the floor it
+        can only be pre-split money. GOOG is the reason this exists — as of
+        2022-08-07 its exports were restated only in part.
+        """
+        floor = history.presplit_price_floor
+        assert floor is not None  # guaranteed by SplitHistory.__post_init__
+        if self.price and self.price > floor and self.quantity:
+            self._rescale(split_multiplier(self.symbol, self.date))
+
+    def _rescale(self, multiplier: int) -> None:
+        """Restate this row in current units, leaving the money unchanged."""
         if multiplier == 1:
             return
-
         if self.quantity:
             self.quantity = round_decimal(self.quantity * multiplier, ROUND_DIGITS)
         if self.price:
             self.price = round_decimal(self.price / multiplier, ROUND_DIGITS)
-
-    def _normalize_google_split(self) -> None:
-        """Ensure past transactions are normalized to split values.
-
-        This is in the context of the 20:1 GOOG stock split which happened at
-        close on 2022-07-15 20:1.
-
-        As of 2022-08-07, Schwab's data exports have some past transactions
-        corrected for the 20:1 split on 2022-07-15, whereas others are not.
-        """
-        split_factor = 20
-        threshold_price = 175
-
-        # The share price has never been above $175*20=$3500 before 2022-07-15
-        # so this price is expressed in pre-split amounts: normalize to post-split
-        if (
-            self.date <= datetime.date(2022, 7, 15)
-            and self.price
-            and self.price > threshold_price
-            and self.quantity
-        ):
-            self.price = round_decimal(self.price / split_factor, ROUND_DIGITS)
-            self.quantity = round_decimal(self.quantity * split_factor, ROUND_DIGITS)
 
 
 class SchwabEquityAwardsJSONParser(BaseSingleFileParser):

--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -334,6 +334,25 @@ def _optional_decimal(details: JsonRowType, field_name: str) -> Decimal | None:
     return _decimal_from_str(value)
 
 
+def _lot_share_sum(row: JsonRowType, names: FieldNames) -> Decimal | None:
+    """Recover a sale's quantity where the row rounds it and the lots do not.
+
+    Returns None when the lots cannot answer: one of them states no count, or
+    they are all whole and the row's own figure was already exact.
+    """
+    total = Decimal(0)
+    found_decimals = False
+    for subtransac in row[names.transac_details]:
+        details = subtransac.get(OPTIONAL_DETAILS_NAME, subtransac)
+        if names.shares not in details:
+            return None
+        shares = _decimal_from_str(details[names.shares])
+        total += shares
+        if not _is_integer(shares):
+            found_decimals = True
+    return total if found_decimals else None
+
+
 def _espp_net_shares(
     details: JsonRowType,
     names: FieldNames,
@@ -620,6 +639,10 @@ class SchwabTransaction(BrokerTransaction):
                 # the units of the trade date while the pool is in current
                 # ones, so it would need converting anyway. Working from the
                 # money sidesteps both, and the money is the same in any units.
+                #
+                # The count still has to come from the lots when the row has
+                # rounded it away, or the pool loses the fraction silently.
+                quantity = _lot_share_sum(row, names) or quantity
                 price = (amount + fees) / quantity
             elif not _is_integer(quantity):
                 price = (amount + fees) / quantity
@@ -818,6 +841,18 @@ class SchwabEquityAwardsJSONParser(BaseSingleFileParser):
             # source on dividends, and it is needed for SA106 and foreign tax
             # credit relief.
             if transac[fields.action] not in {"Journal", "Wire Transfer", "Lapse"}
+        ]
+
+        # A purchase whose every share went to tax acquired nothing. Keeping it
+        # would offer the calculator an acquisition of zero shares, which it
+        # rightly refuses; the tax on it is settled through payroll either way.
+        transactions = [
+            transaction
+            for transaction in transactions
+            if not (
+                transaction.action == ActionType.STOCK_ACTIVITY
+                and transaction.quantity == 0
+            )
         ]
 
         # And after: each converted disposal against the acquisitions around it.

--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -591,6 +591,11 @@ class SchwabTransaction(BrokerTransaction):
         names = field_names
         description = row[names.description]
         self.raw_action = row[names.action]
+
+        # Set where a purchase is known to have pooled nothing. A quantity of
+        # zero reached any other way is a malformed row, and has to stay
+        # visible so the calculator can refuse it.
+        self.acquired_nothing = False
         action = action_from_str(self.raw_action, file)
         symbol = row.get(names.symbol)
         symbol = TICKER_RENAMES.get(symbol, symbol)
@@ -655,6 +660,7 @@ class SchwabTransaction(BrokerTransaction):
                     _detail_counts_multiplier(symbol, date),
                     file,
                 )
+                self.acquired_nothing = quantity == 0
 
                 amount = price * quantity
                 description = f"ESPP purchase on {details[names.purchase_date]}"
@@ -892,16 +898,15 @@ class SchwabEquityAwardsJSONParser(BaseSingleFileParser):
             if transac[fields.action] not in {"Journal", "Wire Transfer", "Lapse"}
         ]
 
-        # A purchase whose every share went to tax acquired nothing. Keeping it
-        # would offer the calculator an acquisition of zero shares, which it
-        # rightly refuses; the tax on it is settled through payroll either way.
+        # A purchase whose every share went to tax acquired nothing, so it is
+        # not offered as an acquisition of zero, which the calculator rightly
+        # refuses. Only that case: a zero that arrives any other way — a vest
+        # whose Quantity is blank, say — is a malformed row, and refusing it
+        # loudly beats dropping it and reporting a smaller holding.
         transactions = [
             transaction
             for transaction in transactions
-            if not (
-                transaction.action == ActionType.STOCK_ACTIVITY
-                and transaction.quantity == 0
-            )
+            if not transaction.acquired_nothing
         ]
 
         # And after: each converted disposal against the acquisitions around it.

--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -29,6 +29,7 @@ from cgt_calc.util import round_decimal
 from .base_parsers import BaseSingleFileParser
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
 
 OPTIONAL_DETAILS_NAME: Final = "Details"
@@ -88,6 +89,10 @@ class FieldNames:
     purchase_date: str = "PurchaseDate"
     purchase_fair_market_value: str = "PurchaseFairMarketValue"
     net_shares_deposited: str = "NetSharesDeposited"
+    shares_withheld: str = "SharesWithheld"
+    shares_sold: str = "SharesSold"
+    shares_sold_withheld_for_taxes: str = "SharesSoldWithheldForTaxes"
+    tax_withholding_method: str = "TaxWithholdingMethod"
 
     def __post_init__(self, schema_version: int) -> None:
         """Set correct field names if the schema is not the default one.
@@ -113,6 +118,10 @@ class FieldNames:
             self.purchase_date = "purchaseDate"
             self.purchase_fair_market_value = "purchaseFairMarketValue"
             self.net_shares_deposited = "netSharesDeposited"
+            self.shares_withheld = "sharesWithheld"
+            self.shares_sold = "sharesSold"
+            self.shares_sold_withheld_for_taxes = "sharesSoldWithheldForTaxes"
+            self.tax_withholding_method = "taxWithholdingMethod"
 
 
 # We want enough decimals to cover what Schwab gives us (up to 4 decimals)
@@ -231,6 +240,183 @@ def _is_integer(number: Decimal) -> bool:
     return number % 1 == 0
 
 
+def _optional_decimal(details: JsonRowType, field_name: str) -> Decimal | None:
+    """Read a count Schwab may leave blank.
+
+    An absent field and an empty one mean the same thing: Schwab had nothing to
+    put there. A "0" does not — it is a count, and a real one.
+    """
+    value = details.get(field_name)
+    if value is None or value == "":
+        return None
+    return _decimal_from_str(value)
+
+
+def _espp_net_shares(
+    details: JsonRowType,
+    names: FieldNames,
+    quantity: Decimal,
+    file: Path,
+) -> Decimal:
+    """How many of an ESPP purchase's shares reach the pool.
+
+    All of them, unless tax was settled out of the purchase itself, in which
+    case what was deposited, withheld and sold has to add back up to what was
+    bought. Shares taken for tax were never acquired, so they are not a
+    disposal and produce no gain; they simply never enter the pool.
+    """
+    deposited = _optional_decimal(details, names.net_shares_deposited)
+    withheld = _optional_decimal(details, names.shares_withheld)
+    sold = _optional_decimal(details, names.shares_sold)
+    method = details.get(names.tax_withholding_method)
+
+    if deposited is None and withheld is None and sold is None and not method:
+        return quantity
+
+    when = details.get(names.purchase_date, "an unknown date")
+
+    if deposited is None:
+        raise ParsingError(
+            file,
+            f"ESPP purchase on {when} settles tax in shares ({method}) but "
+            "does not say how many were deposited",
+        )
+
+    accounted = deposited + (withheld or Decimal(0)) + (sold or Decimal(0))
+    if accounted != quantity:
+        raise ParsingError(
+            file,
+            f"ESPP purchase on {when} bought {quantity} shares but accounts "
+            f"for {accounted}: {deposited} deposited, {withheld or 0} "
+            f"withheld, {sold or 0} sold. Pooling the deposited count alone "
+            "would drop the difference without saying so",
+        )
+
+    return deposited
+
+
+def _check_lapse_units(
+    rows: list[JsonRowType], file_path: Path, names: FieldNames
+) -> None:
+    """Check the split table against the record that states both units.
+
+    A Lapse is not an acquisition and is discarded, but on the way past it
+    proves something no other record can. Its Quantity is restated for later
+    splits while the counts inside it are in the units of their own day, so the
+    two are related by exactly the split multiplier and nothing else.
+
+    That makes the split table falsifiable using only the file. If a date is
+    wrong, or a split has happened that this code has not been told about, it
+    surfaces here — before any disposal has been converted on the strength of
+    it.
+    """
+    for row in rows:
+        if row.get(names.action) != "Lapse":
+            continue
+        if TICKER_RENAMES.get(row.get(names.symbol), row.get(names.symbol)) not in (
+            NVIDIA_SYMBOLS
+        ):
+            continue
+
+        detail_rows = row.get(names.transac_details) or []
+        if not detail_rows:
+            continue
+        details = detail_rows[0].get(OPTIONAL_DETAILS_NAME, detail_rows[0])
+
+        deposited = _optional_decimal(details, names.net_shares_deposited)
+        withheld = _optional_decimal(details, names.shares_sold_withheld_for_taxes)
+        if deposited is None or withheld is None:
+            continue
+
+        date = datetime.datetime.strptime(row[names.date], "%m/%d/%Y").date()
+        multiplier = nvidia_split_multiplier(date)
+        quantity = _decimal_from_number_or_str(row, names.quantity)
+        expected = (deposited + withheld) * multiplier
+
+        if quantity != expected:
+            raise ParsingError(
+                file_path,
+                f"The lapse on {row[names.date]} reports {quantity} shares, "
+                f"but {deposited} deposited plus {withheld} withheld at a "
+                f"split multiplier of {multiplier} makes {expected}. Either "
+                "the split table in this file is wrong or a split is missing "
+                "from it; every disposal before that split would be converted "
+                "by the wrong factor",
+            )
+
+
+def _check_disposal_units(
+    transactions: Sequence[BrokerTransaction], file_path: Path
+) -> None:
+    """Check that disposals really were in the units of their own day.
+
+    Converting them rests on Schwab restating acquisitions for later splits and
+    leaving disposals alone. That is what its NVDA exports do, but it is an
+    observation about the file rather than a guarantee, and the GOOG handling
+    in this same parser exists because Schwab restated some records and not
+    others for that split.
+
+    Getting it wrong is silent: the money is unchanged, so nothing fails to
+    balance. Only the share count moves, and the error surfaces years later as
+    a pool that no longer matches the broker.
+
+    Acquisitions are the yardstick. They are restated, they sit in the same
+    file, and once a disposal has been converted the two are in the same units,
+    so a disposal should cost about what shares cost around it. Converting one
+    that Schwab had already converted leaves it cheaper by exactly the
+    multiplier — 4, 10 or 40 — and the market does not move that far between
+    neighbouring vests.
+    """
+    acquisitions = [
+        transaction
+        for transaction in transactions
+        if transaction.action == ActionType.STOCK_ACTIVITY
+        and transaction.price
+        and transaction.symbol in NVIDIA_SYMBOLS
+    ]
+    if not acquisitions:
+        return
+
+    for transaction in transactions:
+        if (
+            transaction.action != ActionType.SELL
+            or transaction.symbol not in NVIDIA_SYMBOLS
+            or not transaction.price
+        ):
+            continue
+
+        multiplier = nvidia_split_multiplier(transaction.date)
+        if multiplier == 1:
+            continue
+
+        nearest = min(
+            acquisitions,
+            key=lambda acquisition: abs((acquisition.date - transaction.date).days),
+        )
+        if not nearest.price:
+            continue
+
+        ratio = transaction.price / nearest.price
+
+        # Between "these agree" and "this one is a multiplier too cheap", take
+        # whichever is nearer on a log scale: ratio < 1/sqrt(multiplier), or
+        # ratio^2 * multiplier < 1 without a square root. The two hypotheses
+        # are a factor of 4 apart at the very least, so the midpoint is not a
+        # threshold that needs tuning.
+        if ratio * ratio * multiplier < 1:
+            raise ParsingError(
+                file_path,
+                f"The disposal on {transaction.date} works out at "
+                f"{transaction.price:.4f} a share once converted for the "
+                f"{multiplier}:1 split, against {nearest.price:.4f} for the "
+                f"acquisition on {nearest.date}. Being cheaper by about the "
+                "split multiplier is what it looks like when Schwab had "
+                "already restated a disposal and it was converted a second "
+                "time, which would take the wrong number of shares out of the "
+                "pool while leaving the proceeds right",
+            )
+
+
 class SchwabTransaction(BrokerTransaction):
     """Represent single Schwab transaction."""
 
@@ -244,10 +430,15 @@ class SchwabTransaction(BrokerTransaction):
         symbol = TICKER_RENAMES.get(symbol, symbol)
         if symbol not in GOOGLE_SYMBOLS | NVIDIA_SYMBOLS:
             LOGGER.warning(
-                "The Schwab Equity Award JSON parser was only tested for Google "
-                "and NVIDIA stocks (%s), but found symbol '%s'. Please check "
-                "the parsing and output are correct!",
+                "The Schwab Equity Award JSON parser was only tested for "
+                "Google and NVIDIA stocks (%s), but found symbol '%s'. "
+                "Everything else is parsed as usual; what is not applied is "
+                "stock split normalization, which this parser only knows for "
+                "the symbols above. If '%s' has split since the earliest "
+                "transaction here, check the share counts against a broker "
+                "statement before filing.",
                 ", ".join(sorted(GOOGLE_SYMBOLS | NVIDIA_SYMBOLS)),
+                symbol,
                 symbol,
             )
         quantity = _decimal_from_number_or_str(row, names.quantity)
@@ -276,16 +467,22 @@ class SchwabTransaction(BrokerTransaction):
                 date = datetime.datetime.strptime(
                     details[names.purchase_date], "%m/%d/%Y"
                 ).date()
-                price = _decimal_from_str(
-                    details[names.purchase_fair_market_value]
-                )
+                price = _decimal_from_str(details[names.purchase_fair_market_value])
 
-                # Since August 2025 the tax on a purchase is settled by holding
-                # back some of the shares, and only the rest reaches the pool.
-                # Before that this field is empty and Quantity is already net.
-                net_shares = details.get(names.net_shares_deposited)
-                if net_shares:
-                    quantity = _decimal_from_str(net_shares)
+                # Since August 2025 the tax on a purchase is settled out of the
+                # shares themselves, and only the rest reaches the pool. Before
+                # that these fields are empty and Quantity is already net.
+                #
+                # Whether the field holds anything is not the signal. An empty
+                # string and a "0" both do, and they mean opposite things:
+                # nothing was withheld, and everything was. Reading either as
+                # "use this count" loses the whole purchase from the pool
+                # without saying so.
+                #
+                # So the counts have to account for every share bought. That
+                # settles it either way, and it is the same identity a Lapse
+                # has to satisfy.
+                quantity = _espp_net_shares(details, names, quantity, file)
 
                 amount = price * quantity
                 description = f"ESPP purchase on {details[names.purchase_date]}"
@@ -501,6 +698,10 @@ class SchwabEquityAwardsJSONParser(BaseSingleFileParser):
                 "in the expected format",
             )
 
+        # Before anything is converted: the split table has to survive the one
+        # record that can contradict it.
+        _check_lapse_units(data[fields.transactions], file_path, fields)
+
         transactions = [
             SchwabTransaction(transac, file_path, fields)
             for transac in data[fields.transactions]
@@ -514,8 +715,11 @@ class SchwabEquityAwardsJSONParser(BaseSingleFileParser):
             # Tax Withholding is deliberately not skipped: it is US tax at
             # source on dividends, and it is needed for SA106 and foreign tax
             # credit relief.
-            if transac[fields.action]
-            not in {"Journal", "Wire Transfer", "Lapse"}
+            if transac[fields.action] not in {"Journal", "Wire Transfer", "Lapse"}
         ]
+
+        # And after: each converted disposal against the acquisitions around it.
+        _check_disposal_units(transactions, file_path)
+
         transactions.reverse()
         return list(transactions)

--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -338,7 +338,7 @@ def _lot_share_sum(row: JsonRowType, names: FieldNames) -> Decimal | None:
     """Recover a sale's quantity where the row rounds it and the lots do not.
 
     Returns None when the lots cannot answer: one of them states no count, or
-    they are all whole and the row's own figure was already exact.
+    they are all whole and so cannot hold a fraction the row dropped.
     """
     total = Decimal(0)
     found_decimals = False
@@ -351,6 +351,52 @@ def _lot_share_sum(row: JsonRowType, names: FieldNames) -> Decimal | None:
         if not _is_integer(shares):
             found_decimals = True
     return total if found_decimals else None
+
+
+def _lot_price(row: JsonRowType, names: FieldNames) -> Decimal | None:
+    """Return the one price every lot sold at, or None if they differ."""
+    prices = set()
+    for subtransac in row[names.transac_details]:
+        details = subtransac.get(OPTIONAL_DETAILS_NAME, subtransac)
+        if names.sale_price not in details:
+            return None
+        prices.add(details[names.sale_price])
+    if len(prices) != 1:
+        return None
+    return _decimal_from_str(prices.pop())
+
+
+def _recovered_sale_quantity(
+    row: JsonRowType,
+    names: FieldNames,
+    quantity: Decimal,
+    amount: Decimal,
+    fees: Decimal,
+) -> Decimal | None:
+    """Return the count a sale really disposed of, where its Quantity rounds it.
+
+    The lots answer first, when they kept the decimals the row dropped. Failing
+    that the money answers, provided every lot sold at one price — and that is
+    the only witness left when a lot stating zero shares hides the fraction
+    from both count fields at once.
+
+    The money is only consulted when the row does not already reconcile with
+    it, because the price is rounded for display and recomputing from it turns
+    an exact 5 into 4.999995.
+
+    Returns None when neither answers: lots sold at different prices leave the
+    row's own figure as the best there is.
+    """
+    lots = _lot_share_sum(row, names)
+    if lots is not None:
+        return lots
+
+    price = _lot_price(row, names)
+    if not price:
+        return None
+    if round_decimal(quantity * price - fees, 2) == amount:
+        return None
+    return (amount + fees) / price
 
 
 def _espp_net_shares(
@@ -640,9 +686,12 @@ class SchwabTransaction(BrokerTransaction):
                 # ones, so it would need converting anyway. Working from the
                 # money sidesteps both, and the money is the same in any units.
                 #
-                # The count still has to come from the lots when the row has
-                # rounded it away, or the pool loses the fraction silently.
-                quantity = _lot_share_sum(row, names) or quantity
+                # The count still has to be recovered when the row has rounded
+                # it away, or the pool loses the fraction silently.
+                quantity = (
+                    _recovered_sale_quantity(row, names, quantity, amount, fees)
+                    or quantity
+                )
                 price = (amount + fees) / quantity
             elif not _is_integer(quantity):
                 price = (amount + fees) / quantity

--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -35,6 +35,31 @@ OPTIONAL_DETAILS_NAME: Final = "Details"
 FIELD_TO_SCHEMA: Final = {"transactions": 1, "Transactions": 2}
 LOGGER = logging.getLogger(__name__)
 GOOGLE_SYMBOLS = {"GOOG", "GOOGL"}
+NVIDIA_SYMBOLS = {"NVDA"}
+
+# NVDA splits, dated to the first day the new shares traded.
+#
+# Schwab restates acquisitions for later splits but leaves sales in the units
+# of their own day, so sales need converting and acquisitions do not. Dates
+# rather than a price heuristic: a heuristic needs the market price of the day,
+# which means a network call, and it stops working as soon as the real price
+# passes the threshold it guesses with.
+NVIDIA_SPLITS: Final = (
+    (datetime.date(2021, 7, 20), 4),
+    (datetime.date(2024, 6, 10), 10),
+)
+
+
+def nvidia_split_multiplier(on: datetime.date) -> int:
+    """Factor turning a share count printed on `on` into current units.
+
+    Prices divide by the same factor, so the money is unchanged.
+    """
+    factor = 1
+    for effective, ratio in NVIDIA_SPLITS:
+        if on < effective:
+            factor *= ratio
+    return factor
 
 
 @dataclass
@@ -60,6 +85,9 @@ class FieldNames:
     award_id: str = "AwardId"
     date: str = "Date"
     sale_price: str = "SalePrice"
+    purchase_date: str = "PurchaseDate"
+    purchase_fair_market_value: str = "PurchaseFairMarketValue"
+    net_shares_deposited: str = "NetSharesDeposited"
 
     def __post_init__(self, schema_version: int) -> None:
         """Set correct field names if the schema is not the default one.
@@ -82,6 +110,9 @@ class FieldNames:
             self.award_id = "awardName"
             self.date = "eventDate"
             self.sale_price = "salePrice"
+            self.purchase_date = "purchaseDate"
+            self.purchase_fair_market_value = "purchaseFairMarketValue"
+            self.net_shares_deposited = "netSharesDeposited"
 
 
 # We want enough decimals to cover what Schwab gives us (up to 4 decimals)
@@ -181,6 +212,11 @@ def _decimal_from_number_or_str(
     if float_name in row and row[float_name] is not None:
         return Decimal(row[float_name])
 
+    # An empty string means the field is not filled in, the same as it being
+    # absent. Schwab writes one for FeesAndCommissions on a commission-free
+    # sale. Note this is deliberately not done inside _decimal_from_str: an
+    # empty *price* must raise rather than become a zero cost basis, which
+    # would be taxed in full.
     if (
         field_basename in row
         and row[field_basename] is not None
@@ -206,11 +242,12 @@ class SchwabTransaction(BrokerTransaction):
         action = action_from_str(self.raw_action, file)
         symbol = row.get(names.symbol)
         symbol = TICKER_RENAMES.get(symbol, symbol)
-        if symbol not in GOOGLE_SYMBOLS:
+        if symbol not in GOOGLE_SYMBOLS | NVIDIA_SYMBOLS:
             LOGGER.warning(
-                "The Schwab Equity Award JSON parser was only tested for Google stocks (%s), "
-                "but found symbol '%s'. Please check the parsing and output are correct!",
-                ", ".join(GOOGLE_SYMBOLS),
+                "The Schwab Equity Award JSON parser was only tested for Google "
+                "and NVIDIA stocks (%s), but found symbol '%s'. Please check "
+                "the parsing and output are correct!",
+                ", ".join(sorted(GOOGLE_SYMBOLS | NVIDIA_SYMBOLS)),
                 symbol,
             )
         quantity = _decimal_from_number_or_str(row, names.quantity)
@@ -228,25 +265,59 @@ class SchwabTransaction(BrokerTransaction):
                 details = row[names.transac_details][0]["Details"]
             else:
                 details = row[names.transac_details][0]
-            date = datetime.datetime.strptime(
-                details[names.vest_date], "%m/%d/%Y"
-            ).date()
-            # Schwab only provide this one as string:
-            price = _decimal_from_str(details[names.vest_fair_market_value])
-            if amount == Decimal(0):
+
+            if description == "ESPP":
+                # An ESPP purchase, not a vest, and it carries different
+                # fields. The cost basis is the market value on the purchase
+                # date rather than the discounted price paid, because the
+                # discount is taxed as employment income through payroll.
+                # Using the price paid understates the basis roughly tenfold
+                # on the older purchases.
+                date = datetime.datetime.strptime(
+                    details[names.purchase_date], "%m/%d/%Y"
+                ).date()
+                price = _decimal_from_str(
+                    details[names.purchase_fair_market_value]
+                )
+
+                # Since August 2025 the tax on a purchase is settled by holding
+                # back some of the shares, and only the rest reaches the pool.
+                # Before that this field is empty and Quantity is already net.
+                net_shares = details.get(names.net_shares_deposited)
+                if net_shares:
+                    quantity = _decimal_from_str(net_shares)
+
                 amount = price * quantity
-            description = (
-                f"Vest from Award Date "
-                f"{details[names.award_date]} "
-                f"(ID {details[names.award_id]})"
-            )
+                description = f"ESPP purchase on {details[names.purchase_date]}"
+            else:
+                date = datetime.datetime.strptime(
+                    details[names.vest_date], "%m/%d/%Y"
+                ).date()
+                # Schwab only provide this one as string:
+                price = _decimal_from_str(details[names.vest_fair_market_value])
+                if amount == Decimal(0):
+                    amount = price * quantity
+                description = (
+                    f"Vest from Award Date "
+                    f"{details[names.award_date]} "
+                    f"(ID {details[names.award_id]})"
+                )
         elif row[names.action] == "Sale":
             date = datetime.datetime.strptime(row[names.date], "%m/%d/%Y").date()
 
-            # Schwab's data export sometimes lacks decimals on Sales
-            # quantities, in which case we infer it from number of shares in
-            # sub-transactions, or failing that from the amount and salePrice.
-            if not _is_integer(quantity):
+            if symbol in NVIDIA_SYMBOLS:
+                # Derive the price from the money rather than from the per-lot
+                # SalePrice. Amount is net of fees, so the gross is rebuilt
+                # first. Two reasons this is not just a shortcut:
+                #
+                # A disposal can span lots sold at different prices — the
+                # 600-share sale of 30 May 2025 has two — and the branch below
+                # refuses those outright. And the per-lot price is printed in
+                # the units of the trade date while the pool is in current
+                # ones, so it would need converting anyway. Working from the
+                # money sidesteps both, and the money is the same in any units.
+                price = (amount + fees) / quantity
+            elif not _is_integer(quantity):
                 price = (amount + fees) / quantity
             else:
                 subtransac_have_quantities = True
@@ -339,6 +410,31 @@ class SchwabTransaction(BrokerTransaction):
 
         if symbol in GOOGLE_SYMBOLS:
             self._normalize_google_split()
+        elif symbol in NVIDIA_SYMBOLS:
+            self._normalize_nvidia_split()
+
+    def _normalize_nvidia_split(self) -> None:
+        """Convert a disposal into current share units.
+
+        Schwab restates acquisitions for later splits — a vest of 3,000 at
+        $22.341 is recorded that way even though 300 at $223.41 is what
+        happened — but leaves disposals in the units of their own day. Only
+        disposals need converting.
+
+        Missing this costs 54 shares on the two 2023 disposals, and the pool
+        stays wrong by that much for every year afterwards.
+        """
+        if self.action != ActionType.SELL:
+            return
+
+        multiplier = nvidia_split_multiplier(self.date)
+        if multiplier == 1:
+            return
+
+        if self.quantity:
+            self.quantity = round_decimal(self.quantity * multiplier, ROUND_DIGITS)
+        if self.price:
+            self.price = round_decimal(self.price / multiplier, ROUND_DIGITS)
 
     def _normalize_google_split(self) -> None:
         """Ensure past transactions are normalized to split values.
@@ -408,8 +504,18 @@ class SchwabEquityAwardsJSONParser(BaseSingleFileParser):
         transactions = [
             SchwabTransaction(transac, file_path, fields)
             for transac in data[fields.transactions]
-            # Skip as not relevant for CGT
-            if transac[fields.action] not in {"Journal", "Wire Transfer"}
+            # Journal and Wire Transfer move cash between accounts.
+            #
+            # Lapse is the payroll side of a vest and duplicates its Deposit,
+            # which already holds the net shares that reach the pool. Its own
+            # counts are in the units of the day while its price is restated,
+            # so pairing them puts a tenth of the shares in at the full price.
+            #
+            # Tax Withholding is deliberately not skipped: it is US tax at
+            # source on dividends, and it is needed for SA106 and foreign tax
+            # credit relief.
+            if transac[fields.action]
+            not in {"Journal", "Wire Transfer", "Lapse"}
         ]
         transactions.reverse()
         return list(transactions)

--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -414,24 +414,21 @@ def _check_lapse_units(
 def _check_disposal_units(
     transactions: Sequence[BrokerTransaction], file_path: Path
 ) -> None:
-    """Check that disposals really were in the units of their own day.
+    """Warn where a disposal looks like it had already been restated.
 
-    Converting them rests on Schwab restating acquisitions for later splits and
-    leaving disposals alone. That is what its NVDA exports do, but it is an
-    observation about the file rather than a guarantee, and the GOOG handling
-    in this same parser exists because Schwab restated some records and not
-    others for that split.
+    Converting disposals rests on Schwab restating acquisitions and leaving
+    disposals alone. That is what its NVDA exports do, but it is an observation
+    about the file rather than a guarantee, and the GOOG handling in this same
+    parser exists because Schwab restated some records and not others.
 
-    Getting it wrong is silent: the money is unchanged, so nothing fails to
-    balance. Only the share count moves, and the error surfaces years later as
-    a pool that no longer matches the broker.
+    Acquisitions are the yardstick: once a disposal is converted the two are in
+    the same units, so a disposal should cost about what shares cost around it,
+    and one converted twice is cheaper by the whole multiplier.
 
-    Acquisitions are the yardstick. They are restated, they sit in the same
-    file, and once a disposal has been converted the two are in the same units,
-    so a disposal should cost about what shares cost around it. Converting one
-    that Schwab had already converted leaves it cheaper by exactly the
-    multiplier — 4, 10 or 40 — and the market does not move that far between
-    neighbouring vests.
+    This warns rather than raises because the yardstick is a price. A share
+    that halves between the nearest vest and the sale trips the 4:1 threshold
+    on its own, which is a week NVDA has had more than once. The checks that do
+    raise are the ones a price move cannot reach.
     """
     acquisitions = [
         transaction
@@ -478,16 +475,21 @@ def _check_disposal_units(
         # are a factor of 4 apart at the very least, so the midpoint is not a
         # threshold that needs tuning.
         if ratio * ratio * multiplier < 1:
-            raise ParsingError(
+            LOGGER.warning(
+                "%s: the disposal on %s works out at %s a share once converted "
+                "for the %s:1 split, against %s for the acquisition on %s. "
+                "Being cheaper by about the split multiplier is what it looks "
+                "like when Schwab had already restated a disposal and it was "
+                "converted a second time, which would take the wrong number of "
+                "shares out of the pool while leaving the proceeds right. A "
+                "share that simply fell that far between the two dates looks "
+                "the same, so check it rather than trust it",
                 file_path,
-                f"The disposal on {transaction.date} works out at "
-                f"{transaction.price:.4f} a share once converted for the "
-                f"{multiplier}:1 split, against {nearest.price:.4f} for the "
-                f"acquisition on {nearest.date}. Being cheaper by about the "
-                "split multiplier is what it looks like when Schwab had "
-                "already restated a disposal and it was converted a second "
-                "time, which would take the wrong number of shares out of the "
-                "pool while leaving the proceeds right",
+                transaction.date,
+                round_decimal(transaction.price, 4),
+                multiplier,
+                round_decimal(nearest.price, 4),
+                nearest.date,
             )
 
 

--- a/tests/schwab/data/equity_award/nvda_synthetic.json
+++ b/tests/schwab/data/equity_award/nvda_synthetic.json
@@ -1,0 +1,360 @@
+{
+  "_comment": [
+    "Synthetic portfolio. Not a scaled copy of anyone's holding — a portfolio",
+    "assembled to touch every branch in the parser at least once.",
+    "",
+    "Dates and prices are real, because they are what is being tested: the",
+    "split boundaries of 20 July 2021 and 10 June 2024, tax year ends, and the",
+    "30-day window. A NVDA close on a given day is public market data.",
+    "Share counts are invented.",
+    "",
+    "Cases covered:",
+    "  ESPP before the 4:1 split               2021-02-26",
+    "  vest with a paired Lapse                2021-09-15",
+    "  vest with no Lapse                      2023-12-15",
+    "  vest with sell-to-cover                 2024-09-18",
+    "  sale before 10 June 2024, needs x10     2023-01-23",
+    "  sale at a loss                          2025-05-19",
+    "  sale across several lots                2025-05-22",
+    "  acquisition inside the 30-day window    2025-06-18",
+    "  ESPP with tax withheld in shares        2026-02-27",
+    "  disposal between 2 and 5 April          2026-04-02",
+    "",
+    "Expected: 1,730 shares acquired, 690 disposed, 1,040 held."
+  ],
+  "FromDate": "01/01/2020",
+  "ToDate": "12/31/2026",
+  "Transactions": [
+    {
+      "Date": "02/26/2021",
+      "Action": "Deposit",
+      "Symbol": "NVDA",
+      "Quantity": "80",
+      "Description": "ESPP",
+      "FeesAndCommissions": null,
+      "DisbursementElection": null,
+      "Amount": null,
+      "TransactionDetails": [
+        {
+          "Details": {
+            "PurchaseDate": "02/26/2021",
+            "PurchasePrice": "$9.3588",
+            "SubscriptionDate": "08/03/2020",
+            "SubscriptionFairMarketValue": "$11.0102",
+            "PurchaseFairMarketValue": "$13.7145",
+            "TaxWithholdingMethod": null,
+            "NetSharesDeposited": "",
+            "SharesWithheld": "",
+            "SharesSold": "",
+            "CashRefund": "",
+            "CarryForward": ""
+          }
+        }
+      ]
+    },
+    {
+      "Date": "09/15/2021",
+      "Action": "Deposit",
+      "Symbol": "NVDA",
+      "Quantity": "400",
+      "Description": "RS",
+      "FeesAndCommissions": null,
+      "DisbursementElection": null,
+      "Amount": null,
+      "TransactionDetails": [
+        {
+          "Details": {
+            "AwardDate": "08/10/2020",
+            "AwardId": "000001",
+            "VestDate": "09/15/2021",
+            "VestFairMarketValue": "$22.341"
+          }
+        }
+      ]
+    },
+    {
+      "Date": "09/15/2021",
+      "Action": "Lapse",
+      "Symbol": "NVDA",
+      "Quantity": "600",
+      "Description": "Restricted Stock Lapse",
+      "FeesAndCommissions": null,
+      "DisbursementElection": null,
+      "Amount": null,
+      "TransactionDetails": [
+        {
+          "Details": {
+            "AwardDate": "08/10/2020",
+            "AwardId": "000001",
+            "FairMarketValuePrice": "$22.341",
+            "SalePrice": "",
+            "SharesSoldWithheldForTaxes": "20",
+            "NetSharesDeposited": "40",
+            "Taxes": "$4,468.20"
+          }
+        }
+      ]
+    },
+    {
+      "Date": "01/23/2023",
+      "Action": "Sale",
+      "Symbol": "NVDA",
+      "Quantity": "2",
+      "Description": "Share Sale",
+      "FeesAndCommissions": "$0.02",
+      "DisbursementElection": "Cash",
+      "Amount": "$383.84",
+      "TransactionDetails": [
+        {
+          "Details": {
+            "Type": "RS",
+            "Shares": "2",
+            "SalePrice": "$191.93",
+            "GrossProceeds": "$383.86",
+            "VestDate": "09/15/2021",
+            "VestFairMarketValue": "$223.41",
+            "TotalCostBasis": "$446.82",
+            "RealizedGainLoss": "-$62.98",
+            "DispositionType": "Long",
+            "HoldingPeriod": "Long"
+          }
+        }
+      ]
+    },
+    {
+      "Date": "12/15/2023",
+      "Action": "Deposit",
+      "Symbol": "NVDA",
+      "Quantity": "300",
+      "Description": "RS",
+      "FeesAndCommissions": null,
+      "DisbursementElection": null,
+      "Amount": null,
+      "TransactionDetails": [
+        {
+          "Details": {
+            "AwardDate": "03/12/2022",
+            "AwardId": "000002",
+            "VestDate": "12/15/2023",
+            "VestFairMarketValue": "$48.89"
+          }
+        }
+      ]
+    },
+    {
+      "Date": "09/18/2024",
+      "Action": "Deposit",
+      "Symbol": "NVDA",
+      "Quantity": "700",
+      "Description": "RS",
+      "FeesAndCommissions": null,
+      "DisbursementElection": null,
+      "Amount": null,
+      "TransactionDetails": [
+        {
+          "Details": {
+            "AwardDate": "04/08/2023",
+            "AwardId": "000003",
+            "VestDate": "09/18/2024",
+            "VestFairMarketValue": "$113.37"
+          }
+        }
+      ]
+    },
+    {
+      "Date": "09/18/2024",
+      "Action": "Lapse",
+      "Symbol": "NVDA",
+      "Quantity": "1000",
+      "Description": "Restricted Stock Lapse",
+      "FeesAndCommissions": null,
+      "DisbursementElection": null,
+      "Amount": null,
+      "TransactionDetails": [
+        {
+          "Details": {
+            "AwardDate": "04/08/2023",
+            "AwardId": "000003",
+            "FairMarketValuePrice": "$113.37",
+            "SalePrice": "",
+            "SharesSoldWithheldForTaxes": "300",
+            "NetSharesDeposited": "700",
+            "Taxes": "$34,011.00"
+          }
+        }
+      ]
+    },
+    {
+      "Date": "12/20/2024",
+      "Action": "Dividend",
+      "Symbol": "NVDA",
+      "Quantity": null,
+      "Description": "Credit",
+      "FeesAndCommissions": null,
+      "DisbursementElection": null,
+      "Amount": "$14.80",
+      "TransactionDetails": []
+    },
+    {
+      "Date": "12/20/2024",
+      "Action": "Tax Withholding",
+      "Symbol": "NVDA",
+      "Quantity": null,
+      "Description": "Debit",
+      "FeesAndCommissions": null,
+      "DisbursementElection": null,
+      "Amount": "-$2.22",
+      "TransactionDetails": []
+    },
+    {
+      "Date": "05/19/2025",
+      "Action": "Sale",
+      "Symbol": "NVDA",
+      "Quantity": "50",
+      "Description": "Share Sale",
+      "FeesAndCommissions": "$0.02",
+      "DisbursementElection": "Cash",
+      "Amount": "$6,778.48",
+      "TransactionDetails": [
+        {
+          "Details": {
+            "Type": "RS",
+            "Shares": "50",
+            "SalePrice": "$135.57",
+            "GrossProceeds": "$6,778.50",
+            "VestDate": "09/18/2024",
+            "VestFairMarketValue": "$113.37",
+            "TotalCostBasis": "$5,668.50",
+            "RealizedGainLoss": "$1,110.00",
+            "DispositionType": "Short",
+            "HoldingPeriod": "Short"
+          }
+        }
+      ]
+    },
+    {
+      "Date": "05/22/2025",
+      "Action": "Sale",
+      "Symbol": "NVDA",
+      "Quantity": "500",
+      "Description": "Share Sale",
+      "FeesAndCommissions": "$0.10",
+      "DisbursementElection": "Cash",
+      "Amount": "$66,414.90",
+      "TransactionDetails": [
+        {
+          "Details": {
+            "Type": "RS",
+            "Shares": "200",
+            "SalePrice": "$132.83",
+            "GrossProceeds": "$26,566.00",
+            "VestDate": "12/15/2023",
+            "VestFairMarketValue": "$48.89",
+            "TotalCostBasis": "$9,778.00",
+            "RealizedGainLoss": "$16,788.00",
+            "DispositionType": "Long",
+            "HoldingPeriod": "Long"
+          }
+        },
+        {
+          "Details": {
+            "Type": "RS",
+            "Shares": "300",
+            "SalePrice": "$132.83",
+            "GrossProceeds": "$39,849.00",
+            "VestDate": "09/18/2024",
+            "VestFairMarketValue": "$113.37",
+            "TotalCostBasis": "$34,011.00",
+            "RealizedGainLoss": "$5,838.00",
+            "DispositionType": "Short",
+            "HoldingPeriod": "Short"
+          }
+        }
+      ]
+    },
+    {
+      "Date": "06/18/2025",
+      "Action": "Deposit",
+      "Symbol": "NVDA",
+      "Quantity": "100",
+      "Description": "RS",
+      "FeesAndCommissions": null,
+      "DisbursementElection": null,
+      "Amount": null,
+      "TransactionDetails": [
+        {
+          "Details": {
+            "AwardDate": "04/08/2024",
+            "AwardId": "000004",
+            "VestDate": "06/18/2025",
+            "VestFairMarketValue": "$145.48"
+          }
+        }
+      ]
+    },
+    {
+      "Date": "02/27/2026",
+      "Action": "Deposit",
+      "Symbol": "NVDA",
+      "Quantity": "200",
+      "Description": "ESPP",
+      "FeesAndCommissions": null,
+      "DisbursementElection": null,
+      "Amount": null,
+      "TransactionDetails": [
+        {
+          "Details": {
+            "PurchaseDate": "02/27/2026",
+            "PurchasePrice": "$91.80",
+            "SubscriptionDate": "09/03/2024",
+            "SubscriptionFairMarketValue": "$108.00",
+            "PurchaseFairMarketValue": "$177.19",
+            "TaxWithholdingMethod": "Withhold for Taxes",
+            "NetSharesDeposited": "150",
+            "SharesWithheld": "50",
+            "SharesSold": "",
+            "CashRefund": "",
+            "CarryForward": "$12.34"
+          }
+        }
+      ]
+    },
+    {
+      "Date": "04/02/2026",
+      "Action": "Sale",
+      "Symbol": "NVDA",
+      "Quantity": "120",
+      "Description": "Share Sale",
+      "FeesAndCommissions": "$0.03",
+      "DisbursementElection": "Cash",
+      "Amount": "$21,206.97",
+      "TransactionDetails": [
+        {
+          "Details": {
+            "Type": "RS",
+            "Shares": "120",
+            "SalePrice": "$176.725",
+            "GrossProceeds": "$21,207.00",
+            "VestDate": "06/18/2025",
+            "VestFairMarketValue": "$145.48",
+            "TotalCostBasis": "$17,457.60",
+            "RealizedGainLoss": "$3,749.40",
+            "DispositionType": "Short",
+            "HoldingPeriod": "Short"
+          }
+        }
+      ]
+    },
+    {
+      "Date": "04/06/2026",
+      "Action": "Journal",
+      "Symbol": null,
+      "Quantity": null,
+      "Description": "Journal To Account ...763",
+      "FeesAndCommissions": null,
+      "DisbursementElection": null,
+      "Amount": "-$21,206.97",
+      "TransactionDetails": []
+    }
+  ]
+}

--- a/tests/schwab/data/equity_award/nvda_synthetic.json
+++ b/tests/schwab/data/equity_award/nvda_synthetic.json
@@ -1,360 +1,360 @@
 {
-  "_comment": [
-    "Synthetic portfolio. Not a scaled copy of anyone's holding — a portfolio",
-    "assembled to touch every branch in the parser at least once.",
-    "",
-    "Dates and prices are real, because they are what is being tested: the",
-    "split boundaries of 20 July 2021 and 10 June 2024, tax year ends, and the",
-    "30-day window. A NVDA close on a given day is public market data.",
-    "Share counts are invented.",
-    "",
-    "Cases covered:",
-    "  ESPP before the 4:1 split               2021-02-26",
-    "  vest with a paired Lapse                2021-09-15",
-    "  vest with no Lapse                      2023-12-15",
-    "  vest with sell-to-cover                 2024-09-18",
-    "  sale before 10 June 2024, needs x10     2023-01-23",
-    "  sale at a loss                          2025-05-19",
-    "  sale across several lots                2025-05-22",
-    "  acquisition inside the 30-day window    2025-06-18",
-    "  ESPP with tax withheld in shares        2026-02-27",
-    "  disposal between 2 and 5 April          2026-04-02",
-    "",
-    "Expected: 1,730 shares acquired, 690 disposed, 1,040 held."
-  ],
-  "FromDate": "01/01/2020",
-  "ToDate": "12/31/2026",
-  "Transactions": [
-    {
-      "Date": "02/26/2021",
-      "Action": "Deposit",
-      "Symbol": "NVDA",
-      "Quantity": "80",
-      "Description": "ESPP",
-      "FeesAndCommissions": null,
-      "DisbursementElection": null,
-      "Amount": null,
-      "TransactionDetails": [
+    "_comment": [
+        "Synthetic portfolio. Not a scaled copy of anyone's holding — a portfolio",
+        "assembled to touch every branch in the parser at least once.",
+        "",
+        "Dates and prices are real, because they are what is being tested: the",
+        "split boundaries of 20 July 2021 and 10 June 2024, tax year ends, and the",
+        "30-day window. A NVDA close on a given day is public market data.",
+        "Share counts are invented.",
+        "",
+        "Cases covered:",
+        "  ESPP before the 4:1 split               2021-02-26",
+        "  vest with a paired Lapse                2021-09-15",
+        "  vest with no Lapse                      2023-12-15",
+        "  vest with sell-to-cover                 2024-09-18",
+        "  sale before 10 June 2024, needs x10     2023-01-23",
+        "  sale at a loss                          2025-05-19",
+        "  sale across several lots                2025-05-22",
+        "  acquisition inside the 30-day window    2025-06-18",
+        "  ESPP with tax withheld in shares        2026-02-27",
+        "  disposal between 2 and 5 April          2026-04-02",
+        "",
+        "Expected: 1,730 shares acquired, 690 disposed, 1,040 held."
+    ],
+    "FromDate": "01/01/2020",
+    "ToDate": "12/31/2026",
+    "Transactions": [
         {
-          "Details": {
-            "PurchaseDate": "02/26/2021",
-            "PurchasePrice": "$9.3588",
-            "SubscriptionDate": "08/03/2020",
-            "SubscriptionFairMarketValue": "$11.0102",
-            "PurchaseFairMarketValue": "$13.7145",
-            "TaxWithholdingMethod": null,
-            "NetSharesDeposited": "",
-            "SharesWithheld": "",
-            "SharesSold": "",
-            "CashRefund": "",
-            "CarryForward": ""
-          }
-        }
-      ]
-    },
-    {
-      "Date": "09/15/2021",
-      "Action": "Deposit",
-      "Symbol": "NVDA",
-      "Quantity": "400",
-      "Description": "RS",
-      "FeesAndCommissions": null,
-      "DisbursementElection": null,
-      "Amount": null,
-      "TransactionDetails": [
-        {
-          "Details": {
-            "AwardDate": "08/10/2020",
-            "AwardId": "000001",
-            "VestDate": "09/15/2021",
-            "VestFairMarketValue": "$22.341"
-          }
-        }
-      ]
-    },
-    {
-      "Date": "09/15/2021",
-      "Action": "Lapse",
-      "Symbol": "NVDA",
-      "Quantity": "600",
-      "Description": "Restricted Stock Lapse",
-      "FeesAndCommissions": null,
-      "DisbursementElection": null,
-      "Amount": null,
-      "TransactionDetails": [
-        {
-          "Details": {
-            "AwardDate": "08/10/2020",
-            "AwardId": "000001",
-            "FairMarketValuePrice": "$22.341",
-            "SalePrice": "",
-            "SharesSoldWithheldForTaxes": "20",
-            "NetSharesDeposited": "40",
-            "Taxes": "$4,468.20"
-          }
-        }
-      ]
-    },
-    {
-      "Date": "01/23/2023",
-      "Action": "Sale",
-      "Symbol": "NVDA",
-      "Quantity": "2",
-      "Description": "Share Sale",
-      "FeesAndCommissions": "$0.02",
-      "DisbursementElection": "Cash",
-      "Amount": "$383.84",
-      "TransactionDetails": [
-        {
-          "Details": {
-            "Type": "RS",
-            "Shares": "2",
-            "SalePrice": "$191.93",
-            "GrossProceeds": "$383.86",
-            "VestDate": "09/15/2021",
-            "VestFairMarketValue": "$223.41",
-            "TotalCostBasis": "$446.82",
-            "RealizedGainLoss": "-$62.98",
-            "DispositionType": "Long",
-            "HoldingPeriod": "Long"
-          }
-        }
-      ]
-    },
-    {
-      "Date": "12/15/2023",
-      "Action": "Deposit",
-      "Symbol": "NVDA",
-      "Quantity": "300",
-      "Description": "RS",
-      "FeesAndCommissions": null,
-      "DisbursementElection": null,
-      "Amount": null,
-      "TransactionDetails": [
-        {
-          "Details": {
-            "AwardDate": "03/12/2022",
-            "AwardId": "000002",
-            "VestDate": "12/15/2023",
-            "VestFairMarketValue": "$48.89"
-          }
-        }
-      ]
-    },
-    {
-      "Date": "09/18/2024",
-      "Action": "Deposit",
-      "Symbol": "NVDA",
-      "Quantity": "700",
-      "Description": "RS",
-      "FeesAndCommissions": null,
-      "DisbursementElection": null,
-      "Amount": null,
-      "TransactionDetails": [
-        {
-          "Details": {
-            "AwardDate": "04/08/2023",
-            "AwardId": "000003",
-            "VestDate": "09/18/2024",
-            "VestFairMarketValue": "$113.37"
-          }
-        }
-      ]
-    },
-    {
-      "Date": "09/18/2024",
-      "Action": "Lapse",
-      "Symbol": "NVDA",
-      "Quantity": "1000",
-      "Description": "Restricted Stock Lapse",
-      "FeesAndCommissions": null,
-      "DisbursementElection": null,
-      "Amount": null,
-      "TransactionDetails": [
-        {
-          "Details": {
-            "AwardDate": "04/08/2023",
-            "AwardId": "000003",
-            "FairMarketValuePrice": "$113.37",
-            "SalePrice": "",
-            "SharesSoldWithheldForTaxes": "300",
-            "NetSharesDeposited": "700",
-            "Taxes": "$34,011.00"
-          }
-        }
-      ]
-    },
-    {
-      "Date": "12/20/2024",
-      "Action": "Dividend",
-      "Symbol": "NVDA",
-      "Quantity": null,
-      "Description": "Credit",
-      "FeesAndCommissions": null,
-      "DisbursementElection": null,
-      "Amount": "$14.80",
-      "TransactionDetails": []
-    },
-    {
-      "Date": "12/20/2024",
-      "Action": "Tax Withholding",
-      "Symbol": "NVDA",
-      "Quantity": null,
-      "Description": "Debit",
-      "FeesAndCommissions": null,
-      "DisbursementElection": null,
-      "Amount": "-$2.22",
-      "TransactionDetails": []
-    },
-    {
-      "Date": "05/19/2025",
-      "Action": "Sale",
-      "Symbol": "NVDA",
-      "Quantity": "50",
-      "Description": "Share Sale",
-      "FeesAndCommissions": "$0.02",
-      "DisbursementElection": "Cash",
-      "Amount": "$6,778.48",
-      "TransactionDetails": [
-        {
-          "Details": {
-            "Type": "RS",
-            "Shares": "50",
-            "SalePrice": "$135.57",
-            "GrossProceeds": "$6,778.50",
-            "VestDate": "09/18/2024",
-            "VestFairMarketValue": "$113.37",
-            "TotalCostBasis": "$5,668.50",
-            "RealizedGainLoss": "$1,110.00",
-            "DispositionType": "Short",
-            "HoldingPeriod": "Short"
-          }
-        }
-      ]
-    },
-    {
-      "Date": "05/22/2025",
-      "Action": "Sale",
-      "Symbol": "NVDA",
-      "Quantity": "500",
-      "Description": "Share Sale",
-      "FeesAndCommissions": "$0.10",
-      "DisbursementElection": "Cash",
-      "Amount": "$66,414.90",
-      "TransactionDetails": [
-        {
-          "Details": {
-            "Type": "RS",
-            "Shares": "200",
-            "SalePrice": "$132.83",
-            "GrossProceeds": "$26,566.00",
-            "VestDate": "12/15/2023",
-            "VestFairMarketValue": "$48.89",
-            "TotalCostBasis": "$9,778.00",
-            "RealizedGainLoss": "$16,788.00",
-            "DispositionType": "Long",
-            "HoldingPeriod": "Long"
-          }
+            "Date": "02/26/2021",
+            "Action": "Deposit",
+            "Symbol": "NVDA",
+            "Quantity": "80",
+            "Description": "ESPP",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": null,
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "PurchaseDate": "02/26/2021",
+                        "PurchasePrice": "$9.3588",
+                        "SubscriptionDate": "08/03/2020",
+                        "SubscriptionFairMarketValue": "$11.0102",
+                        "PurchaseFairMarketValue": "$13.7145",
+                        "TaxWithholdingMethod": null,
+                        "NetSharesDeposited": "",
+                        "SharesWithheld": "",
+                        "SharesSold": "",
+                        "CashRefund": "",
+                        "CarryForward": ""
+                    }
+                }
+            ]
         },
         {
-          "Details": {
-            "Type": "RS",
-            "Shares": "300",
-            "SalePrice": "$132.83",
-            "GrossProceeds": "$39,849.00",
-            "VestDate": "09/18/2024",
-            "VestFairMarketValue": "$113.37",
-            "TotalCostBasis": "$34,011.00",
-            "RealizedGainLoss": "$5,838.00",
-            "DispositionType": "Short",
-            "HoldingPeriod": "Short"
-          }
-        }
-      ]
-    },
-    {
-      "Date": "06/18/2025",
-      "Action": "Deposit",
-      "Symbol": "NVDA",
-      "Quantity": "100",
-      "Description": "RS",
-      "FeesAndCommissions": null,
-      "DisbursementElection": null,
-      "Amount": null,
-      "TransactionDetails": [
+            "Date": "09/15/2021",
+            "Action": "Deposit",
+            "Symbol": "NVDA",
+            "Quantity": "400",
+            "Description": "RS",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": null,
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "AwardDate": "08/10/2020",
+                        "AwardId": "000001",
+                        "VestDate": "09/15/2021",
+                        "VestFairMarketValue": "$22.341"
+                    }
+                }
+            ]
+        },
         {
-          "Details": {
-            "AwardDate": "04/08/2024",
-            "AwardId": "000004",
-            "VestDate": "06/18/2025",
-            "VestFairMarketValue": "$145.48"
-          }
-        }
-      ]
-    },
-    {
-      "Date": "02/27/2026",
-      "Action": "Deposit",
-      "Symbol": "NVDA",
-      "Quantity": "200",
-      "Description": "ESPP",
-      "FeesAndCommissions": null,
-      "DisbursementElection": null,
-      "Amount": null,
-      "TransactionDetails": [
+            "Date": "09/15/2021",
+            "Action": "Lapse",
+            "Symbol": "NVDA",
+            "Quantity": "600",
+            "Description": "Restricted Stock Lapse",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": null,
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "AwardDate": "08/10/2020",
+                        "AwardId": "000001",
+                        "FairMarketValuePrice": "$22.341",
+                        "SalePrice": "",
+                        "SharesSoldWithheldForTaxes": "20",
+                        "NetSharesDeposited": "40",
+                        "Taxes": "$4,468.20"
+                    }
+                }
+            ]
+        },
         {
-          "Details": {
-            "PurchaseDate": "02/27/2026",
-            "PurchasePrice": "$91.80",
-            "SubscriptionDate": "09/03/2024",
-            "SubscriptionFairMarketValue": "$108.00",
-            "PurchaseFairMarketValue": "$177.19",
-            "TaxWithholdingMethod": "Withhold for Taxes",
-            "NetSharesDeposited": "150",
-            "SharesWithheld": "50",
-            "SharesSold": "",
-            "CashRefund": "",
-            "CarryForward": "$12.34"
-          }
-        }
-      ]
-    },
-    {
-      "Date": "04/02/2026",
-      "Action": "Sale",
-      "Symbol": "NVDA",
-      "Quantity": "120",
-      "Description": "Share Sale",
-      "FeesAndCommissions": "$0.03",
-      "DisbursementElection": "Cash",
-      "Amount": "$21,206.97",
-      "TransactionDetails": [
+            "Date": "01/23/2023",
+            "Action": "Sale",
+            "Symbol": "NVDA",
+            "Quantity": "2",
+            "Description": "Share Sale",
+            "FeesAndCommissions": "$0.02",
+            "DisbursementElection": "Cash",
+            "Amount": "$383.84",
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "Type": "RS",
+                        "Shares": "2",
+                        "SalePrice": "$191.93",
+                        "GrossProceeds": "$383.86",
+                        "VestDate": "09/15/2021",
+                        "VestFairMarketValue": "$223.41",
+                        "TotalCostBasis": "$446.82",
+                        "RealizedGainLoss": "-$62.98",
+                        "DispositionType": "Long",
+                        "HoldingPeriod": "Long"
+                    }
+                }
+            ]
+        },
         {
-          "Details": {
-            "Type": "RS",
-            "Shares": "120",
-            "SalePrice": "$176.725",
-            "GrossProceeds": "$21,207.00",
-            "VestDate": "06/18/2025",
-            "VestFairMarketValue": "$145.48",
-            "TotalCostBasis": "$17,457.60",
-            "RealizedGainLoss": "$3,749.40",
-            "DispositionType": "Short",
-            "HoldingPeriod": "Short"
-          }
+            "Date": "12/15/2023",
+            "Action": "Deposit",
+            "Symbol": "NVDA",
+            "Quantity": "300",
+            "Description": "RS",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": null,
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "AwardDate": "03/12/2022",
+                        "AwardId": "000002",
+                        "VestDate": "12/15/2023",
+                        "VestFairMarketValue": "$48.89"
+                    }
+                }
+            ]
+        },
+        {
+            "Date": "09/18/2024",
+            "Action": "Deposit",
+            "Symbol": "NVDA",
+            "Quantity": "700",
+            "Description": "RS",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": null,
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "AwardDate": "04/08/2023",
+                        "AwardId": "000003",
+                        "VestDate": "09/18/2024",
+                        "VestFairMarketValue": "$113.37"
+                    }
+                }
+            ]
+        },
+        {
+            "Date": "09/18/2024",
+            "Action": "Lapse",
+            "Symbol": "NVDA",
+            "Quantity": "1000",
+            "Description": "Restricted Stock Lapse",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": null,
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "AwardDate": "04/08/2023",
+                        "AwardId": "000003",
+                        "FairMarketValuePrice": "$113.37",
+                        "SalePrice": "",
+                        "SharesSoldWithheldForTaxes": "300",
+                        "NetSharesDeposited": "700",
+                        "Taxes": "$34,011.00"
+                    }
+                }
+            ]
+        },
+        {
+            "Date": "12/20/2024",
+            "Action": "Dividend",
+            "Symbol": "NVDA",
+            "Quantity": null,
+            "Description": "Credit",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": "$14.80",
+            "TransactionDetails": []
+        },
+        {
+            "Date": "12/20/2024",
+            "Action": "Tax Withholding",
+            "Symbol": "NVDA",
+            "Quantity": null,
+            "Description": "Debit",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": "-$2.22",
+            "TransactionDetails": []
+        },
+        {
+            "Date": "05/19/2025",
+            "Action": "Sale",
+            "Symbol": "NVDA",
+            "Quantity": "50",
+            "Description": "Share Sale",
+            "FeesAndCommissions": "$0.02",
+            "DisbursementElection": "Cash",
+            "Amount": "$6,778.48",
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "Type": "RS",
+                        "Shares": "50",
+                        "SalePrice": "$135.57",
+                        "GrossProceeds": "$6,778.50",
+                        "VestDate": "09/18/2024",
+                        "VestFairMarketValue": "$113.37",
+                        "TotalCostBasis": "$5,668.50",
+                        "RealizedGainLoss": "$1,110.00",
+                        "DispositionType": "Short",
+                        "HoldingPeriod": "Short"
+                    }
+                }
+            ]
+        },
+        {
+            "Date": "05/22/2025",
+            "Action": "Sale",
+            "Symbol": "NVDA",
+            "Quantity": "500",
+            "Description": "Share Sale",
+            "FeesAndCommissions": "$0.10",
+            "DisbursementElection": "Cash",
+            "Amount": "$66,414.90",
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "Type": "RS",
+                        "Shares": "200",
+                        "SalePrice": "$132.83",
+                        "GrossProceeds": "$26,566.00",
+                        "VestDate": "12/15/2023",
+                        "VestFairMarketValue": "$48.89",
+                        "TotalCostBasis": "$9,778.00",
+                        "RealizedGainLoss": "$16,788.00",
+                        "DispositionType": "Long",
+                        "HoldingPeriod": "Long"
+                    }
+                },
+                {
+                    "Details": {
+                        "Type": "RS",
+                        "Shares": "300",
+                        "SalePrice": "$132.83",
+                        "GrossProceeds": "$39,849.00",
+                        "VestDate": "09/18/2024",
+                        "VestFairMarketValue": "$113.37",
+                        "TotalCostBasis": "$34,011.00",
+                        "RealizedGainLoss": "$5,838.00",
+                        "DispositionType": "Short",
+                        "HoldingPeriod": "Short"
+                    }
+                }
+            ]
+        },
+        {
+            "Date": "06/18/2025",
+            "Action": "Deposit",
+            "Symbol": "NVDA",
+            "Quantity": "100",
+            "Description": "RS",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": null,
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "AwardDate": "04/08/2024",
+                        "AwardId": "000004",
+                        "VestDate": "06/18/2025",
+                        "VestFairMarketValue": "$145.48"
+                    }
+                }
+            ]
+        },
+        {
+            "Date": "02/27/2026",
+            "Action": "Deposit",
+            "Symbol": "NVDA",
+            "Quantity": "200",
+            "Description": "ESPP",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": null,
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "PurchaseDate": "02/27/2026",
+                        "PurchasePrice": "$91.80",
+                        "SubscriptionDate": "09/03/2024",
+                        "SubscriptionFairMarketValue": "$108.00",
+                        "PurchaseFairMarketValue": "$177.19",
+                        "TaxWithholdingMethod": "Withhold for Taxes",
+                        "NetSharesDeposited": "150",
+                        "SharesWithheld": "50",
+                        "SharesSold": "",
+                        "CashRefund": "",
+                        "CarryForward": "$12.34"
+                    }
+                }
+            ]
+        },
+        {
+            "Date": "04/02/2026",
+            "Action": "Sale",
+            "Symbol": "NVDA",
+            "Quantity": "120",
+            "Description": "Share Sale",
+            "FeesAndCommissions": "$0.03",
+            "DisbursementElection": "Cash",
+            "Amount": "$21,206.97",
+            "TransactionDetails": [
+                {
+                    "Details": {
+                        "Type": "RS",
+                        "Shares": "120",
+                        "SalePrice": "$176.725",
+                        "GrossProceeds": "$21,207.00",
+                        "VestDate": "06/18/2025",
+                        "VestFairMarketValue": "$145.48",
+                        "TotalCostBasis": "$17,457.60",
+                        "RealizedGainLoss": "$3,749.40",
+                        "DispositionType": "Short",
+                        "HoldingPeriod": "Short"
+                    }
+                }
+            ]
+        },
+        {
+            "Date": "04/06/2026",
+            "Action": "Journal",
+            "Symbol": null,
+            "Quantity": null,
+            "Description": "Journal To Account ...763",
+            "FeesAndCommissions": null,
+            "DisbursementElection": null,
+            "Amount": "-$21,206.97",
+            "TransactionDetails": []
         }
-      ]
-    },
-    {
-      "Date": "04/06/2026",
-      "Action": "Journal",
-      "Symbol": null,
-      "Quantity": null,
-      "Description": "Journal To Account ...763",
-      "FeesAndCommissions": null,
-      "DisbursementElection": null,
-      "Amount": "-$21,206.97",
-      "TransactionDetails": []
-    }
-  ]
+    ]
 }

--- a/tests/schwab/test_schwab_equity_award_json.py
+++ b/tests/schwab/test_schwab_equity_award_json.py
@@ -6,6 +6,8 @@ import datetime
 from decimal import Decimal
 from pathlib import Path
 
+import pytest
+
 from cgt_calc.model import ActionType
 from cgt_calc.parsers import schwab_equity_award_json
 
@@ -212,3 +214,42 @@ def test_schwab_transaction_v2_rounding() -> None:
         assert transactions[transaction_id].price == Decimal("123.45")
         assert transactions[transaction_id].fees == Decimal(0)
     assert num_vested == transactions[0].quantity
+
+
+def test_split_multiplier_google_boundary() -> None:
+    """GOOG counts are in current units from the day after the split."""
+    assert (
+        schwab_equity_award_json.split_multiplier("GOOG", datetime.date(2022, 7, 15))
+        == 20
+    )
+    assert (
+        schwab_equity_award_json.split_multiplier("GOOG", datetime.date(2022, 7, 16))
+        == 1
+    )
+
+
+def test_split_multiplier_ignores_unknown_symbol() -> None:
+    """A symbol with no split history is left alone rather than guessed at."""
+    assert (
+        schwab_equity_award_json.split_multiplier("AAPL", datetime.date(2014, 6, 8))
+        == 1
+    )
+    assert (
+        schwab_equity_award_json.split_multiplier(None, datetime.date(2022, 1, 1)) == 1
+    )
+
+
+def test_split_history_demands_a_price_floor_it_can_use() -> None:
+    """An UNRELIABLE export is unusable without the price that gives units away."""
+    with pytest.raises(ValueError, match="presplit_price_floor"):
+        schwab_equity_award_json.SplitHistory(
+            ((datetime.date(2022, 7, 16), 20),),
+            schwab_equity_award_json.Restatement.UNRELIABLE,
+        )
+
+    with pytest.raises(ValueError, match="presplit_price_floor"):
+        schwab_equity_award_json.SplitHistory(
+            ((datetime.date(2021, 7, 20), 4),),
+            schwab_equity_award_json.Restatement.ACQUISITIONS_ONLY,
+            presplit_price_floor=Decimal(175),
+        )

--- a/tests/schwab/test_schwab_equity_award_nvda.py
+++ b/tests/schwab/test_schwab_equity_award_nvda.py
@@ -277,6 +277,57 @@ def test_a_sale_rounded_in_the_row_takes_its_count_from_the_lots(
     assert sale.amount == Decimal("66414.90")
 
 
+def test_a_sale_hiding_its_fraction_in_a_zero_lot_is_recovered(
+    tmp_path: Path,
+) -> None:
+    """Both share-count fields can round the same fraction away.
+
+    A lot stating zero shares leaves the row's count and the lot sum agreeing
+    on a whole number while the money says otherwise. Schwab writes this shape:
+    the v1 fixture's 2022-06-14 sale reads 3 in both and 3.13007 in cash. The
+    price is the only witness, and only when every lot sold at one.
+    """
+
+    def fraction_hidden_in_a_zero_lot(rows: list[JsonRowType]) -> None:
+        for row in rows:
+            if row.get("Action") == "Sale" and row["Date"] == "04/02/2026":
+                row["Amount"] = "$12,050.00"
+                row["FeesAndCommissions"] = None
+                lot = details_of(row)
+                lot["SalePrice"] = "$100.00"
+                row["TransactionDetails"].append({"Details": dict(lot, Shares="0")})
+
+    sale = on(
+        parse(mutated(tmp_path, fraction_hidden_in_a_zero_lot)),
+        datetime.date(2026, 4, 2),
+        ActionType.SELL,
+    )
+
+    assert sale.quantity == Decimal("120.5")
+    assert sale.price == Decimal(100)
+
+
+def test_a_sale_the_row_already_states_exactly_is_left_alone(
+    tmp_path: Path,
+) -> None:
+    """The price is rounded for display, so the money is not the better source.
+
+    Recomputing from it unconditionally turns an exact 50 into 49.99997 and the
+    pool starts drifting on transactions that were never wrong.
+    """
+
+    def nothing(rows: list[JsonRowType]) -> None:
+        pass
+
+    sale = on(
+        parse(mutated(tmp_path, nothing)),
+        datetime.date(2025, 5, 19),
+        ActionType.SELL,
+    )
+
+    assert sale.quantity == Decimal(50)
+
+
 def test_a_disposal_schwab_already_restated_is_flagged(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/schwab/test_schwab_equity_award_nvda.py
+++ b/tests/schwab/test_schwab_equity_award_nvda.py
@@ -1,0 +1,185 @@
+"""NVIDIA-specific parsing of Schwab Equity Award JSON exports.
+
+Schwab reports NVDA history in mixed units. Acquisitions are restated for later
+splits, disposals are not, and one record type mixes both inside itself. Each
+test here pins one of those rules.
+
+The fixture is a synthetic portfolio: real dates and real prices, invented
+share counts. Real dates and prices because they are what is under test — the
+split boundaries of 20 July 2021 and 10 June 2024, and the tax year end.
+"""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from cgt_calc.model import ActionType
+from cgt_calc.parsers import schwab_equity_award_json
+from cgt_calc.parsers.schwab_equity_award_json import nvidia_split_multiplier
+
+FIXTURE = Path("tests/schwab/data/equity_award/nvda_synthetic.json")
+
+
+@pytest.fixture(name="transactions")
+def transactions_fixture() -> list:
+    """Parse the synthetic NVDA portfolio."""
+    return schwab_equity_award_json.SchwabEquityAwardsJSONParser().load_from_file(
+        FIXTURE
+    )
+
+
+def on(transactions: list, date: datetime.date, action: ActionType):
+    """Return the single transaction of that kind on that date."""
+    found = [t for t in transactions if t.date == date and t.action == action]
+    assert len(found) == 1, f"expected one {action} on {date}, got {len(found)}"
+    return found[0]
+
+
+@pytest.mark.parametrize(
+    ("day", "expected"),
+    [
+        # Before both splits: 4:1 in 2021 then 10:1 in 2024.
+        (datetime.date(2021, 2, 26), 40),
+        (datetime.date(2021, 7, 19), 40),
+        # The new shares trade from the 20th, so that day is already post-split.
+        (datetime.date(2021, 7, 20), 10),
+        (datetime.date(2024, 6, 7), 10),
+        (datetime.date(2024, 6, 10), 1),
+        (datetime.date(2026, 4, 2), 1),
+    ],
+)
+def test_split_multiplier_boundaries(day: datetime.date, expected: int) -> None:
+    """The multiplier changes on the day the new shares trade."""
+    assert nvidia_split_multiplier(day) == expected
+
+
+def test_lapse_is_not_an_acquisition(transactions: list) -> None:
+    """A Lapse duplicates its Deposit and must not reach the pool.
+
+    Its NetSharesDeposited is in the units of the day while its price is
+    restated, so pairing them puts a tenth of the shares in at the full price.
+    """
+    assert len(transactions) == 12  # 6 acquisitions, 4 disposals, 2 cash
+
+    vests = [
+        t
+        for t in transactions
+        if t.action == ActionType.STOCK_ACTIVITY
+        and t.date == datetime.date(2021, 9, 15)
+    ]
+    assert len(vests) == 1
+    # The paired Lapse says 40; the Deposit says 400 and is the one that counts.
+    assert vests[0].quantity == Decimal(400)
+
+
+def test_vest_is_read_in_restated_units(transactions: list) -> None:
+    """Both the count and the price of a vest are already restated."""
+    vest = on(transactions, datetime.date(2021, 9, 15), ActionType.STOCK_ACTIVITY)
+
+    assert vest.quantity == Decimal(400)
+    assert vest.price == Decimal("22.341")
+
+
+def test_sell_to_cover_leaves_net_shares(transactions: list) -> None:
+    """1000 vested, 300 went to tax, and the Deposit is already net."""
+    vest = on(transactions, datetime.date(2024, 9, 18), ActionType.STOCK_ACTIVITY)
+
+    assert vest.quantity == Decimal(700)
+
+
+def test_espp_uses_market_value_not_price_paid(transactions: list) -> None:
+    """The discount is taxed through payroll, so the basis is market value.
+
+    Using PurchasePrice of $9.3588 instead of the $13.7145 the shares were
+    worth understates the basis by a third on this purchase, and roughly
+    tenfold on the ones where the discount is larger.
+    """
+    espp = on(transactions, datetime.date(2021, 2, 26), ActionType.STOCK_ACTIVITY)
+
+    assert espp.quantity == Decimal(80)
+    assert espp.price == Decimal("13.7145")
+    assert espp.amount == Decimal(80) * Decimal("13.7145")
+
+
+def test_espp_taxed_in_shares_pools_the_net(transactions: list) -> None:
+    """Since August 2025 the tax is settled in shares: 200 bought, 150 kept."""
+    espp = on(transactions, datetime.date(2026, 2, 27), ActionType.STOCK_ACTIVITY)
+
+    assert espp.quantity == Decimal(150)
+    assert espp.price == Decimal("177.19")
+
+
+def test_disposal_before_the_split_is_converted(transactions: list) -> None:
+    """Disposals are the one record left in the units of their own day.
+
+    Two shares at $191.93 as recorded is twenty at $19.193 in current units,
+    and the money is the same either way. Missing this costs 54 shares across
+    the two 2023 disposals, and the pool stays wrong by that much for every
+    year afterwards.
+    """
+    sale = on(transactions, datetime.date(2023, 1, 23), ActionType.SELL)
+
+    assert sale.quantity == Decimal(20)
+    assert sale.price == Decimal("19.193")
+    assert sale.quantity * sale.price == Decimal("383.86")
+
+
+def test_disposal_after_the_split_is_left_alone(transactions: list) -> None:
+    """A disposal already in current units needs no conversion."""
+    sale = on(transactions, datetime.date(2026, 4, 2), ActionType.SELL)
+
+    assert sale.quantity == Decimal(120)
+    assert sale.price == Decimal("176.725")
+
+
+def test_disposal_price_comes_from_the_money(transactions: list) -> None:
+    """Amount is net of fees, so the gross is rebuilt before dividing.
+
+    Deriving the price this way rather than from the per-lot SalePrice is what
+    lets a disposal span lots sold at different prices.
+    """
+    sale = on(transactions, datetime.date(2025, 5, 22), ActionType.SELL)
+
+    assert sale.fees == Decimal("0.10")
+    assert sale.price == Decimal("132.83")
+    assert sale.quantity == Decimal(500)
+
+
+def test_a_commission_free_disposal_has_zero_fees(transactions: list) -> None:
+    """Schwab writes an empty string for the fees rather than a zero."""
+    sale = on(transactions, datetime.date(2023, 1, 23), ActionType.SELL)
+
+    assert sale.fees == Decimal("0.02")
+
+
+def test_withholding_on_dividends_is_kept(transactions: list) -> None:
+    """US tax at source, needed for SA106 and foreign tax credit relief.
+
+    Skipping it alongside Lapse would lose the figure entirely.
+    """
+    withheld = [t for t in transactions if t.action == ActionType.DIVIDEND_TAX]
+
+    assert len(withheld) == 1
+    assert withheld[0].amount == Decimal("-2.22")
+
+
+def test_the_position_matches_the_transactions(transactions: list) -> None:
+    """Acquisitions less disposals, in current units throughout."""
+    acquired = sum(
+        t.quantity or Decimal(0)
+        for t in transactions
+        if t.action == ActionType.STOCK_ACTIVITY
+    )
+    disposed = sum(
+        t.quantity or Decimal(0)
+        for t in transactions
+        if t.action == ActionType.SELL
+    )
+
+    assert acquired == Decimal(1730)
+    assert disposed == Decimal(690)
+    assert acquired - disposed == Decimal(1040)

--- a/tests/schwab/test_schwab_equity_award_nvda.py
+++ b/tests/schwab/test_schwab_equity_award_nvda.py
@@ -209,10 +209,10 @@ def test_the_position_matches_the_transactions(
 
 def mutated(tmp_path: Path, change: Callable[[list[JsonRowType]], None]) -> Path:
     """Write a copy of the fixture with `change` applied to its transactions."""
-    data = json.loads(FIXTURE.read_text())
+    data = json.loads(FIXTURE.read_text(encoding="utf-8"))
     change(data["Transactions"])
     path = tmp_path / "mutated.json"
-    path.write_text(json.dumps(data))
+    path.write_text(json.dumps(data), encoding="utf-8")
     return path
 
 

--- a/tests/schwab/test_schwab_equity_award_nvda.py
+++ b/tests/schwab/test_schwab_equity_award_nvda.py
@@ -252,6 +252,31 @@ def details_of(row: JsonRowType) -> JsonRowType:
     return first.get("Details", first)
 
 
+def test_a_sale_rounded_in_the_row_takes_its_count_from_the_lots(
+    tmp_path: Path,
+) -> None:
+    """The row rounds the quantity away; the lots still hold the fraction.
+
+    Deriving the price from the money hides it — the proceeds come out right
+    whichever count is used — so the pool would quietly lose the fraction and
+    never say so.
+    """
+
+    def fractional_lots(rows: list[JsonRowType]) -> None:
+        for row in rows:
+            if row.get("Action") == "Sale" and row["Date"] == "05/22/2025":
+                row["TransactionDetails"][0]["Details"]["Shares"] = "200.5"
+
+    sale = on(
+        parse(mutated(tmp_path, fractional_lots)),
+        datetime.date(2025, 5, 22),
+        ActionType.SELL,
+    )
+
+    assert sale.quantity == Decimal("500.5")
+    assert sale.amount == Decimal("66414.90")
+
+
 def test_a_disposal_schwab_already_restated_is_flagged(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -326,7 +351,7 @@ def test_espp_counts_must_account_for_every_share(tmp_path: Path) -> None:
 
 
 def test_espp_with_everything_withheld_pools_nothing(tmp_path: Path) -> None:
-    """And when the counts do add up, zero deposited is simply zero.
+    """And when the counts do add up, zero deposited means nothing was acquired.
 
     The same "0" as above, now corroborated. Distinguishing the two is the
     whole point of asking the counts rather than the field's emptiness.
@@ -346,5 +371,6 @@ def test_espp_with_everything_withheld_pools_nothing(tmp_path: Path) -> None:
         and t.date == datetime.date(2026, 2, 27)
     ]
 
-    assert len(espp) == 1
-    assert espp[0].quantity == Decimal(0)
+    # Not an acquisition of zero shares, which the calculator refuses outright,
+    # but no acquisition at all.
+    assert espp == []

--- a/tests/schwab/test_schwab_equity_award_nvda.py
+++ b/tests/schwab/test_schwab_equity_award_nvda.py
@@ -13,26 +13,37 @@ from __future__ import annotations
 
 import datetime
 from decimal import Decimal
+import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
-from cgt_calc.model import ActionType
+from cgt_calc.exceptions import ParsingError
+from cgt_calc.model import ActionType, BrokerTransaction
 from cgt_calc.parsers import schwab_equity_award_json
-from cgt_calc.parsers.schwab_equity_award_json import nvidia_split_multiplier
+from cgt_calc.parsers.schwab_equity_award_json import (
+    JsonRowType,
+    nvidia_split_multiplier,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 FIXTURE = Path("tests/schwab/data/equity_award/nvda_synthetic.json")
 
 
 @pytest.fixture(name="transactions")
-def transactions_fixture() -> list:
+def transactions_fixture() -> list[BrokerTransaction]:
     """Parse the synthetic NVDA portfolio."""
     return schwab_equity_award_json.SchwabEquityAwardsJSONParser().load_from_file(
         FIXTURE
     )
 
 
-def on(transactions: list, date: datetime.date, action: ActionType):
+def on(
+    transactions: list[BrokerTransaction], date: datetime.date, action: ActionType
+) -> BrokerTransaction:
     """Return the single transaction of that kind on that date."""
     found = [t for t in transactions if t.date == date and t.action == action]
     assert len(found) == 1, f"expected one {action} on {date}, got {len(found)}"
@@ -57,7 +68,7 @@ def test_split_multiplier_boundaries(day: datetime.date, expected: int) -> None:
     assert nvidia_split_multiplier(day) == expected
 
 
-def test_lapse_is_not_an_acquisition(transactions: list) -> None:
+def test_lapse_is_not_an_acquisition(transactions: list[BrokerTransaction]) -> None:
     """A Lapse duplicates its Deposit and must not reach the pool.
 
     Its NetSharesDeposited is in the units of the day while its price is
@@ -76,7 +87,7 @@ def test_lapse_is_not_an_acquisition(transactions: list) -> None:
     assert vests[0].quantity == Decimal(400)
 
 
-def test_vest_is_read_in_restated_units(transactions: list) -> None:
+def test_vest_is_read_in_restated_units(transactions: list[BrokerTransaction]) -> None:
     """Both the count and the price of a vest are already restated."""
     vest = on(transactions, datetime.date(2021, 9, 15), ActionType.STOCK_ACTIVITY)
 
@@ -84,14 +95,16 @@ def test_vest_is_read_in_restated_units(transactions: list) -> None:
     assert vest.price == Decimal("22.341")
 
 
-def test_sell_to_cover_leaves_net_shares(transactions: list) -> None:
+def test_sell_to_cover_leaves_net_shares(transactions: list[BrokerTransaction]) -> None:
     """1000 vested, 300 went to tax, and the Deposit is already net."""
     vest = on(transactions, datetime.date(2024, 9, 18), ActionType.STOCK_ACTIVITY)
 
     assert vest.quantity == Decimal(700)
 
 
-def test_espp_uses_market_value_not_price_paid(transactions: list) -> None:
+def test_espp_uses_market_value_not_price_paid(
+    transactions: list[BrokerTransaction],
+) -> None:
     """The discount is taxed through payroll, so the basis is market value.
 
     Using PurchasePrice of $9.3588 instead of the $13.7145 the shares were
@@ -105,7 +118,9 @@ def test_espp_uses_market_value_not_price_paid(transactions: list) -> None:
     assert espp.amount == Decimal(80) * Decimal("13.7145")
 
 
-def test_espp_taxed_in_shares_pools_the_net(transactions: list) -> None:
+def test_espp_taxed_in_shares_pools_the_net(
+    transactions: list[BrokerTransaction],
+) -> None:
     """Since August 2025 the tax is settled in shares: 200 bought, 150 kept."""
     espp = on(transactions, datetime.date(2026, 2, 27), ActionType.STOCK_ACTIVITY)
 
@@ -113,7 +128,9 @@ def test_espp_taxed_in_shares_pools_the_net(transactions: list) -> None:
     assert espp.price == Decimal("177.19")
 
 
-def test_disposal_before_the_split_is_converted(transactions: list) -> None:
+def test_disposal_before_the_split_is_converted(
+    transactions: list[BrokerTransaction],
+) -> None:
     """Disposals are the one record left in the units of their own day.
 
     Two shares at $191.93 as recorded is twenty at $19.193 in current units,
@@ -128,7 +145,9 @@ def test_disposal_before_the_split_is_converted(transactions: list) -> None:
     assert sale.quantity * sale.price == Decimal("383.86")
 
 
-def test_disposal_after_the_split_is_left_alone(transactions: list) -> None:
+def test_disposal_after_the_split_is_left_alone(
+    transactions: list[BrokerTransaction],
+) -> None:
     """A disposal already in current units needs no conversion."""
     sale = on(transactions, datetime.date(2026, 4, 2), ActionType.SELL)
 
@@ -136,7 +155,9 @@ def test_disposal_after_the_split_is_left_alone(transactions: list) -> None:
     assert sale.price == Decimal("176.725")
 
 
-def test_disposal_price_comes_from_the_money(transactions: list) -> None:
+def test_disposal_price_comes_from_the_money(
+    transactions: list[BrokerTransaction],
+) -> None:
     """Amount is net of fees, so the gross is rebuilt before dividing.
 
     Deriving the price this way rather than from the per-lot SalePrice is what
@@ -149,14 +170,18 @@ def test_disposal_price_comes_from_the_money(transactions: list) -> None:
     assert sale.quantity == Decimal(500)
 
 
-def test_a_commission_free_disposal_has_zero_fees(transactions: list) -> None:
+def test_a_commission_free_disposal_has_zero_fees(
+    transactions: list[BrokerTransaction],
+) -> None:
     """Schwab writes an empty string for the fees rather than a zero."""
     sale = on(transactions, datetime.date(2023, 1, 23), ActionType.SELL)
 
     assert sale.fees == Decimal("0.02")
 
 
-def test_withholding_on_dividends_is_kept(transactions: list) -> None:
+def test_withholding_on_dividends_is_kept(
+    transactions: list[BrokerTransaction],
+) -> None:
     """US tax at source, needed for SA106 and foreign tax credit relief.
 
     Skipping it alongside Lapse would lose the figure entirely.
@@ -167,7 +192,9 @@ def test_withholding_on_dividends_is_kept(transactions: list) -> None:
     assert withheld[0].amount == Decimal("-2.22")
 
 
-def test_the_position_matches_the_transactions(transactions: list) -> None:
+def test_the_position_matches_the_transactions(
+    transactions: list[BrokerTransaction],
+) -> None:
     """Acquisitions less disposals, in current units throughout."""
     acquired = sum(
         t.quantity or Decimal(0)
@@ -175,11 +202,118 @@ def test_the_position_matches_the_transactions(transactions: list) -> None:
         if t.action == ActionType.STOCK_ACTIVITY
     )
     disposed = sum(
-        t.quantity or Decimal(0)
-        for t in transactions
-        if t.action == ActionType.SELL
+        t.quantity or Decimal(0) for t in transactions if t.action == ActionType.SELL
     )
 
     assert acquired == Decimal(1730)
     assert disposed == Decimal(690)
     assert acquired - disposed == Decimal(1040)
+
+
+def mutated(tmp_path: Path, change: Callable[[list[JsonRowType]], None]) -> Path:
+    """Write a copy of the fixture with `change` applied to its transactions."""
+    data = json.loads(FIXTURE.read_text())
+    change(data["Transactions"])
+    path = tmp_path / "mutated.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+def parse(path: Path) -> list[BrokerTransaction]:
+    """Parse an export, whatever it contains."""
+    return schwab_equity_award_json.SchwabEquityAwardsJSONParser().load_from_file(path)
+
+
+def details_of(row: JsonRowType) -> JsonRowType:
+    """Return a transaction's detail block, whichever nesting it uses."""
+    first: JsonRowType = row["TransactionDetails"][0]
+    return first.get("Details", first)
+
+
+def test_a_disposal_schwab_already_restated_is_caught(tmp_path: Path) -> None:
+    """The failure this check exists for, and the reason it needs one.
+
+    Converting a disposal Schwab had already converted leaves the proceeds
+    right and the share count ten times too high. Nothing fails to balance, so
+    before this check the run finished cleanly on a different answer.
+    """
+
+    def already_restated(rows: list[JsonRowType]) -> None:
+        for row in rows:
+            if row.get("Action") == "Sale" and row["Date"] == "01/23/2023":
+                row["Quantity"] = "20"
+                details_of(row)["SalePrice"] = "$19.192"
+
+    with pytest.raises(ParsingError, match="already restated"):
+        parse(mutated(tmp_path, already_restated))
+
+
+def test_a_disposal_in_its_own_units_is_left_alone(tmp_path: Path) -> None:
+    """The check has to stay quiet on the units Schwab actually writes.
+
+    A guard that fires on correct data is worse than no guard, because the way
+    round it is to switch it off.
+    """
+
+    def nothing(rows: list[JsonRowType]) -> None:
+        pass
+
+    assert parse(mutated(tmp_path, nothing))
+
+
+def test_a_split_missing_from_the_table_is_caught(tmp_path: Path) -> None:
+    """A Lapse states both units at once, so it can contradict the table.
+
+    Here the counts are consistent with a split the table does not have. The
+    point is that this is caught from the file alone, with no market data and
+    no broker statement.
+    """
+
+    def as_if_another_split(rows: list[JsonRowType]) -> None:
+        for row in rows:
+            if row.get("Action") == "Lapse" and row["Date"] == "09/18/2024":
+                row["Quantity"] = "2000"
+
+    with pytest.raises(ParsingError, match="split is missing"):
+        parse(mutated(tmp_path, as_if_another_split))
+
+
+def test_espp_counts_must_account_for_every_share(tmp_path: Path) -> None:
+    """A "0" is a count, not a blank.
+
+    Reading it as one silently dropped the whole purchase from the pool: 200
+    shares in, nothing out, no error.
+    """
+
+    def zero_deposited(rows: list[JsonRowType]) -> None:
+        for row in rows:
+            if row.get("Description") == "ESPP" and row["Date"] == "02/27/2026":
+                details_of(row)["NetSharesDeposited"] = "0"
+
+    with pytest.raises(ParsingError, match="accounts for"):
+        parse(mutated(tmp_path, zero_deposited))
+
+
+def test_espp_with_everything_withheld_pools_nothing(tmp_path: Path) -> None:
+    """And when the counts do add up, zero deposited is simply zero.
+
+    The same "0" as above, now corroborated. Distinguishing the two is the
+    whole point of asking the counts rather than the field's emptiness.
+    """
+
+    def all_withheld(rows: list[JsonRowType]) -> None:
+        for row in rows:
+            if row.get("Description") == "ESPP" and row["Date"] == "02/27/2026":
+                details = details_of(row)
+                details["NetSharesDeposited"] = "0"
+                details["SharesWithheld"] = "200"
+
+    espp = [
+        t
+        for t in parse(mutated(tmp_path, all_withheld))
+        if t.action == ActionType.STOCK_ACTIVITY
+        and t.date == datetime.date(2026, 2, 27)
+    ]
+
+    assert len(espp) == 1
+    assert espp[0].quantity == Decimal(0)

--- a/tests/schwab/test_schwab_equity_award_nvda.py
+++ b/tests/schwab/test_schwab_equity_award_nvda.py
@@ -277,6 +277,31 @@ def test_a_sale_rounded_in_the_row_takes_its_count_from_the_lots(
     assert sale.amount == Decimal("66414.90")
 
 
+def test_a_vest_with_no_quantity_is_left_for_the_calculator_to_refuse(
+    tmp_path: Path,
+) -> None:
+    """Only a purchase that pooled nothing may be dropped, not any zero.
+
+    A blank Quantity reads as zero like any other missing number. Dropping it
+    would turn a malformed row into a smaller holding and a confident wrong
+    answer, where refusing it says so.
+    """
+
+    def blank_the_vest(rows: list[JsonRowType]) -> None:
+        for row in rows:
+            if row.get("Description") == "RS" and row["Date"] == "09/18/2024":
+                row["Quantity"] = ""
+                row.pop("QuantitySortValue", None)
+
+    vest = on(
+        parse(mutated(tmp_path, blank_the_vest)),
+        datetime.date(2024, 9, 18),
+        ActionType.STOCK_ACTIVITY,
+    )
+
+    assert vest.quantity == Decimal(0)
+
+
 def test_a_sale_hiding_its_fraction_in_a_zero_lot_is_recovered(
     tmp_path: Path,
 ) -> None:

--- a/tests/schwab/test_schwab_equity_award_nvda.py
+++ b/tests/schwab/test_schwab_equity_award_nvda.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import datetime
 from decimal import Decimal
 import json
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -227,12 +228,16 @@ def details_of(row: JsonRowType) -> JsonRowType:
     return first.get("Details", first)
 
 
-def test_a_disposal_schwab_already_restated_is_caught(tmp_path: Path) -> None:
-    """The failure this check exists for, and the reason it needs one.
+def test_a_disposal_schwab_already_restated_is_flagged(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The failure this check exists for, and why it only warns.
 
     Converting a disposal Schwab had already converted leaves the proceeds
     right and the share count ten times too high. Nothing fails to balance, so
-    before this check the run finished cleanly on a different answer.
+    without this the run finishes cleanly on a different answer. It warns
+    rather than raises because a share that fell far enough between the sale
+    and the nearest vest looks exactly the same.
     """
 
     def already_restated(rows: list[JsonRowType]) -> None:
@@ -241,11 +246,14 @@ def test_a_disposal_schwab_already_restated_is_caught(tmp_path: Path) -> None:
                 row["Quantity"] = "20"
                 details_of(row)["SalePrice"] = "$19.192"
 
-    with pytest.raises(ParsingError, match="already restated"):
-        parse(mutated(tmp_path, already_restated))
+    with caplog.at_level(logging.WARNING):
+        assert parse(mutated(tmp_path, already_restated))
+    assert "already restated" in caplog.text
 
 
-def test_a_disposal_in_its_own_units_is_left_alone(tmp_path: Path) -> None:
+def test_a_disposal_in_its_own_units_is_left_alone(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     """The check has to stay quiet on the units Schwab actually writes.
 
     A guard that fires on correct data is worse than no guard, because the way
@@ -255,7 +263,9 @@ def test_a_disposal_in_its_own_units_is_left_alone(tmp_path: Path) -> None:
     def nothing(rows: list[JsonRowType]) -> None:
         pass
 
-    assert parse(mutated(tmp_path, nothing))
+    with caplog.at_level(logging.WARNING):
+        assert parse(mutated(tmp_path, nothing))
+    assert "already restated" not in caplog.text
 
 
 def test_a_split_missing_from_the_table_is_caught(tmp_path: Path) -> None:

--- a/tests/schwab/test_schwab_equity_award_nvda.py
+++ b/tests/schwab/test_schwab_equity_award_nvda.py
@@ -126,6 +126,30 @@ def test_espp_taxed_in_shares_pools_the_net(
     assert espp.price == Decimal("177.19")
 
 
+def test_espp_before_a_split_pools_the_net_in_current_units(tmp_path: Path) -> None:
+    """The counts inside the row are in the units of their own day.
+
+    Its Quantity is restated, so a purchase predating a split only adds up
+    through the multiplier — and the shares it pools have to go through it too,
+    or they land in a pool that is counting in something else.
+    """
+
+    def moved_before_the_splits(rows: list[JsonRowType]) -> None:
+        for row in rows:
+            if row.get("Description") == "ESPP" and row["Date"] == "02/27/2026":
+                row["Date"] = "05/17/2022"
+                row["Quantity"] = "2000"  # (150 + 50) restated by 10
+                details_of(row)["PurchaseDate"] = "05/17/2022"
+
+    espp = on(
+        parse(mutated(tmp_path, moved_before_the_splits)),
+        datetime.date(2022, 5, 17),
+        ActionType.STOCK_ACTIVITY,
+    )
+
+    assert espp.quantity == Decimal(1500)  # 150 restated by 10
+
+
 def test_disposal_before_the_split_is_converted(
     transactions: list[BrokerTransaction],
 ) -> None:

--- a/tests/schwab/test_schwab_equity_award_nvda.py
+++ b/tests/schwab/test_schwab_equity_award_nvda.py
@@ -22,10 +22,7 @@ import pytest
 from cgt_calc.exceptions import ParsingError
 from cgt_calc.model import ActionType, BrokerTransaction
 from cgt_calc.parsers import schwab_equity_award_json
-from cgt_calc.parsers.schwab_equity_award_json import (
-    JsonRowType,
-    nvidia_split_multiplier,
-)
+from cgt_calc.parsers.schwab_equity_award_json import JsonRowType, split_multiplier
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -65,7 +62,7 @@ def on(
 )
 def test_split_multiplier_boundaries(day: datetime.date, expected: int) -> None:
     """The multiplier changes on the day the new shares trade."""
-    assert nvidia_split_multiplier(day) == expected
+    assert split_multiplier("NVDA", day) == expected
 
 
 def test_lapse_is_not_an_acquisition(transactions: list[BrokerTransaction]) -> None:


### PR DESCRIPTION
## Problem

The parser normalises splits for GOOG only. NVDA needs it too, and Schwab
treats it differently: acquisitions are restated into current units, disposals
are not. Missing it moves no money, only the share count, so nothing fails to
balance and the pool drifts from the broker every year after. On my own export,
54 shares across two 2023 disposals.

## Change

- NVDA disposals convert from the split dates, not a price heuristic — a
  heuristic needs the day's market price and expires once the real price passes
  it.
- A disposal's price comes from the money rather than the per-lot `SalePrice`,
  so a sale can span lots priced differently. Its quantity comes from the lots,
  or from the money where a lot stating zero shares hides the fraction from
  both count fields.
- Two checks raise: the split table against a `Lapse`, which states both units
  at once, and ESPP share accounting. A third warns — a disposal priced far
  below its neighbours has usually been restated twice, but a share that simply
  fell that far looks identical.
- Split handling moves into a per-symbol table. What differs between issuers is
  which records the export restated, so that is what the table states. GOOG
  becomes data, including its $175 floor.
- An ESPP purchase settled entirely in shares acquires nothing, and is no
  longer offered as an acquisition of zero. Only that case: a zero arriving any
  other way is a malformed row and is still refused.

The checks and the table are one change: both rest on the same fact about which
records the export restates.

## Verification

318 tests, `ruff` and `mypy` clean. GOOG is byte-identical before and after the
table change on every existing fixture, and those fixtures exercise the
heuristic on both sides. NVDA is covered by a synthetic portfolio with real
dates and prices and invented share counts, and by a real 146-row export not
included here.

## Open questions

- Table in-tree, or user-supplied config? GOOG cannot be expressed as config —
  its floor comes from that share's own price history, and a wrong one would
  corrupt a pool with nothing to fail on.
- That floor stays a heuristic. The `Lapse` cross-check has no equivalent for a
  partially restated export.
