### PR TITLE
Match Trading 212 overlaps on the second, and keep every distinct ID

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -6,6 +6,7 @@ AMZN
 arg
 ARG003
 ARG004
+another's
 argparse
 argparse's
 args
@@ -55,6 +56,7 @@ colorama
 colorama's
 ConsoleUI
 CRLF
+combinatorially
 csv
 CSVs
 CurrencyConverter
@@ -62,6 +64,7 @@ currentPrice
 cusip
 dataclass
 dest
+dataclasses
 DictReader
 DictReader's
 dprint
@@ -85,6 +88,7 @@ GIA
 GOOG
 GOOGL
 GSU
+hashable
 HL
 Hmrc
 I/O
@@ -150,6 +154,7 @@ rata
 regularMarketPrice
 reportable
 repr
+rescanning
 restkey
 restval
 RKT

--- a/cgt_calc/parsers/trading212.py
+++ b/cgt_calc/parsers/trading212.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-from collections import Counter, defaultdict
+from collections import defaultdict
 import csv
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal, InvalidOperation
 from enum import StrEnum
+from itertools import combinations
 import logging
+import math
 from pathlib import Path
 from typing import ClassVar, Final, NoReturn, TextIO, override
 
@@ -429,7 +431,19 @@ class Trading212Transaction(BrokerTransaction):
 
         isin_raw = row[Trading212Column.ISIN]
         isin = Isin(isin_raw) if isin_raw else None
-        self.transaction_id = row.get(Trading212Column.TRANSACTION_ID)
+        # An export without the ID column gives None; one with the column
+        # but no value gives "". Both mean "no identity", so they must not
+        # be told apart when matching rows across exports.
+        # Every instant an export stated for this transaction. A merge keeps
+        # one copy of a row two exports both report, and the copies can
+        # disagree below the second. The chronology a reorganisation is
+        # checked against has to see all of them: keeping only the survivor's
+        # would let one export's stamp erase another's evidence that a trade
+        # fell between the two halves.
+        self.stated_instants: frozenset[datetime] = frozenset({self.datetime})
+
+        transaction_id = (row.get(Trading212Column.TRANSACTION_ID) or "").strip()
+        self.transaction_id = transaction_id or None
         self.notes = row.get(Trading212Column.NOTES)
         # The row as it was exported. Pairing reads it to prove that a
         # reorganisation row fills nothing it should not. Deduplication does
@@ -518,30 +532,71 @@ class Trading212Transaction(BrokerTransaction):
         """Whether this row is one half of a share reorganisation."""
         return self.raw_action in SPLIT_ACTIONS
 
+    @property
+    def is_reorganisation(self) -> bool:
+        """Whether this row states a share reorganisation, in either form."""
+        return self.action is ActionType.STOCK_SPLIT
+
     def recorded_fields(self) -> tuple[object, ...]:
         """Return the exported transaction content used to merge overlaps.
 
-        The base dataclass contains the tax-relevant values common to every
-        broker. Trading 212's timestamp, action label and foreign-currency
-        values are additional recorded evidence, while its ID is deliberately
-        absent: the broker can reuse one ID for distinct transactions.
+        Two rows sharing this are candidates for being one transaction that
+        two overlapping exports both report. The fields are listed rather
+        than read from `dataclasses.fields`, so that adding a field to the
+        model cannot silently change what counts as the same transaction.
+
+        The timestamp is truncated to a whole second. Older exports state
+        seconds and newer ones milliseconds, so comparing the stated instant
+        would keep both copies of every row in an overlap that spans that
+        change. Comparing the aware UTC value is also what lets the `Time`
+        and `Time (UTC)` columns meet. `date` derives from the same value, so
+        it needs no entry of its own.
+
+        The ID is deliberately absent: Trading 212 reuses one ID across a buy
+        and the sell that closes it, so an ID tells rows apart within a group
+        rather than forming one.
+
+        So are `price_foreign`, `currency_foreign`, `exchange_rate` and
+        `notes`. Nothing outside this module reads them, and the price check
+        that does runs at parse time, so whichever copy of a row survives,
+        the calculation sees the same values. Keeping them would instead
+        block a merge whenever two exports differ only in presentation.
+
+        Reorganisation rows are the exception on both counts, and take the
+        exact instant and those figures back. See below.
         """
-        recorded: list[object] = []
-        for field in fields(self):
-            if not field.compare:
-                continue
-            value = getattr(self, field.name)
-            if isinstance(value, dict):
-                value = tuple(sorted(value.items()))
-            recorded.append(value)
+        recorded = (
+            self.datetime.replace(microsecond=0),
+            self.action,
+            self.raw_action,
+            self.symbol,
+            self.description,
+            self.quantity,
+            self.price,
+            self.fees,
+            self.amount,
+            self.currency,
+            self.broker,
+            self.isin,
+            tuple(sorted(self.foreign_fees.items())),
+            self.ambiguous_quantity,
+        )
+        if not self.is_reorganisation:
+            return recorded
+        # A reorganisation is proved by rows read together, and the checks
+        # that protect it read more than the content above: pairing the two
+        # halves compares the figures below, and a trade is refused for being
+        # stamped between the halves, which turns on their exact instants.
+        # Merging two rows that differ in any of that would let one export's
+        # account of the event stand in for another's, and the evidence that
+        # made the other refuse would go with it. So a reorganisation row
+        # merges only with one that states the event identically.
         return (
             *recorded,
             self.datetime,
-            self.raw_action,
             self.price_foreign,
             self.currency_foreign,
             self.exchange_rate,
-            self.notes or "",
         )
 
     def where(self) -> str:
@@ -621,6 +676,25 @@ def _exported_time(transaction: Trading212Transaction) -> str:
         or row.get(Trading212Column.TIME_UTC)
         or transaction.datetime.isoformat()
     )
+
+
+def _stated_times(transaction: Trading212Transaction) -> str:
+    """Return every instant the exports stated for this row.
+
+    A merged row usually states one, and then this reads as the export
+    wrote it. Where two exports disagreed below the second, naming only the
+    survivor's would point the reader at a stamp that is not the one the
+    refusal turned on.
+    """
+    exported = _exported_time(transaction)
+    if len(transaction.stated_instants) <= 1:
+        return exported
+    others = sorted(
+        instant.isoformat()
+        for instant in transaction.stated_instants
+        if instant != transaction.datetime
+    )
+    return f"{exported}, also reported as {', '.join(others)}"
 
 
 def _describe_half(half: SplitHalf) -> str:
@@ -805,6 +879,72 @@ def _half_incompatibilities(open_half: SplitHalf, close_half: SplitHalf) -> list
     return issues
 
 
+# Where a row came from. Unique per row, and the handle the merge marks rows
+# by, so that transactions never need to be hashable.
+type Provenance = tuple[Path, int]
+
+# The most subset combinations the merge will rank before giving up and taking
+# rows by their own timestamps. C(12, 6) is the dearest way to choose from
+# twelve rows, so anything a real export offers stays exact. The gate is the
+# number of candidates rather than the bucket size: C(13, 13) is one candidate
+# and C(100, 1) is a hundred, both trivial, and the first is how a single file
+# arrives here.
+ANONYMOUS_CANDIDATE_LIMIT: Final = 924
+
+
+def _source_file(transaction: Trading212Transaction) -> Path:
+    """Return the export a row was read from."""
+    source = transaction.source
+    assert source is not None, "transactions are stamped before post-processing"
+    assert source.file is not None
+    return source.file
+
+
+def _provenance(transaction: Trading212Transaction) -> Provenance:
+    """Identify one row by where it came from."""
+    source = transaction.source
+    assert source is not None
+    assert source.index is not None
+    return (_source_file(transaction), source.index)
+
+
+def _row_order_key(transaction: Trading212Transaction) -> tuple[bool, int, int]:
+    """Order rows within one source, most informative timestamp first.
+
+    A row stating a fraction of a second is preferred to one stating a whole
+    second, because the two can be the same transaction reported at different
+    precision and the finer value is the better record.
+    """
+    microsecond = transaction.datetime.microsecond
+    source = transaction.source
+    index = source.index if source is not None and source.index is not None else 0
+    return (microsecond == 0, microsecond, index)
+
+
+def _collection_order_key(
+    rows: list[Trading212Transaction],
+) -> tuple[int, int, tuple[int, ...], tuple[Provenance, ...]]:
+    """Order whole candidate selections, best first.
+
+    Prefers keeping fractional timestamps, then keeping distinct ones. The
+    second test is what stops an export that repeats one fraction displacing
+    one that tells its rows apart: given `.100`/`.500` against `.100`/`.100`,
+    both have two fractions, but only the first has two different ones.
+    Without it the ascending comparison would pick `(.100, .100)` and lose the
+    `.500` occurrence.
+
+    The last two are tie-breaks with no meaning of their own, present so that
+    the order is total and the result cannot depend on filenames.
+    """
+    fractions = sorted(row.datetime.microsecond for row in rows)
+    return (
+        -sum(1 for fraction in fractions if fraction),
+        -len(set(fractions)),
+        tuple(fractions),
+        tuple(sorted(_provenance(row) for row in rows)),
+    )
+
+
 class Trading212Parser(BaseDirParser[BrokerTransaction]):
     """Trading 212 parser."""
 
