### PR TITLE
docs: explain reviewing and using reports

### DIFF
--- a/cgt_calc/args_parser.py
+++ b/cgt_calc/args_parser.py
@@ -197,6 +197,11 @@ Environment variables:
         action="store_true",
         help="do not generate PDF report",
     )
+    output_group.add_argument(
+        "--no-pdflatex",
+        action="store_true",
+        help="save LaTeX source instead of generating a PDF",
+    )
 
     # General Options
     general_group = parser.add_argument_group("General")
@@ -225,12 +230,6 @@ Environment variables:
         "--verbose",
         action="store_true",
         help="enable extra logging",
-    )
-    # For testing only
-    general_group.add_argument(
-        "--no-pdflatex",
-        action="store_true",
-        help=argparse.SUPPRESS,
     )
     return parser
 

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -3825,7 +3825,7 @@ def calculate_cgt(args: argparse.Namespace) -> None:
         )
     done_msg = (
         "Done! Calculations complete (PDF generation skipped)."
-        if args.no_pdflatex
+        if args.no_pdflatex or args.no_report
         else "Done! Report generated successfully."
     )
     LOGGER.info(style_text(done_msg, colour=Fore.GREEN, emoji="🎉", stream=sys.stderr))

--- a/docs/brokers/freetrade.md
+++ b/docs/brokers/freetrade.md
@@ -35,7 +35,7 @@ cgt-calc --year 2024 --freetrade-file freetrade.csv
 ```
 
 The filename does not matter. `--year 2024` means 6 April 2024 to 5 April 2025. Follow
-[Generate Your First Report](../usage.md) to find and check the output.
+[Generate and Review a Report](../usage.md) to find and check the output.
 
 ## Supported activity
 

--- a/docs/brokers/hargreaves-lansdown.md
+++ b/docs/brokers/hargreaves-lansdown.md
@@ -50,7 +50,7 @@ cgt-calc --year 2025 --hl-dir hargreaves_lansdown/
 ```
 
 `--year 2025` means 6 April 2025 to 5 April 2026. Pass the directory, not an individual CSV or PDF.
-Follow [Generate Your First Report](../usage.md) to find and check the output.
+Follow [Generate and Review a Report](../usage.md) to find and check the output.
 
 Run with the balance check enabled. Do not add `--no-balance-check` merely to bypass an error; first
 reconcile the report and any unsupported rows as described under

--- a/docs/brokers/interactive-brokers.md
+++ b/docs/brokers/interactive-brokers.md
@@ -42,7 +42,7 @@ For the 2025/26 tax year, run:
 cgt-calc --year 2025 --interactive-brokers-file U12345678.TRANSACTIONS.20240101.20260505.csv
 ```
 
-`--year 2025` means 6 April 2025 to 5 April 2026. Follow [Generate Your First Report](../usage.md)
+`--year 2025` means 6 April 2025 to 5 April 2026. Follow [Generate and Review a Report](../usage.md)
 to find and check the output.
 
 The Transaction History export contains cash deposits and withdrawals, so a complete export should

--- a/docs/brokers/morgan-stanley.md
+++ b/docs/brokers/morgan-stanley.md
@@ -40,7 +40,7 @@ cgt-calc --year 2025 --mssb-dir morgan_stanley/
 ```
 
 `--year 2025` means 6 April 2025 to 5 April 2026. Pass the directory containing the two CSV files,
-not either file itself. Follow [Generate Your First Report](../usage.md) to find and check the
+not either file itself. Follow [Generate and Review a Report](../usage.md) to find and check the
 output.
 
 ## Supported activity

--- a/docs/brokers/raw.md
+++ b/docs/brokers/raw.md
@@ -144,7 +144,7 @@ For the tax year 2024/25, run:
 cgt-calc --year 2024 --raw-file raw_data.csv
 ```
 
-`--year 2024` means 6 April 2024 to 5 April 2025. Follow [Generate Your First Report](../usage.md)
+`--year 2024` means 6 April 2024 to 5 April 2025. Follow [Generate and Review a Report](../usage.md)
 to find and check the output.
 
 Include cash deposits and withdrawals if your records contain them so the balance check can detect

--- a/docs/brokers/schwab.md
+++ b/docs/brokers/schwab.md
@@ -67,7 +67,7 @@ For the 2025/26 tax year, run:
 cgt-calc --year 2025 --schwab-file schwab_transactions.csv
 ```
 
-`--year 2025` means 6 April 2025 to 5 April 2026. Follow [Generate Your First Report](../usage.md)
+`--year 2025` means 6 April 2025 to 5 April 2026. Follow [Generate and Review a Report](../usage.md)
 to find and check the output.
 
 If your history needed several exports, point `--schwab-dir` at the directory holding them instead:

