### PR TITLE
Extract dividend and interest processing into cgt_calc/income.py

### DIFF
--- a/cgt_calc/calculator_state.py
+++ b/cgt_calc/calculator_state.py
@@ -16,7 +16,6 @@ if TYPE_CHECKING:
         CalculationEntry,
         CalculationLog,
         CurrencyCode,
-        DividendTaxAttribution,
         ExcessReportedIncomeDistributionLog,
         ExcessReportedIncomeLog,
         ForeignAmountLog,
@@ -89,7 +88,6 @@ class CalculatorState:
     dividend_dates: dict[tuple[str, str], set[datetime.date]] = field(
         default_factory=lambda: defaultdict(set)
     )
-    _attributed_dividend_tax: DividendTaxAttribution | None = None
     interest_list: dict[
         tuple[str, CurrencyCode, datetime.date], ForeignCurrencyAmount
     ] = field(default_factory=lambda: defaultdict(ForeignCurrencyAmount))

--- a/cgt_calc/income.py
+++ b/cgt_calc/income.py
@@ -1,0 +1,373 @@
+"""Dividend and interest processing."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+import datetime
+from decimal import Decimal
+import logging
+from typing import TYPE_CHECKING
+
+from .const import (
+    DIVIDEND_CURRENCY_TO_COUNTRY,
+    DIVIDEND_DOUBLE_TAXATION_RULES,
+    DIVIDEND_TAX_LEAD_DAYS,
+    DIVIDEND_TAX_MATCH_DAYS,
+    ISIN_COUNTRY_CODE_LENGTH,
+    UK_CURRENCY,
+)
+from .exceptions import CalculationError
+from .model import (
+    CalculationEntry,
+    Dividend,
+    DividendTaxAttribution,
+    ForeignCurrencyAmount,
+    RuleType,
+)
+from .util import approx_equal, round_decimal
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from .calculator_state import CalculatorState
+    from .currency_converter import CurrencyConverter
+    from .isin_converter import IsinConverter
+    from .model import CurrencyCode, ForeignAmountLog
+
+LOGGER = logging.getLogger(__name__)
+
+
+class IncomeProcessor:
+    """Turns recorded dividends and interest into report entries."""
+
+    def __init__(
+        self,
+        state: CalculatorState,
+        currency_converter: CurrencyConverter,
+        isin_converter: IsinConverter,
+        interest_fund_tickers: list[str],
+        date_in_tax_year: Callable[[datetime.date], bool],
+    ):
+        """Create income processor object."""
+        self.state = state
+        self.currency_converter = currency_converter
+        self.isin_converter = isin_converter
+        self.interest_fund_tickers = interest_fund_tickers
+        self.date_in_tax_year = date_in_tax_year
+        self._attributed_dividend_tax: DividendTaxAttribution | None = None
+
+    def _group_by_month(
+        self,
+        entries: dict[tuple[str, CurrencyCode, datetime.date], ForeignCurrencyAmount],
+    ) -> dict[tuple[str, CurrencyCode, datetime.date], ForeignCurrencyAmount]:
+        """Group in-tax-year amounts by month, keyed by the month's last date."""
+        monthly: dict[
+            tuple[str, CurrencyCode, datetime.date], ForeignCurrencyAmount
+        ] = defaultdict(ForeignCurrencyAmount)
+        last_date: datetime.date = datetime.date.min
+        last_broker: str | None = None
+        last_currency: CurrencyCode | None = None
+
+        for (broker, currency, date), foreign_amount in sorted(entries.items()):
+            if not self.date_in_tax_year(date):
+                continue
+            if (
+                broker == last_broker
+                and currency == last_currency
+                and (date.year, date.month) == (last_date.year, last_date.month)
+            ):
+                monthly[broker, currency, date] = monthly.pop(
+                    (broker, currency, last_date)
+                )
+            monthly[broker, currency, date] += foreign_amount
+            last_date = date
+            last_broker = broker
+            last_currency = currency
+        return monthly
+
+    def process_interests(self) -> None:
+        """Process all interest events.
+
+        It groups them by month, using the last date on each month for the report
+        and updates the interest totals for the year.
+        """
+        monthly_interests = self._group_by_month(self.state.interest_list)
+
+        for (broker, currency, date), foreign_amount in monthly_interests.items():
+            gbp_amount = self.currency_converter.to_gbp(
+                foreign_amount.amount, currency, date
+            )
+            if currency == UK_CURRENCY:
+                self.state.total_uk_interest += gbp_amount
+                rule_prefix = "interestUK"
+            else:
+                self.state.total_foreign_interest += gbp_amount
+                rule_prefix = f"interest{currency}"
+
+            self.state.calculation_log_yields[date][f"{rule_prefix}${broker}"] = [
+                CalculationEntry(
+                    rule_type=RuleType.INTEREST,
+                    quantity=Decimal(1),
+                    amount=gbp_amount,
+                    new_quantity=Decimal(1),
+                    new_pool_cost=Decimal(0),
+                    fees=Decimal(0),
+                )
+            ]
+
+        monthly_interest_taxes = self._group_by_month(self.state.interest_tax_list)
+
+        for (broker, currency, date), foreign_amount in monthly_interest_taxes.items():
+            gbp_amount = self.currency_converter.to_gbp(
+                foreign_amount.amount, currency, date
+            )
+            # Withholding rows are negative, so negate rather than abs():
+            # positive reversal rows then cancel out across months.
+            tax_amount = -gbp_amount
+            rule_prefix = f"interestTax{currency}"
+            self.state.total_interest_tax += tax_amount
+
+            self.state.calculation_log_yields[date][f"{rule_prefix}${broker}"] = [
+                CalculationEntry(
+                    rule_type=RuleType.INTEREST_TAX,
+                    quantity=Decimal(1),
+                    amount=tax_amount,
+                    new_quantity=Decimal(1),
+                    new_pool_cost=Decimal(0),
+                    fees=Decimal(0),
+                )
+            ]
+
+    def dividend_source_country(
+        self, symbol: str, currency: CurrencyCode
+    ) -> str | None:
+        """Return the country a dividend was paid from, or None if unknown.
+
+        The ISIN a security is registered under is the authority. Where no
+        parser supplied one, fall back to guessing from the currency, which is
+        what the calculator did before ISINs were consulted.
+        """
+        isin = self.isin_converter.get_symbol_to_isin_map().get(symbol)
+        if isin is not None:
+            return isin[:ISIN_COUNTRY_CODE_LENGTH]
+        return DIVIDEND_CURRENCY_TO_COUNTRY.get(currency)
+
+    def _warn_unattributed_dividend_tax(
+        self,
+        symbol: str,
+        date: datetime.date,
+        tax: ForeignCurrencyAmount,
+        candidates: list[datetime.date],
+    ) -> None:
+        """Warn about withheld tax that no single dividend can claim."""
+        # The tax is missing from the report of every year that holds a
+        # payment which could have carried it, not only from the year it was
+        # taken in, and each of those years is entitled to hear so. A
+        # withholding just after 5 April can leave a payment short on either
+        # side of the boundary.
+        if not any(self.date_in_tax_year(affected) for affected in (date, *candidates)):
+            return
+        # Tax below half a unit would print as a bare "-0.00", so it is
+        # shown as it stands instead. Whether it is material is a question
+        # about its value in GBP, and answering it here would put a rate
+        # lookup, and the failure of one, in the way of a warning.
+        amount = round_decimal(tax.amount, 2) or tax.amount
+        if candidates:
+            LOGGER.warning(
+                "Dividend tax of %s %s for %s on %s could have been taken "
+                "from the dividend on %s, so it is left out of the report! "
+                "Date it in the export on the one it belongs to to have it "
+                "counted.",
+                amount,
+                tax.currency,
+                symbol,
+                date,
+                " or ".join(str(candidate) for candidate in candidates),
+            )
+            return
+        LOGGER.warning(
+            "Dividend tax of %s %s for %s on %s has no dividend in the %d "
+            "days before it or the %d days after, so it is left out of the "
+            "report!",
+            amount,
+            tax.currency,
+            symbol,
+            date,
+            DIVIDEND_TAX_MATCH_DAYS,
+            DIVIDEND_TAX_LEAD_DAYS,
+        )
+
+    @staticmethod
+    def _dividends_for_tax(
+        date: datetime.date, dividend_dates: set[datetime.date]
+    ) -> list[datetime.date]:
+        """Return the dividends a withholding could have been taken from.
+
+        A payment on the day of the withholding is not in doubt, whatever
+        else lies nearby. Otherwise, every payment in the window counts as a
+        candidate, and it is for the caller to refuse when there is more
+        than one: which of two payments a correction belongs to cannot be
+        told from a date and a net amount.
+
+        The window is asymmetric because the directions mean different
+        things. Tax follows the payment it was taken from, and a correction
+        follows it by longer, so it reaches back weeks; a payment after the
+        withholding only means the broker posted the tax early, which it
+        does by days.
+        """
+        if date in dividend_dates:
+            return [date]
+        return sorted(
+            candidate
+            for candidate in dividend_dates
+            if -DIVIDEND_TAX_MATCH_DAYS
+            <= (candidate - date).days
+            <= DIVIDEND_TAX_LEAD_DAYS
+        )
+
+    def _attribute_dividend_tax(self) -> DividendTaxAttribution:
+        """Attribute each withholding to the dividend it was taken from.
+
+        Brokers do not always date a withholding, or a later correction of
+        one such as a Schwab ``NRA Tax Adj``, on the day of the payment it
+        belongs to, so tax is matched to a dividend of the same broker and
+        symbol nearby. Holding one symbol at two brokers therefore keeps
+        each broker's withholding with that broker's own payments.
+
+        Tax is attributed only where one payment can claim it. Where two
+        could, the export does not record which, and no arrangement of dates
+        and amounts recovers it: an adjustment reaching back to last month's
+        payment looks exactly like ordinary tax on next month's. Those are
+        left out of the report and warned about instead of guessed at. They
+        still reach the summary, and dating one on its dividend in the input
+        settles it.
+
+        Matching runs over the whole history rather than the reported year,
+        so a payment and its withholding either side of 5 April stay
+        together, and one withholding cannot be claimed in two years.
+        """
+        matched: ForeignAmountLog = defaultdict(ForeignCurrencyAmount)
+        unmatched: ForeignAmountLog = defaultdict(ForeignCurrencyAmount)
+        for (broker, symbol, date), tax in self.state.dividend_tax_list.items():
+            if not tax.amount:
+                continue
+            candidates = self._dividends_for_tax(
+                date, self.state.dividend_dates.get((broker, symbol), set())
+            )
+            if len(candidates) == 1:
+                matched[symbol, candidates[0]] += tax
+                continue
+            # Either nothing is near enough, or two payments are and the
+            # export does not say which one this is. Guessing between them
+            # puts a wrong figure in the report; leaving it out and saying so
+            # does not.
+            self._warn_unattributed_dividend_tax(symbol, date, tax, candidates)
+            unmatched[symbol, date] += tax
+        return DividendTaxAttribution(matched, unmatched)
+
+    def dividend_tax_attribution(self) -> DividendTaxAttribution:
+        """Attribute withholding once, for both the summary and the report.
+
+        The two must agree, and attributing twice would warn twice.
+        """
+        if self._attributed_dividend_tax is None:
+            self._attributed_dividend_tax = self._attribute_dividend_tax()
+        return self._attributed_dividend_tax
+
+    def process_dividends(self) -> None:
+        """Process all dividend events and taxes.
+
+        It updates the interest total for the year if needed.
+        """
+        attributed_tax = self.dividend_tax_attribution().matched
+        for (symbol, date), foreign_amount in self.state.dividend_list.items():
+            # Dividends outside the computed tax year are not reported, so
+            # neither are the warnings raised while resolving their treaty.
+            if not self.date_in_tax_year(date):
+                continue
+
+            # Read without inserting: a dividend with no tax must not leave a
+            # zero entry behind in the attribution.
+            tax = attributed_tax.get((symbol, date), ForeignCurrencyAmount())
+            currency = foreign_amount.currency
+            assert currency is not None, f"Dividend for {symbol} has no currency"
+
+            # The tax is converted at the dividend's rate below, so the two
+            # have to be in one currency whichever way the tax runs and
+            # whatever the holding is. Checking this only for tax deducted
+            # from an ordinary holding let a refund, or any tax on a bond
+            # fund, be converted as though it were in the dividend's
+            # currency.
+            if tax.amount and tax.currency != currency:
+                raise CalculationError(
+                    f"Dividend and withholding tax currencies do not match "
+                    f"for {symbol} on {date}: dividend "
+                    f"{foreign_amount.currency}, tax {tax.currency}"
+                )
+
+            treaty = None
+            is_interest_fund = symbol in self.interest_fund_tickers
+            if tax.amount < 0:
+                if is_interest_fund:
+                    LOGGER.warning(
+                        "Cannot apply taxation treaty for bond fund %s", symbol
+                    )
+                else:
+                    country = self.dividend_source_country(symbol, currency)
+                    if country is None:
+                        LOGGER.warning(
+                            "Source country of the %s dividend is unknown (ticker: %s), "
+                            "double taxation rules cannot be determined!",
+                            currency,
+                            symbol,
+                        )
+                    elif country not in DIVIDEND_DOUBLE_TAXATION_RULES:
+                        LOGGER.warning(
+                            "Taxation treaty for %s country is missing (ticker: %s), "
+                            "double taxation rules cannot be determined!",
+                            country,
+                            symbol,
+                        )
+                    else:
+                        treaty = DIVIDEND_DOUBLE_TAXATION_RULES[country]
+                        expected_tax = treaty.country_rate * -foreign_amount.amount
+                        if not approx_equal(expected_tax, tax.amount):
+                            LOGGER.warning(
+                                "Determined double taxation treaty does not match the "
+                                "base taxation rules (expected %.2f base tax for %s "
+                                "but %.2f was deducted) for %s ticker!",
+                                expected_tax,
+                                treaty.country,
+                                tax.amount,
+                                symbol,
+                            )
+                            treaty = None
+
+            amount = self.currency_converter.to_gbp(
+                foreign_amount.amount, currency, date
+            )
+            tax_amount = self.currency_converter.to_gbp(tax.amount, currency, date)
+
+            dividend = Dividend(
+                date=date,
+                symbol=symbol,
+                amount=amount,
+                tax_at_source=tax_amount,
+                is_interest=is_interest_fund,
+                tax_treaty=treaty,
+            )
+
+            self.state.calculation_log_yields[date][f"dividend${symbol}"] = [
+                CalculationEntry(
+                    rule_type=RuleType.DIVIDEND,
+                    quantity=Decimal(1),
+                    amount=amount,
+                    new_quantity=Decimal(1),
+                    new_pool_cost=Decimal(0),
+                    fees=Decimal(0),
+                    dividend=dividend,
+                )
+            ]
+
+            if is_interest_fund:
+                self.state.total_foreign_interest += amount

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -20,16 +20,10 @@ from .const import (
     BED_AND_BREAKFAST_DAYS,
     CAPITAL_GAIN_ALLOWANCES,
     DIVIDEND_ALLOWANCES,
-    DIVIDEND_CURRENCY_TO_COUNTRY,
-    DIVIDEND_DOUBLE_TAXATION_RULES,
-    DIVIDEND_TAX_LEAD_DAYS,
-    DIVIDEND_TAX_MATCH_DAYS,
     ERI_TAX_DATE_DELTA,
     INTERNAL_START_DATE,
-    ISIN_COUNTRY_CODE_LENGTH,
     MAX_CONTENDED_DATES_SHOWN,
     RENAME_DESCRIPTION_PREFIX,
-    UK_CURRENCY,
 )
 from .dates import get_tax_year_end, get_tax_year_start, is_date
 from .exceptions import (
@@ -44,6 +38,7 @@ from .exceptions import (
     SymbolMissingError,
     UnclassifiedGiftError,
 )
+from .income import IncomeProcessor
 from .logging import bullet, style_text
 from .model import (
     ActionType,
@@ -53,12 +48,9 @@ from .model import (
     CalculationType,
     CapitalGainsReport,
     CurrencyCode,
-    Dividend,
-    DividendTaxAttribution,
     ExcessReportedIncome,
     ExcessReportedIncomeDistribution,
     ExcessReportedIncomeLog,
-    ForeignAmountLog,
     ForeignCurrencyAmount,
     HmrcTransactionData,
     HmrcTransactionLog,
@@ -287,6 +279,13 @@ class CapitalGainsCalculator:
             ticker.upper() for ticker in cgt_exempt_tickers or []
         )
         self.state = CalculatorState()
+        self.income = IncomeProcessor(
+            self.state,
+            currency_converter,
+            isin_converter,
+            interest_fund_tickers,
+            self.date_in_tax_year,
+        )
 
     @property
     def portfolio(self) -> dict[str, Position]:
@@ -1738,7 +1737,7 @@ class CapitalGainsCalculator:
         # matched no dividend is counted under its own date: no dividend row
         # can carry it, but the broker took it and the summary says so. The
         # warning raised for it explains why the report does not show it.
-        attribution = self._dividend_tax_attribution()
+        attribution = self.income.dividend_tax_attribution()
         for (symbol, date), tax in [
             *attribution.matched.items(),
             *attribution.unmatched.items(),
@@ -3172,323 +3171,9 @@ class CapitalGainsCalculator:
             eris=[eri],
         )
 
-    def _group_by_month(
-        self,
-        entries: dict[tuple[str, CurrencyCode, datetime.date], ForeignCurrencyAmount],
-    ) -> dict[tuple[str, CurrencyCode, datetime.date], ForeignCurrencyAmount]:
-        """Group in-tax-year amounts by month, keyed by the month's last date."""
-        monthly: dict[
-            tuple[str, CurrencyCode, datetime.date], ForeignCurrencyAmount
-        ] = defaultdict(ForeignCurrencyAmount)
-        last_date: datetime.date = datetime.date.min
-        last_broker: str | None = None
-        last_currency: CurrencyCode | None = None
-
-        for (broker, currency, date), foreign_amount in sorted(entries.items()):
-            if not self.date_in_tax_year(date):
-                continue
-            if (
-                broker == last_broker
-                and currency == last_currency
-                and (date.year, date.month) == (last_date.year, last_date.month)
-            ):
-                monthly[broker, currency, date] = monthly.pop(
-                    (broker, currency, last_date)
-                )
-            monthly[broker, currency, date] += foreign_amount
-            last_date = date
-            last_broker = broker
-            last_currency = currency
-        return monthly
-
-    def process_interests(self) -> None:
-        """Process all interest events.
-
-        It groups them by month, using the last date on each month for the report
-        and updates the interest totals for the year.
-        """
-        monthly_interests = self._group_by_month(self.state.interest_list)
-
-        for (broker, currency, date), foreign_amount in monthly_interests.items():
-            gbp_amount = self.currency_converter.to_gbp(
-                foreign_amount.amount, currency, date
-            )
-            if currency == UK_CURRENCY:
-                self.state.total_uk_interest += gbp_amount
-                rule_prefix = "interestUK"
-            else:
-                self.state.total_foreign_interest += gbp_amount
-                rule_prefix = f"interest{currency}"
-
-            self.state.calculation_log_yields[date][f"{rule_prefix}${broker}"] = [
-                CalculationEntry(
-                    rule_type=RuleType.INTEREST,
-                    quantity=Decimal(1),
-                    amount=gbp_amount,
-                    new_quantity=Decimal(1),
-                    new_pool_cost=Decimal(0),
-                    fees=Decimal(0),
-                )
-            ]
-
-        monthly_interest_taxes = self._group_by_month(self.state.interest_tax_list)
-
-        for (broker, currency, date), foreign_amount in monthly_interest_taxes.items():
-            gbp_amount = self.currency_converter.to_gbp(
-                foreign_amount.amount, currency, date
-            )
-            # Withholding rows are negative, so negate rather than abs():
-            # positive reversal rows then cancel out across months.
-            tax_amount = -gbp_amount
-            rule_prefix = f"interestTax{currency}"
-            self.state.total_interest_tax += tax_amount
-
-            self.state.calculation_log_yields[date][f"{rule_prefix}${broker}"] = [
-                CalculationEntry(
-                    rule_type=RuleType.INTEREST_TAX,
-                    quantity=Decimal(1),
-                    amount=tax_amount,
-                    new_quantity=Decimal(1),
-                    new_pool_cost=Decimal(0),
-                    fees=Decimal(0),
-                )
-            ]
-
-    def dividend_source_country(
-        self, symbol: str, currency: CurrencyCode
-    ) -> str | None:
-        """Return the country a dividend was paid from, or None if unknown.
-
-        The ISIN a security is registered under is the authority. Where no
-        parser supplied one, fall back to guessing from the currency, which is
-        what the calculator did before ISINs were consulted.
-        """
-        isin = self.isin_converter.get_symbol_to_isin_map().get(symbol)
-        if isin is not None:
-            return isin[:ISIN_COUNTRY_CODE_LENGTH]
-        return DIVIDEND_CURRENCY_TO_COUNTRY.get(currency)
-
-    def _warn_unattributed_dividend_tax(
-        self,
-        symbol: str,
-        date: datetime.date,
-        tax: ForeignCurrencyAmount,
-        candidates: list[datetime.date],
-    ) -> None:
-        """Warn about withheld tax that no single dividend can claim."""
-        # The tax is missing from the report of every year that holds a
-        # payment which could have carried it, not only from the year it was
-        # taken in, and each of those years is entitled to hear so. A
-        # withholding just after 5 April can leave a payment short on either
-        # side of the boundary.
-        if not any(self.date_in_tax_year(affected) for affected in (date, *candidates)):
-            return
-        # Tax below half a unit would print as a bare "-0.00", so it is
-        # shown as it stands instead. Whether it is material is a question
-        # about its value in GBP, and answering it here would put a rate
-        # lookup, and the failure of one, in the way of a warning.
-        amount = round_decimal(tax.amount, 2) or tax.amount
-        if candidates:
-            LOGGER.warning(
-                "Dividend tax of %s %s for %s on %s could have been taken "
-                "from the dividend on %s, so it is left out of the report! "
-                "Date it in the export on the one it belongs to to have it "
-                "counted.",
-                amount,
-                tax.currency,
-                symbol,
-                date,
-                " or ".join(str(candidate) for candidate in candidates),
-            )
-            return
-        LOGGER.warning(
-            "Dividend tax of %s %s for %s on %s has no dividend in the %d "
-            "days before it or the %d days after, so it is left out of the "
-            "report!",
-            amount,
-            tax.currency,
-            symbol,
-            date,
-            DIVIDEND_TAX_MATCH_DAYS,
-            DIVIDEND_TAX_LEAD_DAYS,
-        )
-
-    @staticmethod
-    def _dividends_for_tax(
-        date: datetime.date, dividend_dates: set[datetime.date]
-    ) -> list[datetime.date]:
-        """Return the dividends a withholding could have been taken from.
-
-        A payment on the day of the withholding is not in doubt, whatever
-        else lies nearby. Otherwise, every payment in the window counts as a
-        candidate, and it is for the caller to refuse when there is more
-        than one: which of two payments a correction belongs to cannot be
-        told from a date and a net amount.
-
-        The window is asymmetric because the directions mean different
-        things. Tax follows the payment it was taken from, and a correction
-        follows it by longer, so it reaches back weeks; a payment after the
-        withholding only means the broker posted the tax early, which it
-        does by days.
-        """
-        if date in dividend_dates:
-            return [date]
-        return sorted(
-            candidate
-            for candidate in dividend_dates
-            if -DIVIDEND_TAX_MATCH_DAYS
-            <= (candidate - date).days
-            <= DIVIDEND_TAX_LEAD_DAYS
-        )
-
-    def _attribute_dividend_tax(self) -> DividendTaxAttribution:
-        """Attribute each withholding to the dividend it was taken from.
-
-        Brokers do not always date a withholding, or a later correction of
-        one such as a Schwab ``NRA Tax Adj``, on the day of the payment it
-        belongs to, so tax is matched to a dividend of the same broker and
-        symbol nearby. Holding one symbol at two brokers therefore keeps
-        each broker's withholding with that broker's own payments.
-
-        Tax is attributed only where one payment can claim it. Where two
-        could, the export does not record which, and no arrangement of dates
-        and amounts recovers it: an adjustment reaching back to last month's
-        payment looks exactly like ordinary tax on next month's. Those are
-        left out of the report and warned about instead of guessed at. They
-        still reach the summary, and dating one on its dividend in the input
-        settles it.
-
-        Matching runs over the whole history rather than the reported year,
-        so a payment and its withholding either side of 5 April stay
-        together, and one withholding cannot be claimed in two years.
-        """
-        matched: ForeignAmountLog = defaultdict(ForeignCurrencyAmount)
-        unmatched: ForeignAmountLog = defaultdict(ForeignCurrencyAmount)
-        for (broker, symbol, date), tax in self.state.dividend_tax_list.items():
-            if not tax.amount:
-                continue
-            candidates = self._dividends_for_tax(
-                date, self.state.dividend_dates.get((broker, symbol), set())
-            )
-            if len(candidates) == 1:
-                matched[symbol, candidates[0]] += tax
-                continue
-            # Either nothing is near enough, or two payments are and the
-            # export does not say which one this is. Guessing between them
-            # puts a wrong figure in the report; leaving it out and saying so
-            # does not.
-            self._warn_unattributed_dividend_tax(symbol, date, tax, candidates)
-            unmatched[symbol, date] += tax
-        return DividendTaxAttribution(matched, unmatched)
-
-    def _dividend_tax_attribution(self) -> DividendTaxAttribution:
-        """Attribute withholding once, for both the summary and the report.
-
-        The two must agree, and attributing twice would warn twice.
-        """
-        if self.state._attributed_dividend_tax is None:  # noqa: SLF001
-            self.state._attributed_dividend_tax = (  # noqa: SLF001
-                self._attribute_dividend_tax()
-            )
-        return self.state._attributed_dividend_tax  # noqa: SLF001
-
     def process_dividends(self) -> None:
-        """Process all dividend events and taxes.
-
-        It updates the interest total for the year if needed.
-        """
-        attributed_tax = self._dividend_tax_attribution().matched
-        for (symbol, date), foreign_amount in self.state.dividend_list.items():
-            # Dividends outside the computed tax year are not reported, so
-            # neither are the warnings raised while resolving their treaty.
-            if not self.date_in_tax_year(date):
-                continue
-
-            # Read without inserting: a dividend with no tax must not leave a
-            # zero entry behind in the attribution.
-            tax = attributed_tax.get((symbol, date), ForeignCurrencyAmount())
-            currency = foreign_amount.currency
-            assert currency is not None, f"Dividend for {symbol} has no currency"
-
-            # The tax is converted at the dividend's rate below, so the two
-            # have to be in one currency whichever way the tax runs and
-            # whatever the holding is. Checking this only for tax deducted
-            # from an ordinary holding let a refund, or any tax on a bond
-            # fund, be converted as though it were in the dividend's
-            # currency.
-            if tax.amount and tax.currency != currency:
-                raise CalculationError(
-                    f"Dividend and withholding tax currencies do not match "
-                    f"for {symbol} on {date}: dividend "
-                    f"{foreign_amount.currency}, tax {tax.currency}"
-                )
-
-            treaty = None
-            is_interest_fund = symbol in self.interest_fund_tickers
-            if tax.amount < 0:
-                if is_interest_fund:
-                    LOGGER.warning(
-                        "Cannot apply taxation treaty for bond fund %s", symbol
-                    )
-                else:
-                    country = self.dividend_source_country(symbol, currency)
-                    if country is None:
-                        LOGGER.warning(
-                            "Source country of the %s dividend is unknown (ticker: %s), "
-                            "double taxation rules cannot be determined!",
-                            currency,
-                            symbol,
-                        )
-                    elif country not in DIVIDEND_DOUBLE_TAXATION_RULES:
-                        LOGGER.warning(
-                            "Taxation treaty for %s country is missing (ticker: %s), "
-                            "double taxation rules cannot be determined!",
-                            country,
-                            symbol,
-                        )
-                    else:
-                        treaty = DIVIDEND_DOUBLE_TAXATION_RULES[country]
-                        expected_tax = treaty.country_rate * -foreign_amount.amount
-                        if not approx_equal(expected_tax, tax.amount):
-                            LOGGER.warning(
-                                "Determined double taxation treaty does not match the "
-                                "base taxation rules (expected %.2f base tax for %s "
-                                "but %.2f was deducted) for %s ticker!",
-                                expected_tax,
-                                treaty.country,
-                                tax.amount,
-                                symbol,
-                            )
-                            treaty = None
-
-            amount = self.currency_converter.to_gbp(
-                foreign_amount.amount, currency, date
-            )
-            tax_amount = self.currency_converter.to_gbp(tax.amount, currency, date)
-
-            dividend = Dividend(
-                date=date,
-                symbol=symbol,
-                amount=amount,
-                tax_at_source=tax_amount,
-                is_interest=is_interest_fund,
-                tax_treaty=treaty,
-            )
-
-            self.state.calculation_log_yields[date][f"dividend${symbol}"] = [
-                CalculationEntry(
-                    rule_type=RuleType.DIVIDEND,
-                    quantity=Decimal(1),
-                    amount=amount,
-                    new_quantity=Decimal(1),
-                    new_pool_cost=Decimal(0),
-                    fees=Decimal(0),
-                    dividend=dividend,
-                )
-            ]
-
-            if is_interest_fund:
-                self.state.total_foreign_interest += amount
+        """Process all dividend events and taxes."""
+        self.income.process_dividends()
 
     def _warn_unmatched_cgt_exempt_tickers(self) -> None:
         """Warn for any exempt ticker with no transactions."""
@@ -3706,8 +3391,8 @@ class CapitalGainsCalculator:
                         )
                     ]
 