@@ -884,9 +1024,15 @@ class Trading212Parser(BaseDirParser[BrokerTransaction]):
 
         Exports are requested by date range, so consecutive downloads
         routinely cover the same days and report the same transaction twice.
-        For matching recorded content, the largest count in any one export is
-        authoritative. Distinct nonblank IDs can prove additional fills, but
-        an ID never joins rows with different content: Trading 212 reuses IDs.
+        Rows recording the same content are gathered into a group, and how
+        many of them are real is settled by the export reporting the most:
+        no export may be assumed complete, but none is expected to invent a
+        fill either.
+
+        This runs per file as well as over a directory, and on one file it
+        cannot change anything: that file supplies the whole group, so the
+        count it reports is the count kept. Removing a repeated row there
+        would lose a real fill, and the invariant is what stops it.
 
         Every split row is checked before any overlap copy can be dropped, so
         a richer schema cannot hide a cash leg or other contrary evidence.
@@ -902,35 +1048,184 @@ class Trading212Parser(BaseDirParser[BrokerTransaction]):
                 _check_split_has_no_money(transaction)
             groups[transaction.recorded_fields()].append(transaction)
 
-        kept: list[BrokerTransaction] = []
+        selected: set[Provenance] = set()
         for group in groups.values():
-            per_export = Counter(
-                transaction.source.file if transaction.source is not None else None
-                for transaction in group
-            )
-            identified: dict[str, Trading212Transaction] = {}
-            for transaction in group:
-                if transaction.transaction_id:
-                    identified.setdefault(transaction.transaction_id, transaction)
+            selected.update(cls._select_group(group))
+            # The copies this group collapses into one can disagree below the
+            # second, and the survivor is chosen without regard to a
+            # reorganisation it might sit inside. Give every kept row the
+            # instants all of them stated, so the chronology check still sees
+            # the evidence the discarded copies carried.
+            instants = frozenset(row.datetime for row in group)
+            if len(instants) > 1:
+                for row in group:
+                    row.stated_instants = instants
+        cls._warn_conflicting_content(groups)
 
-            # One row per id the export tells apart, then topped up to the
-            # largest count any single export reported. `keep_count` caps the
-            # top-up, never the rows already seeded: the ids are evidence in
-            # their own right. The comparison is `>=` so that stays true by
-            # construction -- with `==`, a `keep_count` that ever fell below
-            # the seed would sail past the break and keep the whole group,
-            # turning "at most one copy per export" into "every copy".
-            keep_count = max(*per_export.values(), len(identified))
-            chosen = list(identified.values())
-            chosen_objects = {id(transaction) for transaction in chosen}
-            for transaction in group:
-                if len(chosen) >= keep_count:
-                    break
-                if id(transaction) not in chosen_objects:
-                    chosen.append(transaction)
-                    chosen_objects.add(id(transaction))
-            kept.extend(chosen)
-        return kept
+        # Filtering the original list rather than concatenating the groups
+        # keeps the relative order of what survives, which matters because
+        # the sort that follows is stable and rows within one second tie on
+        # its key.
+        return [
+            row for row in transactions if _provenance(_as_trading212(row)) in selected
+        ]
+
+    @classmethod
+    def _select_group(cls, group: list[Trading212Transaction]) -> set[Provenance]:
+        """Decide which rows recording one transaction to keep.
+
+        Identified rows are taken a whole source bucket at a time, so that a
+        repeated copy in one export can never stand in for a distinct
+        occurrence in another, and so that an ID reported twice by one export
+        keeps both of its rows.
+        """
+        by_source: dict[Path, list[Trading212Transaction]] = defaultdict(list)
+        for row in group:
+            by_source[_source_file(row)].append(row)
+        file_count = max(len(rows) for rows in by_source.values())
+
+        # One pass over the group, rather than rescanning every source for
+        # each distinct ID, which is quadratic once a group holds many.
+        id_buckets: dict[str, dict[Path, list[Trading212Transaction]]] = defaultdict(
+            lambda: defaultdict(list)
+        )
+        for row in group:
+            if row.transaction_id:
+                id_buckets[row.transaction_id][_source_file(row)].append(row)
+
+        identified: list[Trading212Transaction] = []
+        for transaction_id in sorted(id_buckets):
+            buckets = list(id_buckets[transaction_id].values())
+            multiplicity = max(len(bucket) for bucket in buckets)
+            tied = [bucket for bucket in buckets if len(bucket) == multiplicity]
+            best = min(tied, key=_collection_order_key)
+            identified += best
+
+        chosen = list(identified)
+        needed = max(file_count, len(identified)) - len(identified)
+        if needed:
+            chosen += cls._best_anonymous(by_source, identified, needed, file_count)
+        return {_provenance(row) for row in chosen}
+
+    @classmethod
+    def _best_anonymous(
+        cls,
+        by_source: dict[Path, list[Trading212Transaction]],
+        identified: list[Trading212Transaction],
+        needed: int,
+        file_count: int,
+    ) -> list[Trading212Transaction]:
+        """Fill the remaining slots from one export's rows without an ID.
+
+        Only the exports reporting the most rows for this content are
+        eligible, and the completed selection is ranked as a whole rather
+        than the anonymous rows alone. Ranking them alone would let a second
+        copy of a timestamp already taken beat a row carrying one not yet
+        represented.
+        """
+        best_key = None
+        best: list[Trading212Transaction] = []
+        # Any source that could not be ranked exactly taints the comparison,
+        # not just the one that wins: its approximate subset is what gets
+        # ranked, so it can lose a contest its exact subset would have won,
+        # and which export the rows come from then depends on the gate.
+        approximated: list[Path] = []
+        for source in sorted(by_source):
+            rows = by_source[source]
+            if len(rows) != file_count:
+                continue
+            anonymous = sorted(
+                (row for row in rows if row.transaction_id is None),
+                key=_row_order_key,
+            )
+            subset, used_fallback = cls._best_subset(identified, anonymous, needed)
+            if used_fallback:
+                approximated.append(source)
+            key = _collection_order_key([*identified, *subset])
+            if best_key is None or key < best_key:
+                best_key, best = key, subset
+
+        if approximated:
+            LOGGER.warning(
+                "Too many ways to choose %d of the transactions that share one "
+                "second and are identical in every detail used to match "
+                "exports, so they were taken by timestamp alone from %s, "
+                "preferring rows that state a fraction of a second over rows "
+                "that state a whole one, then the lowest fractions. The number "
+                "of transactions and the tax figures are unaffected, but which "
+                "rows were kept, and which export they came from, may differ "
+                "from an exact comparison.",
+                needed,
+                ", ".join(str(source) for source in approximated),
+            )
+        return best
+
+    @staticmethod
+    def _best_subset(
+        identified: list[Trading212Transaction],
+        anonymous: list[Trading212Transaction],
+        needed: int,
+    ) -> tuple[list[Trading212Transaction], bool]:
+        """Choose `needed` of one export's rows without an ID.
+
+        Ranking every candidate is exact but grows combinatorially, so it is
+        gated on how many candidates there are rather than how many rows:
+        taking all of a large bucket, or one row from it, is cheap and stays
+        exact. Returns the rows and whether that gate was hit, so the caller
+        can report it once it knows which source won.
+        """
+        if math.comb(len(anonymous), needed) <= ANONYMOUS_CANDIDATE_LIMIT:
+            exact = min(
+                combinations(anonymous, needed),
+                key=lambda subset: _collection_order_key([*identified, *subset]),
+            )
+            return list(exact), False
+        return anonymous[:needed], True
+
+    @staticmethod
+    def _warn_conflicting_content(
+        groups: dict[tuple[object, ...], list[Trading212Transaction]],
+    ) -> None:
+        """Report an ID that two exports describe differently.
+
+        Trading 212 reuses an ID across a buy and the sell that closes it, so
+        an ID under several groups is ordinary and must not warn. What is not
+        ordinary is the same ID at the same instant for the same action
+        described two ways, which is one export restating a row another still
+        reports the old way. Both are kept, so the totals may count it twice,
+        and only re-exporting can settle it.
+        """
+        sources: dict[tuple[str, tuple[object, ...]], set[Path]] = defaultdict(set)
+        for fingerprint, group in groups.items():
+            for row in group:
+                if row.transaction_id:
+                    sources[row.transaction_id, fingerprint].add(_source_file(row))
+
+        by_id: dict[str, list[tuple[object, ...]]] = defaultdict(list)
+        for transaction_id, fingerprint in sources:
+            by_id[transaction_id].append(fingerprint)
+
+        for transaction_id, fingerprints in by_id.items():
+            for first, second in combinations(fingerprints, 2):
+                # A fingerprint opens with the truncated instant and the
+                # action, which together are what a restatement holds fixed
+                # and a reused ID does not.
+                if first[:2] != second[:2]:
+                    continue
+                files = sources[transaction_id, first]
+                others = sources[transaction_id, second]
+                if files & others:
+                    # One export lists both, so they are separate rows rather
+                    # than two accounts of one row.
+                    continue
+                LOGGER.warning(
+                    "Transaction ID %s is described differently by %s. Both "
+                    "rows were kept, so totals may count this transaction "
+                    "twice. Re-export the overlapping range so the files "
+                    "agree.",
+                    transaction_id,
+                    " and ".join(str(f) for f in sorted(files | others)),
+                )
 
     @classmethod
     @override