--- a/docs/brokers/sharesight.md
+++ b/docs/brokers/sharesight.md
@@ -65,7 +65,7 @@ cgt-calc --year 2024 --sharesight-dir sharesight/ --no-balance-check
 
 `--year 2024` means 6 April 2024 to 5 April 2025. `--no-balance-check` is needed because these two
 reports do not contain the complete cash activity required to reconcile a broker balance. Follow
-[Generate Your First Report](../usage.md) to find and check the output.
+[Generate and Review a Report](../usage.md) to find and check the output.
 
 ## Supported activity
 

--- a/docs/brokers/trading212.md
+++ b/docs/brokers/trading212.md
@@ -52,7 +52,7 @@ For the 2024/25 tax year, run:
 cgt-calc --year 2024 --trading212-dir trading212/
 ```
 
-`--year 2024` means 6 April 2024 to 5 April 2025. Follow [Generate Your First Report](../usage.md)
+`--year 2024` means 6 April 2024 to 5 April 2025. Follow [Generate and Review a Report](../usage.md)
 to find and check the output.
 
 ## Supported activity

--- a/docs/brokers/vanguard.md
+++ b/docs/brokers/vanguard.md
@@ -63,7 +63,7 @@ cgt-calc --year 2025 --vanguard-file vanguard.csv
 ```
 
 `--year 2025` means 6 April 2025 to 5 April 2026. Pass the CSV, not the original Excel workbook.
-Follow [Generate Your First Report](../usage.md) to find and check the output.
+Follow [Generate and Review a Report](../usage.md) to find and check the output.
 
 Run with the balance check enabled. Do not add `--no-balance-check` merely to bypass an error; first
 reconcile the file and any unsupported activity as described under

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ Section 104 pooling, gains and losses, a dividend with overseas tax, and cash in
 ## Where to start
 
 - [Installation](installation.md) — install the tool and LaTeX
-- [Usage](usage.md) — generate your first report
+- [Usage](usage.md) — generate and review a report
 - [Brokers](brokers/index.md) — export instructions for each supported broker
 - [Offshore funds (ERI)](offshore-funds.md) — if you hold non-UK funds
 - [Development](development/index.md) — contribute to the project

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,15 +1,18 @@
-# Generate Your First Report
+# Generate and Review a Report
 
 ## Before you start
 
 You will need:
 
-- **cgt-calc and LaTeX installed.** Follow the [installation guide](installation.md) before
-    continuing.
+- **cgt-calc installed.** Follow the [installation guide](installation.md) before continuing.
+- **LaTeX installed if you want a PDF report.** It is not needed for a terminal-only report using
+    `--no-report`.
 - **A complete transaction history from every relevant account.** Follow the instructions for each
-    [supported broker](brokers/index.md). Include transactions from before the tax year when they
-    are needed to establish the cost of shares you owned or sold during that year. Exporting the
-    history since the account was opened is the safest option.
+    [supported broker](brokers/index.md). Include transactions from before the report starts when
+    they establish the cost of shares you owned or sold. Also include acquisitions in the 30 days
+    after the report ends, because they can be matched to a disposal inside the period. Exporting
+    from the date the account was opened through at least 30 days after the report ends is the
+    safest option.
 - **Excess Reported Income data when applicable.** If you own or have owned funds from outside the
     UK, whether accumulating or distributing, check the [offshore funds guide](offshore-funds.md).
 - **Transfers to or from a spouse or civil partner, recorded by hand.** No broker export marks
@@ -26,6 +29,27 @@ Pass the first year of the UK tax year to `--year`. For example, `--year 2024` m
 year, from 6 April 2024 to 5 April 2025.
 
 If you omit `--year`, cgt-calc uses the most recently completed UK tax year.
