### PR TITLE
Extract the CLI entry points into cgt_calc/cli.py

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -45,6 +45,7 @@ CG57835
 CG59562
 cgt
 classmethod
+cli
 cls
 CMF5
 codepage
@@ -134,6 +135,7 @@ pdflatex
 PermissionError
 pipx
 Plc
+PLC0415
 png
 Podman
 prek

--- a/cgt_calc/cli.py
+++ b/cgt_calc/cli.py
@@ -1,0 +1,139 @@
+"""Capital Gain Calculator command line interface."""
+
+from __future__ import annotations
+
+import decimal
+import logging
+import sys
+from typing import TYPE_CHECKING
+
+from colorama import Fore
+
+from . import render_latex
+from .args_parser import (
+    create_parser,
+    reject_duplicate_stdin,
+    reject_schwab_file_and_dir,
+    resolve_reporting_period,
+)
+from .currency_converter import CurrencyConverter
+from .current_price_fetcher import CurrentPriceFetcher
+from .exceptions import CgtError
+from .initial_prices import InitialPrices
+from .isin_converter import IsinConverter
+from .logging import setup_logging, style_text
+from .parsers.broker_registry import BrokerRegistry
+from .spin_off_handler import SpinOffHandler
+
+if TYPE_CHECKING:
+    import argparse
+
+LOGGER = logging.getLogger(__name__)
+
+
+def calculate_cgt(args: argparse.Namespace) -> None:
+    """Perform all the computations."""
+
+    # Imported here because cgt_calc.main re-exports the entry points below,
+    # so a module-level import either way round would be circular.
+    from .main import CapitalGainsCalculator  # noqa: PLC0415
+
+    isin_translation_file = args.isin_translation_file
+
+    # Read data from input files
+    isin_converter = IsinConverter(isin_translation_file)
+    broker_transactions = BrokerRegistry.load_all_transactions(args, isin_converter)
+    currency_converter = CurrencyConverter.create(args.exchange_rates_file)
+    price_fetcher = CurrentPriceFetcher(currency_converter)
+    initial_prices = InitialPrices(args.initial_prices_file)
+    spin_off_handler = SpinOffHandler(args.spin_offs_file)
+
+    calculator = CapitalGainsCalculator(
+        args.year,
+        currency_converter,
+        isin_converter,
+        price_fetcher,
+        spin_off_handler,
+        initial_prices,
+        args.interest_fund_tickers,
+        cgt_exempt_tickers=args.cgt_exempt_tickers,
+        balance_check=args.balance_check,
+        calc_unrealized_gains=args.calc_unrealized_gains,
+        period_start=args.period_from,
+        period_end=args.period_to,
+    )
+    # First pass converts broker transactions to HMRC transactions.
+    # This means applying same day rule and collapsing all transactions with
+    # same type within the same day.
+    # It also converts prices to GBP, validates data and calculates dividends,
+    # taxes on dividends and interest.
+    calculator.convert_to_hmrc_transactions(broker_transactions)
+    # Second pass calculates capital gain tax for the given tax year.
+    report = calculator.calculate_capital_gain()
+    # The report string is newline-terminated already; avoid a trailing
+    # blank line so piped output stays stable under newline normalisation.
+    print(report, end="")
+
+    # Generate PDF report.
+    if not args.no_report:
+        render_latex.render_pdf(
+            report,
+            output_path=args.output,
+            skip_pdflatex=args.no_pdflatex,
+        )
+    done_msg = (
+        "Done! Calculations complete (PDF generation skipped)."
+        if args.no_pdflatex or args.no_report
+        else "Done! Report generated successfully."
+    )
+    LOGGER.info(style_text(done_msg, colour=Fore.GREEN, emoji="🎉", stream=sys.stderr))
+
+
+def main() -> int:
+    """Run main function."""
+
+    # Enable colourised logging.
+    setup_logging()
+
+    # Throw exception on accidental float usage
+    decimal.getcontext().traps[decimal.FloatOperation] = True
+
+    parser = create_parser()
+
+    if len(sys.argv) == 1:
+        parser.print_help()
+        return 0
+
+    args = parser.parse_args()
+    reject_duplicate_stdin(parser, args)
+    reject_schwab_file_and_dir(parser, args)
+    resolve_reporting_period(parser, args)
+
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    try:
+        calculate_cgt(args)
+    except CgtError as err:
+        if args.verbose:
+            LOGGER.exception("Exception:")
+        else:
+            # Print error without traceback
+            LOGGER.error("%s", err)
+        return 1
+    except Exception:
+        # Last-resort catch for unexpected exceptions
+        LOGGER.critical("Unexpected error!")
+        LOGGER.exception("Details:")
+        return 1
+
+    return 0
+
+
+def init() -> None:
+    """Entry point."""
+    sys.exit(main())
+
+
+if __name__ == "__main__":
+    init()

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from collections import Counter, defaultdict
 import datetime
