### PR TITLE
Secure legacy rates and clarify data handling

### DIFF
--- a/cgt_calc/currency_converter.py
+++ b/cgt_calc/currency_converter.py
@@ -201,7 +201,7 @@ class CurrencyConverter:
         if date.year < NEW_ENDPOINT_FROM_YEAR:
             month_str = date.strftime("%m%y")
             url = (
-                "http://www.hmrc.gov.uk/softwaredevelopers/rates/"
+                "https://www.hmrc.gov.uk/softwaredevelopers/rates/"
                 f"exrates-monthly-{month_str}.xml"
             )
         else:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,9 +5,13 @@ The following configuration files and options allow you to customize the calcula
 ## Automatic data fetching
 
 - **Exchange rates.** Monthly GBP exchange rates are automatically downloaded from the
-    [UK Trade Tariff API](https://www.trade-tariff.service.gov.uk/exchange_rates) and saved to
-    `out/exchange_rates.csv`. You can override these by providing your own file in the same format
-    using the `--exchange-rates-file` option.
+    [UK Trade Tariff API](https://www.trade-tariff.service.gov.uk/exchange_rates) for 2021 onwards
+    and [HMRC's legacy service](https://www.hmrc.gov.uk/softwaredevelopers/2020-exrates.html) for
+    earlier periods, then saved to `out/exchange_rates.csv`. You can select another file in the same
+    format with `--exchange-rates-file`. Keep the completed file with the report to preserve the
+    exchange rates used. cgt-calc may add missing months to the selected file, so retain the version
+    used for the final report. This does not preserve other fetched data such as Yahoo Finance
+    prices.
 
 - **ISIN to ticker translation.** When an ERI row identifies a fund only by its ISIN, cgt-calc maps
     it to ticker symbols. It uses existing mappings first and queries the

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -2,15 +2,25 @@
 
 ## Privacy and data security
 
-**Your financial data stays on your computer.** This tool processes all transactions locally and
-does **not send your transaction history or personal information** to any external services.
+**Your transaction files stay on your computer.** cgt-calc processes them locally. Lookup payloads
+do not include transaction amounts or personal fields, but external services still receive
+connection data such as your IP address. cgt-calc may also send identifiers and dates for the
+lookups below.
 
-The only external API calls made are:
+The external services used are:
 
 - [**UK Trade Tariff API**](https://www.trade-tariff.service.gov.uk/exchange_rates) – to fetch
-    monthly GBP exchange rates (no personal data sent)
+    monthly GBP exchange rates for 2021 onwards
+- [**HMRC's legacy exchange-rate service**](https://www.hmrc.gov.uk/softwaredevelopers/2020-exrates.html)
+    – to fetch monthly GBP exchange rates for periods before 2021
 - [**Open FIGI API**](https://www.openfigi.com/api/overview) – to translate ISIN codes to tickers
-    when needed (only ISIN codes are queried, no transaction amounts or personal details)
+    when needed (only ISIN codes are queried)
+- [**Yahoo Finance**](https://uk.help.yahoo.com/kb/finance/privacy-policy-sln6177.html) – to fetch
+    current prices when you use `--unrealized-gains`, or historical prices when the transaction
+    history contains a spin-off (ticker symbols and, for historical lookups, dates are queried)
+
+Reports and cache files are saved locally. Store them under the same access, retention and deletion
+controls as your own tax records.
 
 ## Disclaimer
 

--- a/tests/general/test_currency_converter.py
+++ b/tests/general/test_currency_converter.py
@@ -361,10 +361,10 @@ def test_write_exchange_rates_file(tmp_path: Path) -> None:
     )
 
 
-def test_query_hmrc_api_old_endpoint_error_names_rates_file(
+def test_query_hmrc_api_old_endpoint_error_includes_https_url_and_rates_file(
     tmp_path: Path,
 ) -> None:
-    """Use the old endpoint before 2021 and mention the rates file on errors."""
+    """Use HTTPS before 2021 and mention the rates file on errors."""
     rates_file = tmp_path / "rates.csv"
     rates_file.write_text("month,currency,rate\n", encoding="utf8")
     converter = CurrencyConverter(exchange_rates_file=rates_file)
@@ -378,7 +378,9 @@ def test_query_hmrc_api_old_endpoint_error_names_rates_file(
     with pytest.raises(ExternalApiError, match=r"rates\.csv") as excinfo:
         converter.currency_to_gbp_rate(CurrencyCode("USD"), datetime.date(2019, 5, 1))
 
-    assert "exrates-monthly-0519" in str(excinfo.value)
+    message = str(excinfo.value)
+    assert "https://www.hmrc.gov.uk/" in message
+    assert "exrates-monthly-0519" in message
 
 
 def test_query_hmrc_api_http_error_includes_snippet() -> None:


### PR DESCRIPTION
Use HTTPS for legacy HMRC exchange rates and clarify what cgt-calc sends to external services.

- distinguish lookup payloads from connection metadata
- name both exchange-rate sources
- limit repeatability guidance to retained exchange rates