+
+### Report part of a tax year
+
+Use `--from` and `--to` instead of `--year` to report a period within one UK tax year. For example,
+the following reports disposals on or after 30 October 2024 for the
+[HMRC 2024/25 Capital Gains Tax adjustment](https://www.gov.uk/guidance/work-out-your-capital-gains-tax-adjustment-for-the-2024-to-2025-tax-year):
+
+```shell
+cgt-calc --from 2024-10-30 --to 2025-04-05 --schwab-file schwab_transactions.csv
+```
+
+cgt-calc still reads earlier transactions from the supplied history to establish the share pool, but
+only reports the selected period. Matching is not limited by the end date: a purchase made after it
+is still identified against a reported disposal under the 30-day rule if it is in the supplied
+history.
+
+A period report does not calculate the HMRC adjustment or allocate the annual exempt amount between
+periods. Use the **Gain** and **Loss** figures with the full-year report and HMRC guidance; do not
+treat its **Taxable gain** as your annual figure. Do not treat its dividend or interest figures as
+annual totals either: they include only income received inside the period, and the dividend section
+still deducts the full-year dividend allowance.
 
 ## Generate the report
 
@@ -68,13 +92,24 @@ cgt-calc --year 2024 --schwab-file transactions.csv > report.txt
 
 Redirecting stdout does not change where the PDF is saved.
 
+Use `--no-report` instead of `--output` to print the terminal summary without generating a report.
+This creates neither a PDF nor LaTeX source and does not require `pdflatex`:
+
+```shell
+cgt-calc --year 2024 --schwab-file transactions.csv --no-report
+```
+
+To save the LaTeX source without creating a PDF, use `--no-pdflatex`. The source follows the
+`--output` path with a `.tex` extension (by default, `out/calculations.tex`). For example,
+`--output reports/2024-25.pdf` writes `reports/2024-25.tex`.
+
 ## Check the result
 
 Before relying on the figures:
 
 1. Read every warning printed while the calculator runs.
-2. Check that the section headed “Portfolio at the end of … tax year” agrees with your records at
-    the end of that tax year.
+2. Check that the portfolio section agrees with your records on the end date in the heading (5 April
+    for a full-year report).
 3. Compare the disposal count and proceeds with your broker statements.
 4. Check that dividends and interest are present when you expect them.
 5. Confirm that every relevant account was included once, without overlapping exports.
@@ -86,6 +121,28 @@ history.
 
 A successful run means cgt-calc could parse and calculate the supplied transactions. It does not
 prove that the supplied history was complete or that every part of your tax position is supported.
+
+The PDF shows the matching rules applied to each disposal: **SAME DAY**, **BED AND BREAKFAST** and
+**SECTION 104**. Check any unexpected matches against HMRC's
+[guidance for shares and Capital Gains Tax](https://www.gov.uk/government/publications/shares-and-capital-gains-tax-hs284-self-assessment-helpsheet).
+
+## Use the figures
+
+Treat the cgt-calc report as one calculation working paper. It covers only the supported
+transactions supplied to the tool. Combine it with gains and losses from other assets,
+brought-forward losses and any claims or reliefs before completing your return.
+
+Use HMRC's guidance to
+[check whether the gains must be reported](https://www.gov.uk/capital-gains-tax/work-out-need-to-pay).
+If completing Self Assessment, use the
+[Capital gains summary form and notes](https://www.gov.uk/government/publications/self-assessment-capital-gains-summary-sa108)
+for the relevant tax year. cgt-calc does not calculate the tax payable, map its output to return
+boxes or submit a return.
+
+Keep the original exports, supporting statements, command used, warnings and generated report with
+the calculation. Follow HMRC's
+[Capital Gains Tax record-keeping guidance](https://www.gov.uk/capital-gains-tax/records) for the
+required records and retention period.
 
 Run `cgt-calc --help` for the complete list of available options. Use `--verbose` when you need more
 detail while investigating a warning or error.

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -132,6 +132,33 @@ def test_main_prints_help_when_no_arguments() -> None:
     assert result.returncode == 0
     assert "usage:" in result.stdout
     assert "Calculate UK capital gains" in result.stdout
+    assert "--no-pdflatex" in result.stdout
+
+
+def test_no_report_completion_message() -> None:
+    """Ensure a terminal-only run does not claim to generate a report."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "cgt_calc.main",
+            "--year",
+            "2022",
+            "--raw-file",
+            "tests/raw/data/test_data.csv",
+            "--no-balance-check",
+            "--no-report",
+            "--exchange-rates-file",
+            "tests/exchange_rates_data.csv",
+        ],
+        capture_output=True,
+        encoding="utf-8",
+        check=False,
+    )
+
+    assert result.returncode == 0
+    stderr_lines = [line for line in result.stderr.splitlines() if line.strip()]
+    assert stderr_lines[-1] == "Done! Calculations complete (PDF generation skipped)."
 
 
 def test_interest_tax_totals_are_positive() -> None:

--- a/zensical.toml
+++ b/zensical.toml
@@ -12,7 +12,7 @@ nav = [
   { "Home" = "index.md" },
   { "Getting started" = [
     { "Installation" = "installation.md" },
-    { "Generating a report" = "usage.md" },
+    { "Generate a report" = "usage.md" },
     { "Docker" = "docker.md" },
   ] },
   { "Input data" = [


### PR DESCRIPTION
Document partial-period, terminal-only and LaTeX-source workflows, and connect report review to current HMRC guidance.

- explain the input history required for 30-day matching
- document report generation and reconciliation options
- expose LaTeX-only output and correct the terminal completion message
- link stable HMRC reporting, share and record guidance