-import decimal
 from decimal import Decimal
 from fractions import Fraction
 import logging
@@ -14,13 +13,7 @@ from typing import TYPE_CHECKING, Literal
 
 from colorama import Fore, Style
 
-from . import render_latex
-from .args_parser import (
-    create_parser,
-    reject_duplicate_stdin,
-    reject_schwab_file_and_dir,
-    resolve_reporting_period,
-)
+from .cli import calculate_cgt, init, main
 from .const import (
     BALANCE_CHECK_CONTEXT_ROWS,
     BED_AND_BREAKFAST_DAYS,
@@ -37,14 +30,11 @@ from .const import (
     RENAME_DESCRIPTION_PREFIX,
     UK_CURRENCY,
 )
-from .currency_converter import CurrencyConverter
-from .current_price_fetcher import CurrentPriceFetcher
 from .dates import get_tax_year_end, get_tax_year_start, is_date
 from .exceptions import (
     AmountMissingError,
     CalculatedAmountDiscrepancyError,
     CalculationError,
-    CgtError,
     InvalidTransactionError,
     IsinMissingError,
     PriceMissingError,
@@ -53,9 +43,7 @@ from .exceptions import (
     SymbolMissingError,
     UnclassifiedGiftError,
 )
-from .initial_prices import InitialPrices
-from .isin_converter import IsinConverter
-from .logging import bullet, setup_logging, style_text
+from .logging import bullet, style_text
 from .model import (
     ActionType,
     BrokerTransaction,
@@ -79,9 +67,7 @@ from .model import (
     RuleType,
     SpinOff,
 )
-from .parsers.broker_registry import BrokerRegistry
 from .parsers.raw import RawTransaction
-from .spin_off_handler import SpinOffHandler
 from .stock_splits import (
     SplitMode,
     SplitTransformation,
@@ -97,9 +83,16 @@ from .transaction_log import add_to_list, has_key
 from .util import approx_equal, normalize_amount, round_decimal, strip_zeros
 
 if TYPE_CHECKING:
-    import argparse
-
+    from .currency_converter import CurrencyConverter
+    from .current_price_fetcher import CurrentPriceFetcher
+    from .initial_prices import InitialPrices
+    from .isin_converter import IsinConverter
     from .model import TransactionSource
+    from .spin_off_handler import SpinOffHandler
+
+# The CLI entry points live in cgt_calc.cli now; re-exported here so
+# existing imports and `python -m cgt_calc.main` keep working.
+__all__ = ["CapitalGainsCalculator", "calculate_cgt", "init", "main"]
 
 LOGGER = logging.getLogger(__name__)
 
@@ -3801,106 +3794,6 @@ class CapitalGainsCalculator:
             amount,
             unrealized_gains,
         )
-
-
-def calculate_cgt(args: argparse.Namespace) -> None:
-    """Perform all the computations."""
-
-    isin_translation_file = args.isin_translation_file
-
-    # Read data from input files
-    isin_converter = IsinConverter(isin_translation_file)
-    broker_transactions = BrokerRegistry.load_all_transactions(args, isin_converter)
-    currency_converter = CurrencyConverter.create(args.exchange_rates_file)
-    price_fetcher = CurrentPriceFetcher(currency_converter)
-    initial_prices = InitialPrices(args.initial_prices_file)
-    spin_off_handler = SpinOffHandler(args.spin_offs_file)
-
-    calculator = CapitalGainsCalculator(
-        args.year,
-        currency_converter,
-        isin_converter,
-        price_fetcher,
-        spin_off_handler,
-        initial_prices,
-        args.interest_fund_tickers,
-        cgt_exempt_tickers=args.cgt_exempt_tickers,
-        balance_check=args.balance_check,
-        calc_unrealized_gains=args.calc_unrealized_gains,
-        period_start=args.period_from,
-        period_end=args.period_to,
-    )
-    # First pass converts broker transactions to HMRC transactions.
-    # This means applying same day rule and collapsing all transactions with
-    # same type within the same day.
-    # It also converts prices to GBP, validates data and calculates dividends,
-    # taxes on dividends and interest.
-    calculator.convert_to_hmrc_transactions(broker_transactions)
-    # Second pass calculates capital gain tax for the given tax year.
-    report = calculator.calculate_capital_gain()
-    # The report string is newline-terminated already; avoid a trailing
-    # blank line so piped output stays stable under newline normalisation.
-    print(report, end="")
-
-    # Generate PDF report.
-    if not args.no_report:
-        render_latex.render_pdf(
-            report,
-            output_path=args.output,
-            skip_pdflatex=args.no_pdflatex,
-        )
-    done_msg = (
-        "Done! Calculations complete (PDF generation skipped)."
-        if args.no_pdflatex or args.no_report
-        else "Done! Report generated successfully."
-    )
-    LOGGER.info(style_text(done_msg, colour=Fore.GREEN, emoji="🎉", stream=sys.stderr))
-
-
-def main() -> int:
-    """Run main function."""
-
-    # Enable colourised logging.
-    setup_logging()
-
-    # Throw exception on accidental float usage
-    decimal.getcontext().traps[decimal.FloatOperation] = True
-
-    parser = create_parser()
-
-    if len(sys.argv) == 1:
-        parser.print_help()
-        return 0
-
-    args = parser.parse_args()
-    reject_duplicate_stdin(parser, args)
-    reject_schwab_file_and_dir(parser, args)
-    resolve_reporting_period(parser, args)
-
-    if args.verbose:
-        logging.getLogger().setLevel(logging.DEBUG)
-
-    try:
-        calculate_cgt(args)
-    except CgtError as err:
-        if args.verbose:
-            LOGGER.exception("Exception:")
-        else:
-            # Print error without traceback
-            LOGGER.error("%s", err)
-        return 1
-    except Exception:
-        # Last-resort catch for unexpected exceptions
-        LOGGER.critical("Unexpected error!")
-        LOGGER.exception("Details:")
-        return 1
-
-    return 0
-
-
-def init() -> None:
-    """Entry point."""
-    sys.exit(main())
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
 "Release Notes" = "https://github.com/cgt-calc/capital-gains-calculator/releases"
 
 [project.scripts]
-cgt-calc = "cgt_calc.main:init"
+cgt-calc = "cgt_calc.cli:init"
 
 [dependency-groups]
 dev = [

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -1223,7 +1223,7 @@ def test_main_returns_failure_on_unexpected_error(
     def explode(args: argparse.Namespace) -> None:
         raise RuntimeError("boom")
 
-    monkeypatch.setattr("cgt_calc.main.calculate_cgt", explode)
+    monkeypatch.setattr("cgt_calc.cli.calculate_cgt", explode)
     monkeypatch.setattr(sys, "argv", ["cgt-calc", "--year", "2021"])
 
     # main() enables the FloatOperation trap on the active decimal context;


### PR DESCRIPTION
First step of splitting up main.py: move the CLI entry points to their own module, leaving main.py to the calculator.

- Add cgt_calc/cli.py with calculate_cgt, main and init moved verbatim; CapitalGainsCalculator is imported at call time to avoid a circular import with the re-export.
- Point the cgt-calc console script at cgt_calc.cli:init.
- Keep re-exports and the __main__ guard in cgt_calc.main so existing imports and python -m cgt_calc.main keep working.
- Update the monkeypatch target in test_calc.py to follow calculate_cgt to its new module.

Pure move, no behavior change.