-        self.process_dividends()
-        self.process_interests()
+        self.income.process_dividends()
+        self.income.process_interests()
 
         LOGGER.info(
             "\n%s\n",

--- a/tests/general/test_dividend_source_country.py
+++ b/tests/general/test_dividend_source_country.py
@@ -105,7 +105,7 @@ def test_no_treaty_when_the_source_country_cannot_be_determined(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Without an ISIN, GBP says nothing about where the income came from."""
-    with caplog.at_level(logging.WARNING, logger="cgt_calc.main"):
+    with caplog.at_level(logging.WARNING, logger="cgt_calc.income"):
         assert _treaty_country(_dividend_pair(CurrencyCode("GBP"), None)) is None
     assert "Source country of the GBP dividend is unknown" in caplog.text
 
@@ -114,7 +114,7 @@ def test_no_treaty_when_withholding_does_not_match_the_treaty_rate(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Relief is refused when the rate deducted is not the treaty rate."""
-    with caplog.at_level(logging.WARNING, logger="cgt_calc.main"):
+    with caplog.at_level(logging.WARNING, logger="cgt_calc.income"):
         assert (
             _treaty_country(
                 _dividend_pair(CurrencyCode("GBP"), US_ISIN, Decimal("0.30"))

--- a/tests/general/test_dividend_tax_attribution.py
+++ b/tests/general/test_dividend_tax_attribution.py
@@ -89,7 +89,7 @@ def _unattributed_warnings(
     # once, and those records must not be counted again here.
     caplog.clear()
     calculator = _calculator(transactions, tax_year)
-    with caplog.at_level(logging.WARNING, logger="cgt_calc.main"):
+    with caplog.at_level(logging.WARNING, logger="cgt_calc.income"):
         calculator.convert_to_hmrc_transactions(transactions)
         calculator.process_dividends()
     return [

--- a/tests/general/test_warning_scope.py
+++ b/tests/general/test_warning_scope.py
@@ -78,7 +78,7 @@ def test_treaty_mismatch_warning_scoped_to_tax_year(
     transactions = _dividend_with_unexpected_withholding(date)
     calculator = _calculator(transactions)
 
-    with caplog.at_level(logging.WARNING, logger="cgt_calc.main"):
+    with caplog.at_level(logging.WARNING, logger="cgt_calc.income"):
         calculator.convert_to_hmrc_transactions(transactions)
         calculator.calculate_capital_gain()
 


### PR DESCRIPTION
Third step of splitting main.py into phase modules: moves dividend/interest
processing out of CapitalGainsCalculator into a new IncomeProcessor.

- Moves the eight dividend/interest methods into `cgt_calc/income.py`'s
  `IncomeProcessor`, which takes the shared `CalculatorState` plus the
  converters it reads.
- Calculator keeps a `process_dividends` delegate for external callers.
- Dividend tax attribution memo moves off `CalculatorState` onto the
  processor, dropping the three SLF001 suppressions PR 2 left.
- Four caplog test filters follow the moved warnings to the `cgt_calc.income`
  logger.

Pure move, no behavior change.
