### PR TITLE
Bring every broker's split guidance up to the reorganisation behaviour

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -209,6 +209,7 @@ txn
 ty
 UCITS
 un
+unmapped
 unprovable
 UnresolvedRatio
 unvalidated

--- a/docs/brokers/freetrade.md
+++ b/docs/brokers/freetrade.md
@@ -93,7 +93,9 @@ promise to import its corporate-action rows directly.
     a financial transaction merely to make the calculation run.
 - Current exports add `Stock Split ...` columns, but `STOCK_SPLIT` rows are not yet mapped. The
     columns are accepted so ordinary rows can still be imported; an actual split row stops with
-    `Unknown type`.
+    `Unknown type`. Remove it in a working copy only together with a RAW
+    [`STOCK_SPLIT` row](raw.md#share-reorganisations) stating the change to your whole pooled
+    holding.
 - The importer supports a GBP account currency only. Changing the currency text in the CSV would not
     convert its amounts.
 - The export has no asset-class column, and the importer does not use one. Every `ORDER` is

--- a/docs/brokers/interactive-brokers.md
+++ b/docs/brokers/interactive-brokers.md
@@ -81,7 +81,10 @@ treaty applies.
     `Unknown type`; do not delete the row merely to make the calculation run.
 - Cash `Deposit` and `Withdrawal` rows are supported, but transfers of shares or funds between
     accounts are not. Corporate actions such as splits, mergers and spin-offs are not mapped from an
-    IBKR export either.
+    IBKR export either; record a split or consolidation as a RAW
+    [`STOCK_SPLIT` row](raw.md#share-reorganisations) stating the change to your whole pooled
+    holding. If the export contains the corporate-action row, it stops the import, so remove it from
+    a working copy only when adding the RAW replacement.
 - The importer does not read an asset-class field. It has been validated for ordinary share and fund
     trades; do not rely on it to calculate options, futures, bonds, contracts for difference or
     crypto assets.

--- a/docs/brokers/schwab.md
+++ b/docs/brokers/schwab.md
@@ -110,7 +110,7 @@ The importer recognises these exact values from the main CSV's `Action` column:
 | `Security Transfer`                                                | An `ACH`-related cash movement; an `Amount` is required and no holding is moved     |
 | `Reinvest Shares`                                                  | A purchase of the reinvested shares                                                 |
 | `Reinvest Dividend`                                                | Unsupported; the row is ignored and cgt-calc prints a warning                       |
-| `Stock Split`                                                      | Adds the exported new shares at no cost                                             |
+| `Stock Split`                                                      | A share reorganisation: the pooled cost is unchanged and spread over the new count  |
 | `Spin-off`                                                         | Adds the new holding and moves part of the old holding's pooled cost to it          |
 | `Cash Merger` followed by `Cash Merger Adj`                        | A disposal for cash, built from the adjacent amount and quantity rows               |
 | `Full Redemption Adj` followed by `Full Redemption`                | A disposal for cash, built from the adjacent amount and quantity rows               |
@@ -157,8 +157,21 @@ interest with the trade confirmation before relying on the result.
 
 ### Corporate actions
 
-A `Stock Split` row must contain the positive number of new shares added by the split. A
-consolidation or reverse split that removes shares is not supported by this action.
+A `Stock Split` row states the change the event made to this account's holding: positive for the new
+shares a split added, negative for the shares a consolidation removed. cgt-calc applies it as a
+share reorganisation: nothing is bought or sold, and the pooled cost is unchanged and spread over
+the new count ([TCGA 1992 s127](https://www.legislation.gov.uk/ukpga/1992/12/part/IV/chapter/II)).
+
+Two situations are refused rather than guessed:
+
+- If the same security also has units from another input, one account's change does not state the
+    whole pooled holding's. Replace the Schwab row's effect with a RAW
+    [`STOCK_SPLIT` row](raw.md#share-reorganisations) stating the change to all of them together;
+    where a date has both, the RAW row is used and the Schwab row is ignored. See
+    [`also has units from`](raw.md#also-has-units-from-on-a-stock_split-row).
+- Because Schwab rows carry dates without times, a purchase, sale, gift or transfer of the same
+    security on the day of the split cannot be placed before or after it, and the day is refused.
+    See [`cannot be placed either side of it`](raw.md#cannot-be-placed-either-side-of-it).
 
 For a `Spin-off`, cgt-calc needs to know the old holding from which the new shares came. It asks for
 the old ticker during an interactive run and saves the answer in `out/spin_offs.csv`. For a
@@ -259,7 +272,6 @@ use the one with the correct quantity.
     above.
 - A cash merger that gives replacement shares as well as cash is not supported. The cash-only
     importer prints a warning for every merger so you remember to check this.
-- `Stock Split` supports extra shares from a split, not shares removed by a consolidation.
 - All values in Schwab CSV and JSON files are treated as USD. Changing a currency symbol in the CSV
     does not convert the data.
 - cgt-calc does not remove duplicates from Schwab exports, because the CSV has no transaction ID to

--- a/docs/brokers/sharesight.md
+++ b/docs/brokers/sharesight.md
@@ -94,8 +94,10 @@ these markers.
     Sharesight uses them when the original buy and sell records are unavailable, but cgt-calc needs
     the original acquisition dates and costs for UK share matching.
 - `Split`, `Consolidation` and `Bonus` rows are not supported. They stop the import with an unknown
-    action error. Do not delete such a row to make the calculation run: later quantities and gains
-    could be wrong.
+    action error. Do not delete such a row on its own to make the calculation run: later quantities
+    and gains would be wrong. For a split or consolidation, remove the row in a working copy only
+    together with a RAW [`STOCK_SPLIT` row](raw.md#share-reorganisations) stating the change to your
+    whole pooled holding.
 - Cash deposits, withdrawals and balances are not imported, which is why `--no-balance-check` is
     required.
 - Taxable Income sections other than local and foreign dividend payments are not imported.

--- a/docs/brokers/vanguard.md
+++ b/docs/brokers/vanguard.md
@@ -155,7 +155,9 @@ taxed as interest rather than dividends; see
 - Account fees and ETF dealing fees are not assigned to a purchase or disposal as allowable costs.
 - Corporate actions other than the supported `NameChange` pair are not mapped. A split, merger,
     conversion, transfer of investments or other unfamiliar row can stop the import or be absent
-    from the cash table.
+    from the cash table. A split or consolidation can be recorded as a RAW
+    [`STOCK_SPLIT` row](raw.md#share-reorganisations) stating the change to your whole pooled
+    holding; remove the unmapped row, if the export has one, in a working copy only alongside it.
 - `NameChange` supports uppercase ticker-style codes, with an optional dot suffix, rather than fund
     names. A row such as `NameChange: U.S. Equity Index Fund replaced with ...` stops with
     `Unknown action`.


### PR DESCRIPTION
The Schwab guide still described a `Stock Split` row as adding the exported new shares at no cost, which is the treatment the reorganisation work replaced. It now states the s127 behaviour, and documents the two refusals a Schwab user can hit: a split of a security whose pool also has units from another input, and a same-day trade of that security, since Schwab rows carry no times.

Sharesight, Freetrade, Interactive Brokers and Vanguard documented their split rows as unsupported and stopped there. Each now points at the RAW `STOCK_SPLIT` remedy, with any row removal confined to a working copy and tied to the replacement.