@@ -1297,7 +1592,7 @@ class Trading212Parser(BaseDirParser[BrokerTransaction]):
             if row.symbol != event.symbol or quantity_sign(row.action) == 0:
                 continue
             other = _as_trading212(row)
-            if first <= other.datetime <= last:
+            if any(first <= instant <= last for instant in other.stated_instants):
                 raise _split_error(
                     other,
                     f"This row is stamped between the two halves of the "
@@ -1306,7 +1601,7 @@ class Trading212Parser(BaseDirParser[BrokerTransaction]):
                     f"units before it or the units after it. Rows: "
                     f"{other.raw_action} at {other.where()} "
                     f"(No. of shares={other.quantity}, "
-                    f"Time={_exported_time(other)}); the reorganisation at "
+                    f"Time={_stated_times(other)}); the reorganisation at "
                     f"{first} and {last}. Check this row against Trading 212; "
                     "if it really was dealt while the reorganisation was in "
                     f"flight, leave {event.symbol} out and work it out by hand "

--- a/docs/brokers/trading212.md
+++ b/docs/brokers/trading212.md
@@ -39,11 +39,13 @@ trading212/
 The base filenames do not matter. cgt-calc reads every CSV file directly inside the directory, but
 it does not search subdirectories. Do not add unrelated CSV files, and make sure there are no gaps
 between date ranges. Matching transactions in overlapping files are reconciled using their recorded
-contents and the number of copies in each export. IDs help distinguish otherwise identical fills,
-but are not treated as globally unique because Trading 212 can reuse one ID for different
-transactions. If overlapping files represent one split in both the older one-row form and the newer
-open/close form, cgt-calc refuses rather than risk applying it twice; replace them with one complete
-export covering the named dates.
+contents and the number of copies in each export. For ordinary transactions, cgt-calc ignores
+fractional seconds when matching overlapping files, so older exports without milliseconds still
+match newer ones. Reorganisation rows use their exact times, because those times are needed to
+validate the event. IDs help distinguish otherwise identical fills, but are not treated as globally
+unique because Trading 212 can reuse one ID for different transactions. If overlapping files
+represent one split in both the older one-row form and the newer open/close form, cgt-calc refuses
+rather than risk applying it twice; replace them with one complete export covering the named dates.
 
 One overlap cannot be reconciled: if two exports give the same transaction different IDs, cgt-calc
 reads them as two separate fills and counts both. Reorganisation rows are refused rather than
@@ -174,6 +176,25 @@ you used to install it and try again. If the error remains, open a
 
 Do not upload an unredacted account export: it can contain transaction IDs and other financial
 information.
+
+### A transaction is described differently by two exports
+
+Two exports give the same Trading 212 transaction ID for what looks like the same transaction, at
+the same second and for the same action, but they disagree about its details. That normally means
+one export was taken after Trading 212 restated the transaction, for example after correcting a fee.
+
+cgt-calc cannot tell which version is right, so it keeps both. Your totals may therefore count that
+transaction twice. Re-export the overlapping period so that every file describes it the same way,
+replace the older file, and run the calculation again.
+
+### A same-second warning about identical transactions appears
+
+cgt-calc found an unusually large group of otherwise identical transactions within one second. It
+kept the correct number, so the totals are unchanged.
+
+Check that the rows in the named files are genuine. If they are, please
+[open an issue](https://github.com/cgt-calc/capital-gains-calculator/issues/new); otherwise replace
+the affected exports with a fresh one.
 
 ### No transactions are detected
 

--- a/tests/trading212/test_trading212.py
+++ b/tests/trading212/test_trading212.py
@@ -5,14 +5,16 @@ from __future__ import annotations
 from datetime import UTC, date, datetime
 from decimal import Decimal
 import logging
+import os
 from pathlib import Path
 import subprocess
+import sys
 from typing import TYPE_CHECKING
 
 import pytest
 
 from cgt_calc.exceptions import ParsingError
-from cgt_calc.model import ActionType
+from cgt_calc.model import ActionType, BrokerTransaction
 from cgt_calc.parsers.trading212 import (
     Trading212Column,
     Trading212Parser,
@@ -23,7 +25,7 @@ from tests.general.test_calc import create_calculator
 from tests.utils import build_cmd, report_path, stderr_alerts
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Sequence
 
 
 HEADER_2020 = [
@@ -1546,3 +1548,994 @@ def test_the_legacy_single_row_stock_split_still_reaches_the_calculator(
     # A reorganisation, so the pool doubles in units and keeps its cost.
     assert calculator.portfolio["FOO"].quantity == Decimal(20)
     assert calculator.portfolio["FOO"].amount == Decimal(100)
+
+
+# ===== Overlapping export de-duplication =====
+#
+# A single export may repeat a row, because Trading 212 can fill one
+# order more than once in a second. Two exports covering overlapping
+# ranges repeat every row in the overlap. Only the second kind may be
+# removed, so these tests always say which file each row came from.
+
+
+def _trade_row(
+    time: str,
+    transaction_id: str = "",
+    *,
+    action: str = "Market buy",
+    total: str = "-10.00",
+    header: list[str] | None = None,
+) -> list[str]:
+    """One buy of FOO, identical in every field the merge compares."""
+    columns = header if header is not None else HEADER_2024
+    # The parser warns when price * quantity does not reach the total, so
+    # a row that differs by value has to move both together.
+    price = total.lstrip("-")
+    time_column = (
+        Trading212Column.TIME_UTC
+        if Trading212Column.TIME_UTC.value in columns
+        else Trading212Column.TIME
+    )
+    return _make_row(
+        columns,
+        {
+            Trading212Column.ACTION: action,
+            time_column: time,
+            Trading212Column.TICKER: "FOO",
+            Trading212Column.NAME: "Foo Inc",
+            Trading212Column.NO_OF_SHARES: "1.0000000000",
+            Trading212Column.PRICE_PER_SHARE: price,
+            Trading212Column.CURRENCY_PRICE_PER_SHARE: "GBP",
+            Trading212Column.TOTAL: total,
+            Trading212Column.CURRENCY_TOTAL: "GBP",
+            Trading212Column.TRANSACTION_ID: transaction_id,
+        },
+    )
+
+
+def _prepare_files(tmp_path: Path, files: Mapping[str, list[list[str]]]) -> Path:
+    folder = tmp_path / "inputs"
+    folder.mkdir(parents=True)
+    for name, rows in files.items():
+        _write_csv(folder / name, rows)
+    return folder
+
+
+def _export(*rows: list[str], header: list[str] | None = None) -> list[list[str]]:
+    return [header if header is not None else HEADER_2024, *rows]
+
+
+def _fractions(transactions: Sequence[BrokerTransaction]) -> list[int]:
+    """Sub-second component of each row, which is what the merge picks between."""
+    return [_datetime_of(transaction).microsecond for transaction in transactions]
+
+
+def _datetime_of(transaction: BrokerTransaction) -> datetime:
+    assert isinstance(transaction, Trading212Transaction)
+    return transaction.datetime
+
+
+def _identity(
+    transactions: Sequence[BrokerTransaction],
+) -> list[tuple[object, ...]]:
+    """Everything about a row that distinguishes it from its neighbours.
+
+    `BrokerTransaction` is a data class whose equality covers none of the
+    time below the day, the ID, or the file a row came from, so comparing
+    transactions directly passes even when the merge picked the wrong
+    representative or ordered the result backwards.
+    """
+    return [
+        (
+            _datetime_of(transaction),
+            _transaction_id_of(transaction),
+            transaction.action,
+            transaction.amount,
+        )
+        for transaction in transactions
+    ]
+
+
+def _transaction_id_of(transaction: BrokerTransaction) -> str | None:
+    assert isinstance(transaction, Trading212Transaction)
+    return transaction.transaction_id
+
+
+def _source_of(transaction: BrokerTransaction) -> Path:
+    assert transaction.source is not None
+    assert transaction.source.file is not None
+    return transaction.source.file
+
+
+# An export predating the ID column entirely, as opposed to one that has
+# the column and leaves it blank.
+HEADER_2024_NO_ID = [column for column in HEADER_2024 if column != "ID"]
+
+
+# ----- one export is never de-duplicated -----
+
+
+def test_single_file_keeps_one_row(tmp_path: Path) -> None:
+    """One row is one transaction."""
+    folder = _prepare_files(
+        tmp_path, {"a.csv": _export(_trade_row("2024-01-01 10:00:00"))}
+    )
+    assert len(Trading212Parser.load_from_dir(folder)) == 1
+
+
+def test_single_file_keeps_repeated_anonymous_rows(tmp_path: Path) -> None:
+    """Two identical rows in one export are two fills, not a duplicate."""
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(
+                _trade_row("2024-01-01 10:00:00"),
+                _trade_row("2024-01-01 10:00:00"),
+            )
+        },
+    )
+    assert len(Trading212Parser.load_from_dir(folder)) == 2
+
+
+def test_single_file_keeps_repeated_rows_sharing_an_id(tmp_path: Path) -> None:
+    """A repeated ID within one export still means two fills.
+
+    This is one of the two cases the superseded prototype got wrong: it
+    hashed the ID, so the second row collided with the first and was
+    dropped.
+    """
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(
+                _trade_row("2024-01-01 10:00:00", "X"),
+                _trade_row("2024-01-01 10:00:00", "X"),
+            )
+        },
+    )
+    assert len(Trading212Parser.load_from_dir(folder)) == 2
+
+
+def test_single_file_keeps_rows_at_different_seconds(tmp_path: Path) -> None:
+    """Equal tax fields an hour apart are two transactions."""
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(
+                _trade_row("2024-01-01 10:00:00"),
+                _trade_row("2024-01-01 11:00:00"),
+            )
+        },
+    )
+    assert len(Trading212Parser.load_from_dir(folder)) == 2
+
+
+def test_single_file_keeps_distinct_ids_in_one_second(tmp_path: Path) -> None:
+    """Two IDs in one second are two transactions."""
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(
+                _trade_row("2024-01-01 10:00:00", "X"),
+                _trade_row("2024-01-01 10:00:00", "Y"),
+            )
+        },
+    )
+    assert len(Trading212Parser.load_from_dir(folder)) == 2
+
+
+def test_one_file_dir_matches_load_from_file(tmp_path: Path) -> None:
+    """The directory phase is a no-op when there is nothing to overlap."""
+    rows = _export(
+        _trade_row("2024-01-01 10:00:00", "X"),
+        _trade_row("2024-01-01 10:00:00", "X"),
+        _trade_row("2024-01-01 10:00:00"),
+        _trade_row("2024-01-01 10:00:01"),
+    )
+    folder = _prepare_files(tmp_path, {"a.csv": rows})
+
+    from_dir = Trading212Parser.load_from_dir(folder)
+    from_file = Trading212Parser.load_from_file(folder / "a.csv")
+
+    assert len(from_dir) == len(from_file) == 4
+    assert _identity(from_dir) == _identity(from_file)
+    # The rows differ only below the day and by ID, which data class
+    # equality ignores, so this has to be checked on the identities.
+    assert _identity(from_dir) != _identity(from_file)[::-1]
+
+
+def test_one_file_dir_does_not_warn(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A single export can never be a conflict between exports."""
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(
+                _trade_row("2024-01-01 10:00:00", "X"),
+                _trade_row("2024-01-01 10:00:00", "X", total="-11.00"),
+            )
+        },
+    )
+    with caplog.at_level(logging.WARNING, logger="cgt_calc.parsers.trading212"):
+        transactions = Trading212Parser.load_from_dir(folder)
+
+    assert len(transactions) == 2
+    assert caplog.text == ""
+
+
+# ----- overlapping exports are de-duplicated -----
+
+
+def test_identified_transaction_in_two_files_kept_once(tmp_path: Path) -> None:
+    """The plain overlap: one transaction, two exports, one row."""
+    row = _trade_row("2024-01-01 10:00:00", "X")
+    folder = _prepare_files(tmp_path, {"a.csv": _export(row), "b.csv": _export(row)})
+    assert len(Trading212Parser.load_from_dir(folder)) == 1
+
+
+def test_identified_and_anonymous_representation_kept_once(tmp_path: Path) -> None:
+    """An older export without the ID column matches a newer one that has it.
+
+    The older file has no `ID` header at all, which is a different thing
+    from a file that carries the column and leaves it empty; both must
+    read as "no identity" and match the identified row.
+    """
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(_trade_row("2024-01-01 10:00:00", "X")),
+            "b.csv": _export(
+                _trade_row("2024-01-01 10:00:00", header=HEADER_2024_NO_ID),
+                header=HEADER_2024_NO_ID,
+            ),
+        },
+    )
+    transactions = Trading212Parser.load_from_dir(folder)
+    assert _identity(transactions) == [
+        (
+            datetime(2024, 1, 1, 10, 0, tzinfo=UTC),
+            "X",
+            ActionType.BUY,
+            Decimal("-10.00"),
+        )
+    ]
+
+
+def test_blank_id_column_matches_a_missing_one(tmp_path: Path) -> None:
+    """A blank ID and no ID column are both "no identity"."""
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(_trade_row("2024-01-01 10:00:00")),
+            "b.csv": _export(
+                _trade_row("2024-01-01 10:00:00", header=HEADER_2024_NO_ID),
+                header=HEADER_2024_NO_ID,
+            ),
+        },
+    )
+    assert len(Trading212Parser.load_from_dir(folder)) == 1
+
+
+def test_anonymous_transaction_in_two_files_kept_once(tmp_path: Path) -> None:
+    """Two ID-less exports still de-duplicate on the transaction details."""
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(_trade_row("2024-01-01 10:00:00")),
+            "b.csv": _export(_trade_row("2024-01-01 10:00:00")),
+        },
+    )
+    assert len(Trading212Parser.load_from_dir(folder)) == 1
+
+
+def test_anonymous_multiplicity_takes_the_widest_export(tmp_path: Path) -> None:
+    """One export seeing two fills settles it, even if another saw one."""
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(_trade_row("2024-01-01 10:00:00")),
+            "b.csv": _export(
+                _trade_row("2024-01-01 10:00:00"),
+                _trade_row("2024-01-01 10:00:00"),
+            ),
+        },
+    )
+    assert len(Trading212Parser.load_from_dir(folder)) == 2
+
+
+def test_distinct_ids_on_one_fingerprint_both_kept(tmp_path: Path) -> None:
+    """Two IDs are two transactions however the exports are split."""
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(_trade_row("2024-01-01 10:00:00", "X")),
+            "b.csv": _export(_trade_row("2024-01-01 10:00:00", "Y")),
+        },
+    )
+    assert len(Trading212Parser.load_from_dir(folder)) == 2
+
+
+def test_repeated_id_uses_maximum_per_file_multiplicity(tmp_path: Path) -> None:
+    """Not one, and not the sum across files."""
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(
+                _trade_row("2024-01-01 10:00:00", "X"),
+                _trade_row("2024-01-01 10:00:00", "X"),
+            ),
+            "b.csv": _export(_trade_row("2024-01-01 10:00:00", "X")),
+        },
+    )
+    assert len(Trading212Parser.load_from_dir(folder)) == 2
+
+
+def test_buy_and_sell_reusing_one_id_both_kept(tmp_path: Path) -> None:
+    """Trading 212 reuses an ID across a buy and the sell that closes it."""
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(
+                _trade_row("2024-01-01 10:00:00", "X"),
+                _trade_row(
+                    "2024-04-29 13:20:03", "X", action="Market sell", total="12.00"
+                ),
+            ),
+        },
+    )
+    assert len(Trading212Parser.load_from_dir(folder)) == 2
+
+
+def test_anonymous_rows_at_different_seconds_across_files(tmp_path: Path) -> None:
+    """Equal tax fields an hour apart are never one transaction.
+
+    The other case the superseded prototype got wrong: data class
+    equality ignored the time, so these two collapsed into one.
+    """
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(_trade_row("2024-01-01 10:00:00")),
+            "b.csv": _export(_trade_row("2024-01-01 11:00:00")),
+        },
+    )
+    assert len(Trading212Parser.load_from_dir(folder)) == 2
+
+
+def test_mixed_precision_merges_and_keeps_the_fraction(tmp_path: Path) -> None:
+    """An old whole-second export and a new millisecond one agree."""
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(_trade_row("2024-01-01 10:00:00")),
+            "b.csv": _export(_trade_row("2024-01-01 10:00:00.123")),
+        },
+    )
+    transactions = Trading212Parser.load_from_dir(folder)
+    assert _fractions(transactions) == [123000]
+
+
+def test_time_and_time_utc_columns_merge(tmp_path: Path) -> None:
+    """The renamed column describes the same instant, so it must match."""
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(_trade_row("2024-01-01 10:00:00")),
+            "b.csv": _export(
+                _trade_row("2024-01-01 11:00:00+01:00", header=HEADER_2026_UTC),
+                header=HEADER_2026_UTC,
+            ),
+        },
+    )
+    assert len(Trading212Parser.load_from_dir(folder)) == 1
+
+
+def test_deposit_and_buy_keep_the_buy_last_across_precisions(tmp_path: Path) -> None:
+    """The merge must not disturb the same-second deposit/buy ordering."""
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(
+                _make_row(
+                    HEADER_2024,
+                    {
+                        Trading212Column.ACTION: "Deposit",
+                        Trading212Column.TIME: "2024-01-01 10:00:00",
+                        Trading212Column.TOTAL: "100.00",
+                        Trading212Column.CURRENCY_TOTAL: "GBP",
+                    },
+                ),
+                _trade_row("2024-01-01 10:00:00"),
+            ),
+            "b.csv": _export(
+                _make_row(
+                    HEADER_2024,
+                    {
+                        Trading212Column.ACTION: "Deposit",
+                        Trading212Column.TIME: "2024-01-01 10:00:00.123",
+                        Trading212Column.TOTAL: "100.00",
+                        Trading212Column.CURRENCY_TOTAL: "GBP",
+                    },
+                ),
+                _trade_row("2024-01-01 10:00:00.123"),
+            ),
+        },
+    )
+    transactions = Trading212Parser.load_from_dir(folder)
+
+    assert _fractions(transactions) == [123000, 123000]
+    assert [t.action for t in transactions] == [ActionType.TRANSFER, ActionType.BUY]
+
+
+def test_three_overlapping_exports_use_the_widest(tmp_path: Path) -> None:
+    """More exports do not add multiplicity; the widest single one decides."""
+    one = _export(_trade_row("2024-01-01 10:00:00"))
+    two = _export(_trade_row("2024-01-01 10:00:00"), _trade_row("2024-01-01 10:00:00"))
+    folder = _prepare_files(tmp_path, {"a.csv": one, "b.csv": two, "c.csv": one})
+    assert len(Trading212Parser.load_from_dir(folder)) == 2
+
+
+# ----- which representative survives -----
+
+
+def test_wider_id_bucket_wins_whole(tmp_path: Path) -> None:
+    """Two fills under one ID come from the export that saw both.
+
+    Assembling the two from the union would take `.100` from each file
+    and lose the `.500` fill entirely.
+    """
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(
+                _trade_row("2024-01-01 10:00:00.100", "X"),
+                _trade_row("2024-01-01 10:00:00.500", "X"),
+            ),
+            "b.csv": _export(_trade_row("2024-01-01 10:00:00.100", "X")),
+        },
+    )
+    assert _fractions(Trading212Parser.load_from_dir(folder)) == [100000, 500000]
+
+
+def test_tied_id_buckets_prefer_distinct_fractions(tmp_path: Path) -> None:
+    """A bucket that repeats one fraction loses to one that tells them apart.
+
+    Both exports report the ID twice, so multiplicity cannot separate
+    them. Comparing the fractions alone would pick `(.100, .100)`, which
+    sorts below `(.100, .500)`, and discard the distinct occurrence.
+    """
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(
+                _trade_row("2024-01-01 10:00:00.100", "X"),
+                _trade_row("2024-01-01 10:00:00.500", "X"),
+            ),
+            "b.csv": _export(
+                _trade_row("2024-01-01 10:00:00.100", "X"),
+                _trade_row("2024-01-01 10:00:00.100", "X"),
+            ),
+        },
+    )
+    assert _fractions(Trading212Parser.load_from_dir(folder)) == [100000, 500000]
+
+
+def test_wider_anonymous_bucket_wins_whole(tmp_path: Path) -> None:
+    """The same coherence rule applies with no IDs to help."""
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(
+                _trade_row("2024-01-01 10:00:00.100"),
+                _trade_row("2024-01-01 10:00:00.500"),
+            ),
+            "b.csv": _export(_trade_row("2024-01-01 10:00:00.100")),
+        },
+    )
+    assert _fractions(Trading212Parser.load_from_dir(folder)) == [100000, 500000]
+
+
+def test_anonymous_completion_ranks_with_the_identified_rows(tmp_path: Path) -> None:
+    """The anonymous slot is filled against what is already selected.
+
+    Ranking the anonymous rows on their own would prefer the export
+    holding two of them, then take its `.100` — duplicating the
+    timestamp the identified row already carries and dropping `.500`.
+    """
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(
+                _trade_row("2024-01-01 10:00:00.100", "X"),
+                _trade_row("2024-01-01 10:00:00.500"),
+            ),
+            "b.csv": _export(
+                _trade_row("2024-01-01 10:00:00.100"),
+                _trade_row("2024-01-01 10:00:00.500"),
+            ),
+        },
+    )
+    assert _fractions(Trading212Parser.load_from_dir(folder)) == [100000, 500000]
+
+
+def test_anonymous_subset_is_chosen_against_the_identified_rows(
+    tmp_path: Path,
+) -> None:
+    """The subset is picked knowing which timestamps are already taken.
+
+    One export is the widest, so there is no choice between sources to
+    mask the decision, and it offers three anonymous rows for two slots.
+    Judged alone the cheapest pair is `.100` and `.500`; judged with the
+    identified `.100` already selected, `.100` adds nothing and the pair
+    `.500`/`.700` is what keeps four distinct timestamps.
+    """
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(
+                _trade_row("2024-01-01 10:00:00.100", "X"),
+                _trade_row("2024-01-01 10:00:00.100"),
+                _trade_row("2024-01-01 10:00:00.500"),
+                _trade_row("2024-01-01 10:00:00.700"),
+            ),
+            "b.csv": _export(_trade_row("2024-01-01 10:00:00.900", "Y")),
+        },
+    )
+    assert _fractions(Trading212Parser.load_from_dir(folder)) == [
+        100000,
+        500000,
+        700000,
+        900000,
+    ]
+
+
+def test_each_id_chooses_its_bucket_independently(tmp_path: Path) -> None:
+    """Two IDs may end up at a pairing neither export reports.
+
+    The exports disagree about each ID's fraction and nothing says which
+    is right, so each ID independently takes the earliest. IDs already
+    establish that these are two occurrences, so nothing is lost.
+    """
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(
+                _trade_row("2024-01-01 10:00:00.100", "X"),
+                _trade_row("2024-01-01 10:00:00.500", "Y"),
+            ),
+            "b.csv": _export(
+                _trade_row("2024-01-01 10:00:00.500", "X"),
+                _trade_row("2024-01-01 10:00:00.100", "Y"),
+            ),
+        },
+    )
+    assert _fractions(Trading212Parser.load_from_dir(folder)) == [100000, 100000]
+
+
+def test_conflicting_fractions_take_the_earliest(tmp_path: Path) -> None:
+    """An arbitrary but deterministic choice, not a claim about accuracy."""
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(_trade_row("2024-01-01 10:00:00.500")),
+            "b.csv": _export(_trade_row("2024-01-01 10:00:00.100")),
+        },
+    )
+    assert _fractions(Trading212Parser.load_from_dir(folder)) == [100000]
+    # The same pair with the file names swapped resolves the same way.
+    other = _prepare_files(
+        tmp_path / "swapped",
+        {
+            "a.csv": _export(_trade_row("2024-01-01 10:00:00.100")),
+            "b.csv": _export(_trade_row("2024-01-01 10:00:00.500")),
+        },
+    )
+    assert _fractions(Trading212Parser.load_from_dir(other)) == [100000]
+
+
+# ----- conflicting descriptions of one ID -----
+
+
+def test_restated_row_keeps_both_and_warns(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """One ID, one instant, one action, two different amounts.
+
+    That is an export restating a row another still reports the old way.
+    Neither can be preferred, so both are kept and the double count is
+    announced rather than left to be found in the totals.
+    """
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(_trade_row("2024-01-01 10:00:00", "X")),
+            "b.csv": _export(_trade_row("2024-01-01 10:00:00", "X", total="-11.00")),
+        },
+    )
+    with caplog.at_level(logging.WARNING, logger="cgt_calc.parsers.trading212"):
+        transactions = Trading212Parser.load_from_dir(folder)
+
+    assert len(transactions) == 2
+    assert "Transaction ID X is described differently" in caplog.text
+    assert "a.csv" in caplog.text
+    assert "b.csv" in caplog.text
+
+
+def test_reused_id_across_buy_and_sell_does_not_warn(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The ordinary reuse must stay silent or the warning is useless."""
+    rows = _export(
+        _trade_row("2024-01-01 10:00:00", "X"),
+        _trade_row("2024-04-29 13:20:03", "X", action="Market sell", total="12.00"),
+    )
+    folder = _prepare_files(tmp_path, {"a.csv": rows, "b.csv": rows})
+
+    with caplog.at_level(logging.WARNING, logger="cgt_calc.parsers.trading212"):
+        transactions = Trading212Parser.load_from_dir(folder)
+
+    assert len(transactions) == 2
+    assert caplog.text == ""
+
+
+def test_one_file_holding_both_descriptions_does_not_warn(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An export listing both proves they are separate rows."""
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(
+                _trade_row("2024-01-01 10:00:00", "X"),
+                _trade_row("2024-01-01 10:00:00", "X", total="-11.00"),
+            ),
+            "b.csv": _export(_trade_row("2024-01-01 10:00:00", "X")),
+        },
+    )
+    with caplog.at_level(logging.WARNING, logger="cgt_calc.parsers.trading212"):
+        transactions = Trading212Parser.load_from_dir(folder)
+
+    assert len(transactions) == 2
+    assert caplog.text == ""
+
+
+# ----- how hard the merge is allowed to work -----
+
+
+def _anonymous_export(fractions: list[str]) -> list[list[str]]:
+    return _export(
+        *(_trade_row(f"2024-01-01 10:00:00.{f}") for f in fractions),
+    )
+
+
+def _identified_export(count: int) -> list[list[str]]:
+    return _export(
+        *(
+            _trade_row("2024-01-01 10:00:00.100", f"ID{index:03d}")
+            for index in range(count)
+        )
+    )
+
+
+def test_large_bucket_falls_back_to_timestamp_order_and_warns(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Forty rows needing twenty is 137,846,528,820 candidates.
+
+    Ranking them is out of the question, so the merge takes them by
+    timestamp alone and says so. The count and the tax figures are
+    unchanged; only the choice of which rows carry which sub-second time
+    is.
+
+    The export lists `.400` first and `.000` last, and the result is the
+    same as if it had listed them in order, because the single-file phase
+    sorts before the merge ever sees the rows.
+
+    The whole-second rows are what show the ordering is not simply
+    "earliest". `10:00:00` is the earliest instant present, yet every one
+    of those rows is dropped: a row stating a fraction is preferred to
+    one stating a whole second, because the two can be the same
+    transaction reported at different precision.
+    """
+    fractions = [f"{value:03d}" for value in (400, 0, 300, 200) for _ in range(10)]
+    folder = _prepare_files(
+        tmp_path,
+        {"a.csv": _anonymous_export(fractions), "b.csv": _identified_export(20)},
+    )
+    with caplog.at_level(logging.WARNING, logger="cgt_calc.parsers.trading212"):
+        transactions = Trading212Parser.load_from_dir(folder)
+
+    assert len(transactions) == 40
+    assert "taken by timestamp alone" in caplog.text
+    # Twenty identified rows at .100, then the twenty anonymous rows the
+    # ordering picks: the .200s and .300s. Every .000 row loses despite
+    # 10:00:00 being the earliest instant in the group.
+    assert sorted(_fractions(transactions)) == (
+        [100000] * 20 + [200000] * 10 + [300000] * 10
+    )
+    assert 0 not in _fractions(transactions)
+
+
+def test_one_warning_names_every_approximated_source(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Two exports are approximated, and one warning covers both.
+
+    Both are over the gate, so neither was ranked exactly and either
+    could have won a contest it lost. Reporting only the winner, or
+    reporting each source as it is tried, would misstate which
+    comparisons were approximate.
+    """
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _anonymous_export([f"{100 + i:03d}" for i in range(20)] * 2),
+            "b.csv": _anonymous_export([f"{500 + i:03d}" for i in range(20)] * 2),
+            "c.csv": _identified_export(20),
+        },
+    )
+    with caplog.at_level(logging.WARNING, logger="cgt_calc.parsers.trading212"):
+        Trading212Parser.load_from_dir(folder)
+
+    approximated = [
+        record for record in caplog.messages if "exact comparison" in record
+    ]
+    assert len(approximated) == 1
+    assert "a.csv" in approximated[0]
+    assert "b.csv" in approximated[0]
+
+
+def test_losing_fallback_source_still_warns(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An approximated source that loses still taints the comparison.
+
+    `a.csv` offers `C(20, 16) = 4,845` candidates, so its subset is the
+    prefix rather than its best. Its ten lowest fractions are identical,
+    which makes that prefix duplicate-heavy, and `b.csv` wins on distinct
+    timestamps. Ranked exactly, `a.csv` would have won instead: it holds
+    ten distinct fractions that the prefix never reaches.
+
+    So the gate decided which export supplied the rows. Warning only when
+    the winner fell back would have said nothing here, and raising the
+    limit would silently change the result.
+    """
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _anonymous_export(
+                ["001"] * 10 + [f"{100 + index:03d}" for index in range(10)]
+            ),
+            "b.csv": _export(
+                *(
+                    _trade_row("2024-01-01 10:00:00.900", f"ID{index:03d}")
+                    for index in range(4)
+                ),
+                *(_trade_row("2024-01-01 10:00:00.200") for _ in range(8)),
+                *(
+                    _trade_row(f"2024-01-01 10:00:00.{201 + index:03d}")
+                    for index in range(8)
+                ),
+            ),
+        },
+    )
+    with caplog.at_level(logging.WARNING, logger="cgt_calc.parsers.trading212"):
+        transactions = Trading212Parser.load_from_dir(folder)
+
+    # b.csv supplies the anonymous rows, yet a.csv is what was approximated.
+    assert {
+        _source_of(transaction).name
+        for transaction in transactions
+        if _transaction_id_of(transaction) is None
+    } == {"b.csv"}
+    assert "may differ from an exact comparison" in caplog.text
+    assert "a.csv" in caplog.text
+
+
+def test_candidate_limit_boundary(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """C(12, 6) is 924 and stays exact; C(13, 6) is 1,716 and does not."""
+    at_limit = _prepare_files(
+        tmp_path / "at",
+        {
+            "a.csv": _anonymous_export([f"{100 + i:03d}" for i in range(12)]),
+            "b.csv": _identified_export(6),
+        },
+    )
+    with caplog.at_level(logging.WARNING, logger="cgt_calc.parsers.trading212"):
+        assert len(Trading212Parser.load_from_dir(at_limit)) == 12
+    assert caplog.text == ""
+
+    over_limit = _prepare_files(
+        tmp_path / "over",
+        {
+            "a.csv": _anonymous_export([f"{100 + i:03d}" for i in range(13)]),
+            "b.csv": _identified_export(7),
+        },
+    )
+    with caplog.at_level(logging.WARNING, logger="cgt_calc.parsers.trading212"):
+        assert len(Trading212Parser.load_from_dir(over_limit)) == 13
+    assert "taken by timestamp alone" in caplog.text
+
+
+def test_large_but_cheap_buckets_stay_exact(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The gate counts candidates, not rows.
+
+    Thirteen rows all needed is one candidate, and a hundred rows needing
+    one is a hundred. A gate on bucket size would have sent both to the
+    fallback, the first of them being how a single export arrives here.
+    """
+    all_needed = _prepare_files(
+        tmp_path / "all",
+        {
+            "a.csv": _anonymous_export([f"{100 + i:03d}" for i in range(13)]),
+            "b.csv": _anonymous_export(["100"]),
+        },
+    )
+    with caplog.at_level(logging.WARNING, logger="cgt_calc.parsers.trading212"):
+        assert len(Trading212Parser.load_from_dir(all_needed)) == 13
+    assert caplog.text == ""
+
+    one_needed = _prepare_files(
+        tmp_path / "one",
+        {
+            "a.csv": _anonymous_export([f"{i:03d}" for i in range(100, 200)]),
+            "b.csv": _identified_export(99),
+        },
+    )
+    with caplog.at_level(logging.WARNING, logger="cgt_calc.parsers.trading212"):
+        assert len(Trading212Parser.load_from_dir(one_needed)) == 100
+    assert caplog.text == ""
+
+
+# ----- the whole pipeline -----
+
+
+def test_duplicated_export_matches_reading_it_once(tmp_path: Path) -> None:
+    """The likeliest real overlap: the same range exported twice.
+
+    Goes through a real fixture rather than a constructed one, so it
+    exercises grouping, bucket choice and the final sort together.
+    """
+    fixture = Path(__file__).parent / "data" / "2024" / "inputs" / "transactions.csv"
+    folder = tmp_path / "inputs"
+    folder.mkdir()
+    for name in ("first.csv", "second.csv"):
+        (folder / name).write_text(fixture.read_text(encoding="utf-8"), "utf-8")
+
+    once = Trading212Parser.load_from_file(fixture)
+    twice = Trading212Parser.load_from_dir(folder)
+
+    assert _identity(twice) == _identity(once)
+
+
+# Prints what the merge can actually vary: which representative was kept
+# and in what order. Printing only the data class fields would compare
+# equal however the rows were chosen or ordered.
+_DETERMINISM_SCRIPT = """
+import sys
+from pathlib import Path
+
+from cgt_calc.parsers.trading212 import Trading212Parser
+
+for transaction in Trading212Parser.load_from_dir(Path(sys.argv[1])):
+    print(
+        transaction.datetime.isoformat(),
+        transaction.transaction_id,
+        transaction.source.file.name,
+        transaction.source.index,
+        transaction.action,
+        transaction.amount,
+        sep="|",
+    )
+"""
+
+
+def test_result_does_not_depend_on_hash_randomisation(tmp_path: Path) -> None:
+    """No set of transactions may decide the output order.
+
+    Once the invalid hash is gone this holds by construction, since the
+    groups are dict-ordered and only provenance keys reach a set. The
+    test guards against a `set` creeping back in.
+    """
+    folder = _prepare_files(
+        tmp_path,
+        {
+            "a.csv": _export(
+                _trade_row("2024-01-01 10:00:00", "X"),
+                _trade_row("2024-01-01 10:00:00.500"),
+            ),
+            "b.csv": _export(
+                _trade_row("2024-01-01 10:00:00", "Y"),
+                _trade_row("2024-01-01 10:00:00.100"),
+            ),
+        },
+    )
+    runs = {
+        subprocess.run(
+            [sys.executable, "-c", _DETERMINISM_SCRIPT, str(folder)],
+            capture_output=True,
+            text=True,
+            check=True,
+            env={**os.environ, "PYTHONHASHSEED": seed},
+        ).stdout
+        for seed in ("0", "1", "12345")
+    }
+    assert len(runs) == 1
+    # Two IDs fill the two slots the widest export establishes, so the
+    # anonymous rows are absorbed as their other representation.
+    lines = next(iter(runs)).splitlines()
+    assert len(lines) == 2
+    # The two rows differ only in ID and provenance, so the probe has to
+    # print those for a reordering to be visible at all.
+    assert [line.split("|")[1] for line in lines] == ["X", "Y"]
+
+
+# ----- empty inputs -----
+
+
+def test_empty_directory_warns_and_returns_nothing(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A directory with no exports is reported, not treated as no activity.
+
+    The merge runs on the combined list either way, so this also covers
+    it being handed nothing.
+    """
+    folder = tmp_path / "inputs"
+    folder.mkdir()
+
+    with caplog.at_level(logging.WARNING, logger="cgt_calc.parsers.base_parsers"):
+        transactions = Trading212Parser.load_from_dir(folder)
+
+    assert transactions == []
+    assert "No transactions detected in directory" in caplog.text
+    assert "Trading 212" in caplog.text
+
+
+def test_header_only_export_warns_for_the_directory(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A file with a header and no rows leaves the directory empty.
+
+    `load_from_dir` suppresses the per-file warning and reports once for
+    the directory, which is what stops a multi-file export warning for
+    every file that happens to cover a quiet period.
+    """
+    folder = _prepare_files(tmp_path, {"a.csv": [HEADER_2024]})
+
+    with caplog.at_level(logging.WARNING):
+        transactions = Trading212Parser.load_from_dir(folder)
+
+    assert transactions == []
+    assert caplog.text.count("No transactions detected") == 1
+    assert "in directory" in caplog.text
+
+
+def test_completely_empty_file_is_rejected(tmp_path: Path) -> None:
+    """A file with no header at all cannot be parsed, so it raises."""
+    folder = tmp_path / "inputs"
+    folder.mkdir()
+    (folder / "a.csv").write_text("", encoding="utf-8")
+
+    with pytest.raises(ParsingError) as exc:
+        Trading212Parser.load_from_dir(folder)
+
+    assert "Trading 212 CSV file is empty" in str(exc.value)
+
+
+def test_empty_file_alongside_a_real_one_is_rejected(tmp_path: Path) -> None:
+    """The empty file is not quietly skipped because another file parsed."""
+    folder = _prepare_files(
+        tmp_path, {"b.csv": _export(_trade_row("2024-01-01 10:00:00"))}
+    )
+    (folder / "a.csv").write_text("", encoding="utf-8")
+
+    with pytest.raises(ParsingError) as exc:
+        Trading212Parser.load_from_dir(folder)
+
+    assert "Trading 212 CSV file is empty" in str(exc.value)

--- a/tests/trading212/test_trading212_splits.py
+++ b/tests/trading212/test_trading212_splits.py
@@ -1793,3 +1793,160 @@ def test_a_chain_of_near_misses_does_not_grow_one_candidate_group(
     # The third row is outside the window from the first, so it is a
     # candidate for some other event, not for this one.
     assert "07:01:58" not in message
+
+
+# ===== overlapping exports may not synthesize an event =====
+
+
+def _trade_between_halves(
+    header: list[str], *, time: str = "2026-02-02 07:44:13.500"
+) -> list[str]:
+    """Return a buy of the reorganised holding, stamped at `time`."""
+    return _make_row(
+        header,
+        {
+            Trading212Column.ACTION: "Market buy",
+            Trading212Column.TIME: time,
+            Trading212Column.TICKER: "FOO",
+            Trading212Column.NAME: "Foo Company",
+            Trading212Column.ISIN: "US0000000002",
+            Trading212Column.NO_OF_SHARES: "1.0000000000",
+            Trading212Column.PRICE_PER_SHARE: "90.00",
+            Trading212Column.CURRENCY_PRICE_PER_SHARE: "GBP",
+            Trading212Column.TOTAL: "-90.00",
+            Trading212Column.CURRENCY_TOTAL: "GBP",
+            Trading212Column.TRANSACTION_ID: "mid",
+        },
+    )
+
+
+def test_halves_from_two_exports_do_not_form_one_event(tmp_path: Path) -> None:
+    """Two exports stamping the event differently must not be combined.
+
+    Each half is deduplicated in its own group, so nothing stops a close
+    from one export pairing with an open from another. The pair that
+    results is one no export reported, and the checks that guard a
+    reorganisation are read off its instants: a trade the first export
+    places between its halves falls outside the synthesized pair and
+    stops being refused.
+
+    Refusing the ambiguity is the safe answer. Merging is for rows that
+    state the same event, and these do not.
+    """
+    header = HEADER_2026
+    early = [
+        split_row(header, SPLIT_CLOSE_ACTION, time="2026-02-02 07:44:13.010"),
+        split_row(
+            header,
+            SPLIT_OPEN_ACTION,
+            time="2026-02-02 07:44:13.020",
+            shares=CONSOLIDATION_AFTER,
+            price=PRICE_AFTER,
+        ),
+    ]
+    straddling = [
+        split_row(header, SPLIT_CLOSE_ACTION, time="2026-02-02 07:44:13.100"),
+        _trade_between_halves(header),
+        split_row(
+            header,
+            SPLIT_OPEN_ACTION,
+            time="2026-02-02 07:44:13.900",
+            shares=CONSOLIDATION_AFTER,
+            price=PRICE_AFTER,
+        ),
+    ]
+
+    one = tmp_path / "one"
+    both = tmp_path / "both"
+    one.mkdir()
+    both.mkdir()
+
+    with pytest.raises(ParsingError) as alone:
+        load(one, {"a.csv": [header, *straddling]})
+    assert "stamped between the two halves" in str(alone.value)
+
+    with pytest.raises(ParsingError) as combined:
+        load(both, {"a.csv": [header, *straddling], "b.csv": [header, *early]})
+    # Refused for the ambiguity rather than silently accepting the trade.
+    assert "Stock split close" in str(combined.value)
+
+
+def test_a_disagreed_trade_timestamp_is_not_erased_by_a_merge(
+    tmp_path: Path,
+) -> None:
+    """Both exports' stamps for one trade have to reach the split check.
+
+    Two exports report the same trade, one placing it between the halves
+    and one before them. They record the same content, so the merge keeps
+    a single copy, and it picks that copy without knowing a
+    reorganisation surrounds it. Keeping only the survivor's stamp would
+    let the export that saw nothing wrong overrule the one that did, and
+    the trade's share count would be read on the wrong side of the event.
+
+    The export that places it outside is right on its own evidence, so it
+    still loads alone. Only the pair refuses.
+    """
+    header = HEADER_2026
+    halves = [
+        split_row(header, SPLIT_CLOSE_ACTION, time="2026-02-02 07:44:13.200"),
+        split_row(
+            header,
+            SPLIT_OPEN_ACTION,
+            time="2026-02-02 07:44:13.800",
+            shares=CONSOLIDATION_AFTER,
+            price=PRICE_AFTER,
+        ),
+    ]
+
+    def export(trade_time: str) -> list[list[str]]:
+        return [header, *halves, _trade_between_halves(header, time=trade_time)]
+
+    between = export("2026-02-02 07:44:13.500")
+    before = export("2026-02-02 07:44:13.100")
+
+    for name, rows, refuses in (
+        ("between", between, True),
+        ("before", before, False),
+    ):
+        folder = tmp_path / name
+        folder.mkdir()
+        if refuses:
+            with pytest.raises(ParsingError):
+                load(folder, {"a.csv": rows})
+        else:
+            assert load(folder, {"a.csv": rows})
+
+    both = tmp_path / "both"
+    both.mkdir()
+    with pytest.raises(ParsingError) as combined:
+        load(both, {"a.csv": between, "b.csv": before})
+
+    message = str(combined.value)
+    assert "stamped between the two halves" in message
+    # The survivor is the .100 copy, so the refusal has to name the .500
+    # one it turned on or the error points at a stamp that looks fine.
+    assert "also reported as" in message
+    assert "07:44:13.500" in message
+
+
+def test_the_same_event_in_two_exports_still_combines(tmp_path: Path) -> None:
+    """The overlap that does state one event is still merged.
+
+    Reorganisation rows compare on the exact instant and the figures
+    pairing checks, so two exports reporting the event identically still
+    collapse to one, and only a disagreement refuses.
+    """
+    header = HEADER_2026
+    rows = [
+        split_row(header, SPLIT_CLOSE_ACTION, time="2026-02-02 07:44:13.100"),
+        split_row(
+            header,
+            SPLIT_OPEN_ACTION,
+            time="2026-02-02 07:44:13.900",
+            shares=CONSOLIDATION_AFTER,
+            price=PRICE_AFTER,
+        ),
+    ]
+    transactions = load(tmp_path, {"a.csv": [header, *rows], "b.csv": [header, *rows]})
+    (event,) = transactions
+    assert isinstance(event, StockSplitTransaction)


### PR DESCRIPTION
Overlap matching compared the stated instant and seeded one row per distinct ID, so an export stating whole seconds never matched a newer one stating milliseconds, and two exports reporting two fills each under their own ID kept two rows instead of four.

Now:

- Overlaps match on the instant truncated to a whole second, so whole-second and millisecond exports reconcile, and the Time and Time (UTC) columns meet.
- Each ID keeps a whole source bucket, so an ID reported twice by one export keeps both rows and one export's repeated copy cannot displace a distinct occurrence in another.
- Where copies compete, the row stating a fraction of a second wins, then the one whose fractions are distinct.
- Ranking every way of choosing is gated on candidate count; taking rows by timestamp alone beyond the gate is warned about, because it can change which export supplied them.
- Warns when one ID is described two ways at one instant for one action, which is a restated export that both files still report.
- Ordinary rows carry every instant the exports stated for them. Two exports can report one trade at different fractions of a second, and the merge keeps one copy without knowing a reorganisation surrounds it, so keeping only the survivor's stamp let the export that saw nothing wrong overrule the one that placed the trade between the halves. The refusal names the disagreeing stamp it turned on.
- Reorganisation rows are the exception: they keep comparing on the exact instant and on price_foreign, currency_foreign and exchange_rate, which pairing checks. Each half deduplicates in its own group, so a truncated comparison would let a close from one export pair with an open from another and form an event no export reported, which stops a trade stamped between the halves from being refused. Two exports that disagree about the event are refused as ambiguous; rows stating it identically still merge.

Ordinary rows drop price_foreign, currency_foreign, exchange_rate and notes from the comparison: nothing reads them past parse time, so they only blocked merges on presentation.

The fingerprint is now a listed set of fields rather than reflection over the dataclass, so adding a model field cannot silently change what counts as the same transaction.

Closes #994. Builds on #1039 and #1041.
