### PR TITLE
Align ERI guidance and reporting-fund links

### DIFF
--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -1425,7 +1425,7 @@ class CapitalGainsCalculator:
 
         When those funds are "reporting" funds, that is, enlisted in HMRC
         official list of reporting funds:
-        https://www.gov.uk/government/publications/offshore-funds-list-of-reporting-funds
+        https://www.gov.uk/government/publications/approved-offshore-reporting-funds
         We need to declare the excess income periodically (yearly) from these
         funds.
 

--- a/cgt_calc/parsers/eri/__init__.py
+++ b/cgt_calc/parsers/eri/__init__.py
@@ -5,5 +5,5 @@ HMRC for taxation purposes.
 For each fund it lists the amount of excess income that has to be reported from
 a taxation perspective.
 
-Full list of reporting funds at: https://www.gov.uk/government/publications/offshore-funds-list-of-reporting-funds
+Full list of reporting funds at: https://www.gov.uk/government/publications/approved-offshore-reporting-funds
 """

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,10 +9,10 @@ The following configuration files and options allow you to customize the calcula
     `out/exchange_rates.csv`. You can override these by providing your own file in the same format
     using the `--exchange-rates-file` option.
 
-- **ISIN to ticker translation.** When an ERI row carries only an ISIN, the tool automatically
-    translates it to ticker symbols using the
-    [Open FIGI API](https://www.openfigi.com/api/overview). This is used for calculating Excess
-    Reported Income (ERI) on offshore funds. The default read/write cache is
+- **ISIN to ticker translation.** When an ERI row identifies a fund only by its ISIN, cgt-calc maps
+    it to ticker symbols. It uses existing mappings first and queries the
+    [Open FIGI API](https://www.openfigi.com/api/overview) only if needed. This is used for
+    calculating Excess Reported Income (ERI) on offshore funds. The default read/write cache is
     `out/isin_translation.csv`; `--isin-translation-file` selects a different cache path. Existing
     entries are read, and cgt-calc can create or rewrite the file after a successful Open FIGI
     lookup or after learning a mapping from broker transactions. Pre-packaged mappings are available

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,10 +9,10 @@ The following configuration files and options allow you to customize the calcula
     `out/exchange_rates.csv`. You can override these by providing your own file in the same format
     using the `--exchange-rates-file` option.
 
-- **ISIN to ticker translation.** When your broker doesn't provide ticker symbols, the tool
-    automatically translates ISIN codes using the
+- **ISIN to ticker translation.** When an ERI row carries only an ISIN, the tool automatically
+    translates it to ticker symbols using the
     [Open FIGI API](https://www.openfigi.com/api/overview). This is used for calculating Excess
-    Reportable Income (ERI) on offshore funds. The default read/write cache is
+    Reported Income (ERI) on offshore funds. The default read/write cache is
     `out/isin_translation.csv`; `--isin-translation-file` selects a different cache path. Existing
     entries are read, and cgt-calc can create or rewrite the file after a successful Open FIGI
     lookup or after learning a mapping from broker transactions. Pre-packaged mappings are available


### PR DESCRIPTION
Follow up on the review findings from #1053.

- describe ISIN-to-ticker lookup as triggered by an ISIN-only ERI row
- use the project terminology “Excess Reported Income”
- point both ERI docstrings at the current HMRC reporting-funds page