### PR TITLE
Simplify the first report workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,35 +4,13 @@
 
 # <img src="https://cgt-calc.uk/assets/logo.svg" alt="" width="34" valign="middle"> UK Capital Gains Calculator
 
-Calculate your **UK capital gains** from your investment transaction history and generate a detailed
-calculation report. cgt-calc is intended for UK individual investors working from supported broker
-exports.
+Use cgt-calc to calculate **UK capital gains** from your investment transaction history and generate
+a detailed report from a supported broker export.
 
 Supported sources include **Charles Schwab**, **Freetrade**, **Hargreaves Lansdown**, **Interactive
 Brokers**, **Morgan Stanley**, **Sharesight**, **Trading 212**, **Vanguard**, or a custom **RAW**
-format.
-
-For supported transactions, the tool converts prices to **GBP** and applies the UK **same-day**,
-**30-day ("bed and breakfast")**, and **Section 104 holding** rules. It prints a summary of disposal
-proceeds, allowable costs, gains, losses, dividends, and interest to the terminal and writes the
-full calculations to a **PDF report**.
-
-cgt-calc reports the net gain from the transactions you supply and, for supported tax years,
-estimates the amount remaining after the annual exempt amount. It does **not** account for gains or
-losses outside those inputs, apply tax rates, work out your final tax bill, or submit a tax return.
-Some investment scenarios are not supported; check the relevant
-[broker guide](https://cgt-calc.uk/brokers/) and the
-[offshore funds limitations](https://cgt-calc.uk/offshore-funds/#unsupported-functionality) before
-relying on the result.
-
-## 📊 Example Report
-
-This compact 2025/26 example shows foreign-currency transactions, same-day and 30-day matching,
-Section 104 pooling, gains and losses, a dividend with overseas tax, and cash interest.
-
-<a href="https://cgt-calc.uk/assets/example_report.pdf">
-  <img src="https://cgt-calc.uk/assets/example_report_preview.webp" alt="Preview of the 2025/26 example report" width="600">
-</a>
+format. Check your broker's guide before starting, especially for employer shares, because not every
+award export or transaction type is supported.
 
 ## 🚀 Quick Start
 
@@ -44,9 +22,35 @@ uv tool install cgt-calc
 cgt-calc --year 2025 --schwab-file schwab_transactions.csv
 ```
 
-`pdflatex` must be on your `PATH` to generate the PDF report. See
-[Installation](https://cgt-calc.uk/installation/) and [Usage](https://cgt-calc.uk/usage/) for
-details, and [Brokers](https://cgt-calc.uk/brokers/) for how to export your transaction history.
+Replace the Schwab option with the one for your broker. LaTeX is needed to create the PDF report.
+See [Installation](https://cgt-calc.uk/installation/), [Brokers](https://cgt-calc.uk/brokers/), and
+[Usage](https://cgt-calc.uk/usage/) for the complete steps.
+
+## What cgt-calc calculates
+
+For supported transactions, the tool converts prices to **GBP** and applies the UK **same-day**,
+**30-day ("bed and breakfast")**, and **Section 104 holding** rules. These match a sale with shares
+bought or received on the same day, shares bought or received within the following 30 days, then
+older shares. It shows **Disposal proceeds** (the sale price or value used when no sale took place),
+**Allowable costs** (costs included in the gain or loss calculation), gains, losses, dividends, and
+interest in the terminal and writes the full calculation to a **PDF report**.
+
+cgt-calc reports the net gain from the transactions you supply and, for supported tax years,
+estimates the amount left after the annual tax-free allowance for capital gains (the **annual exempt
+amount**). It does **not** include gains or losses outside those inputs, apply tax rates, work out
+your final tax bill, or submit a tax return. Some investment scenarios are not supported; check the
+relevant [broker guide](https://cgt-calc.uk/brokers/) and the
+[offshore funds limitations](https://cgt-calc.uk/offshore-funds/#unsupported-functionality) before
+relying on the result.
+
+## 📊 Example Report
+
+This compact 2025/26 example shows foreign-currency transactions, how sales are matched with shares
+acquired at different times, gains and losses, a dividend with overseas tax, and cash interest.
+
+<a href="https://cgt-calc.uk/assets/example_report.pdf">
+  <img src="https://cgt-calc.uk/assets/example_report_preview.webp" alt="Preview of the 2025/26 example report" width="600">
+</a>
 
 ## 📚 Documentation
 

--- a/docs/brokers/index.md
+++ b/docs/brokers/index.md
@@ -1,16 +1,20 @@
 # Brokers
 
-You need to provide the transaction history for each of your accounts, covering all transactions
-since you first acquired any shares owned during the relevant tax years. Pick your broker below for
-export instructions.
+Choose your broker below to find the export instructions and command to use. Export the complete
+history from the account's first transaction when possible, not only the tax year you are
+calculating. Earlier purchases or employer-share awards can establish the cost of shares sold later.
+
+If your shares came from an employer, check the broker guide carefully. Schwab supports only the
+award-export formats described in its guide, Morgan Stanley support is limited to Alphabet's GSU
+plan, and Sharesight requires equity grants to be recorded in a particular way.
 
 | Broker                                        | CLI option                                                                             | Notes                               |
 | --------------------------------------------- | -------------------------------------------------------------------------------------- | ----------------------------------- |
-| [Charles Schwab](schwab.md)                   | `--schwab-file` or `--schwab-dir`, `--schwab-award-file`, `--schwab-equity-award-json` | Equity awards supported             |
+| [Charles Schwab](schwab.md)                   | `--schwab-file` or `--schwab-dir`, `--schwab-award-file`, `--schwab-equity-award-json` | Some Equity Awards formats          |
 | [Freetrade](freetrade.md)                     | `--freetrade-file`                                                                     | Activity CSV export                 |
 | [Hargreaves Lansdown](hargreaves-lansdown.md) | `--hl-dir`                                                                             | Tax Centre CSVs plus contract notes |
 | [Interactive Brokers](interactive-brokers.md) | `--interactive-brokers-file`                                                           | Transaction history CSV             |
-| [Morgan Stanley](morgan-stanley.md)           | `--mssb-dir`                                                                           | Alphabet equity-award report folder |
+| [Morgan Stanley](morgan-stanley.md)           | `--mssb-dir`                                                                           | Alphabet GSU reports only           |
 | [Sharesight](sharesight.md)                   | `--sharesight-dir`                                                                     | Multi-broker portfolio tracker      |
 | [Trading 212](trading212.md)                  | `--trading212-dir`                                                                     | Folder of yearly exports            |
 | [Vanguard](vanguard.md)                       | `--vanguard-file`                                                                      | Client Transactions Listing CSV     |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,23 +1,35 @@
 # UK Capital Gains Calculator
 
-Calculate your **UK capital gains** from your investment transaction history and generate a detailed
-calculation report. cgt-calc is intended for UK individual investors working from supported broker
-exports.
+Use cgt-calc to calculate **UK capital gains** from your investment transaction history and generate
+a detailed report from a supported broker export.
 
 Supported sources include **Charles Schwab**, **Freetrade**, **Hargreaves Lansdown**, **Interactive
 Brokers**, **Morgan Stanley**, **Sharesight**, **Trading 212**, **Vanguard**, or a custom **RAW**
-format.
+format. Check your broker's guide before starting, especially for employer shares, because not every
+award export or transaction type is supported.
+
+## Where to start
+
+- [Installation](installation.md) — install cgt-calc and check that it runs
+- [Brokers](brokers/index.md) — find the export instructions for your broker
+- [Usage](usage.md) — generate and check your report
+- [Offshore funds (ERI)](offshore-funds.md) — if you hold non-UK funds
+
+## What cgt-calc calculates
 
 For supported transactions, the tool converts prices to **GBP** and applies the UK **same-day**,
-**30-day ("bed and breakfast")**, and **Section 104 holding** rules. It prints a summary of disposal
-proceeds, allowable costs, gains, losses, dividends, and interest to the terminal and writes the
-full calculations to a **PDF report**.
+**30-day ("bed and breakfast")**, and **Section 104 holding** rules. These match a sale with shares
+bought or received on the same day, shares bought or received within the following 30 days, then
+older shares. It shows **Disposal proceeds** (the sale price or value used when no sale took place),
+**Allowable costs** (costs included in the gain or loss calculation), gains, losses, dividends, and
+interest in the terminal and writes the full calculation to a **PDF report**.
 
 cgt-calc reports the net gain from the transactions you supply and, for supported tax years,
-estimates the amount remaining after the annual exempt amount. It does **not** account for gains or
-losses outside those inputs, apply tax rates, work out your final tax bill, or submit a tax return.
-Some investment scenarios are not supported; check the relevant [broker guide](brokers/index.md) and
-the [offshore funds limitations](offshore-funds.md#unsupported-functionality) before relying on the
+estimates the amount left after the annual tax-free allowance for capital gains (the **annual exempt
+amount**). It does **not** include gains or losses outside those inputs, apply tax rates, work out
+your final tax bill, or submit a tax return. Some investment scenarios are not supported; check the
+relevant [broker guide](brokers/index.md) and the
+[offshore funds limitations](offshore-funds.md#unsupported-functionality) before relying on the
 result.
 
 The PDF report includes separate **Capital Gains** and **Interest and Dividends** sections, with a
@@ -26,8 +38,8 @@ brokers that pay daily interest.
 
 ## Example report
 
-This compact 2025/26 example shows foreign-currency transactions, same-day and 30-day matching,
-Section 104 pooling, gains and losses, a dividend with overseas tax, and cash interest:
+This compact 2025/26 example shows foreign-currency transactions, how sales are matched with shares
+acquired at different times, gains and losses, a dividend with overseas tax, and cash interest:
 
 <div class="report-preview">
   <img src="assets/example_report_page1.webp" alt="Example report, page 1" loading="lazy">
@@ -36,11 +48,3 @@ Section 104 pooling, gains and losses, a dividend with overseas tax, and cash in
 </div>
 
 [View full example report (PDF)](assets/example_report.pdf)
-
-## Where to start
-
-- [Installation](installation.md) — install the tool and LaTeX
-- [Usage](usage.md) — generate and review a report
-- [Brokers](brokers/index.md) — export instructions for each supported broker
-- [Offshore funds (ERI)](offshore-funds.md) — if you hold non-UK funds
-- [Development](development/index.md) — contribute to the project

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,8 +3,8 @@
 ## Prerequisites
 
 - **Python 3.12** or newer (tested on 3.12, 3.13, and 3.14)
-- **pdflatex** must be available in your `PATH` to generate PDF reports (with `--no-pdflatex` the
-    LaTeX source is saved instead)
+- **LaTeX** if you want a PDF report. Install `pdflatex` using the instructions below. You can run
+    cgt-calc without it by using `--no-report`.
 
 ## Install cgt-calc
 
@@ -50,7 +50,18 @@ apt install texlive-latex-base
 
 [Install MiKTeX.](https://miktex.org/download)
 
-## Shell completions
+## Check the installation
+
+Run:
+
+```shell
+cgt-calc --version
+```
+
+If you use `uvx` instead of installing cgt-calc, run `uvx cgt-calc --version`. Once the command
+prints a version, choose your [broker](brokers/index.md) and follow the [report guide](usage.md).
+
+## Shell completions (optional)
 
 `cgt-calc` can generate a tab completion script for `bash`, `zsh`, `fish`, `tcsh` and PowerShell.
 Save it where your shell looks for completions, e.g.:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,19 +2,21 @@
 
 ## Before you start
 
-You will need:
+Most users need:
 
 - **cgt-calc installed.** Follow the [installation guide](installation.md) before continuing.
 - **LaTeX installed if you want a PDF report.** It is not needed for a terminal-only report using
     `--no-report`.
 - **A complete transaction history from every relevant account.** Follow the instructions for each
-    [supported broker](brokers/index.md). Include transactions from before the report starts when
-    they establish the cost of shares you owned or sold. Also include acquisitions in the 30 days
-    after the report ends, because they can be matched to a disposal inside the period. Exporting
-    from the date the account was opened through at least 30 days after the report ends is the
-    safest option.
-- **Excess Reported Income data when applicable.** If you own or have owned funds from outside the
-    UK, whether accumulating or distributing, check the [offshore funds guide](offshore-funds.md).
+    [supported broker](brokers/index.md). Earlier purchases or employer-share awards can establish
+    the cost of shares sold later. Purchases in the 30 days after the report ends can be matched to
+    a sale or other disposal inside the report. Exporting from the date the account was opened
+    through at least 30 days after the report ends is the safest option.
+
+Depending on your investments, you may also need:
+
+- **Extra income data for some funds outside the UK.** This can apply whether the fund pays income
+    to you or reinvests it. Check the [offshore funds guide](offshore-funds.md).
 - **Transfers to or from a spouse or civil partner, recorded by hand.** No broker export marks
     these. Add them in a small RAW file using the
     [`TRANSFER_TO_SPOUSE` or `TRANSFER_FROM_SPOUSE`](brokers/raw.md#transfers-to-a-spouse-or-civil-partner)
@@ -29,27 +31,6 @@ Pass the first year of the UK tax year to `--year`. For example, `--year 2024` m
 year, from 6 April 2024 to 5 April 2025.
 
 If you omit `--year`, cgt-calc uses the most recently completed UK tax year.
-
-### Report part of a tax year
-
-Use `--from` and `--to` instead of `--year` to report a period within one UK tax year. For example,
-the following reports disposals on or after 30 October 2024 for the
-[HMRC 2024/25 Capital Gains Tax adjustment](https://www.gov.uk/guidance/work-out-your-capital-gains-tax-adjustment-for-the-2024-to-2025-tax-year):
-
-```shell
-cgt-calc --from 2024-10-30 --to 2025-04-05 --schwab-file schwab_transactions.csv
-```
-
-cgt-calc still reads earlier transactions from the supplied history to establish the share pool, but
-only reports the selected period. Matching is not limited by the end date: a purchase made after it
-is still identified against a reported disposal under the 30-day rule if it is in the supplied
-history.
-
-A period report does not calculate the HMRC adjustment or allocate the annual exempt amount between
-periods. Use the **Gain** and **Loss** figures with the full-year report and HMRC guidance; do not
-treat its **Taxable gain** as your annual figure. Do not treat its dividend or interest figures as
-annual totals either: they include only income received inside the period, and the dividend section
-still deducts the full-year dividend allowance.
 
 ## Generate the report
 
@@ -110,7 +91,8 @@ Before relying on the figures:
 1. Read every warning printed while the calculator runs.
 2. Check that the portfolio section agrees with your records on the end date in the heading (5 April
     for a full-year report).
-3. Compare the disposal count and proceeds with your broker statements.
+3. Compare **Number of disposals** with your records. Check that **Disposal proceeds** agrees with
+    sale amounts on your broker statements and any values used for other disposals.
 4. Check that dividends and interest are present when you expect them.
 5. Confirm that every relevant account was included once, without overlapping exports.
 6. Check that unusual events such as share splits, spin-offs and offshore fund income were handled.
@@ -128,9 +110,9 @@ The PDF shows the matching rules applied to each disposal: **SAME DAY**, **BED A
 
 ## Use the figures
 
-Treat the cgt-calc report as one calculation working paper. It covers only the supported
-transactions supplied to the tool. Combine it with gains and losses from other assets,
-brought-forward losses and any claims or reliefs before completing your return.
+The cgt-calc report covers only the supported transactions supplied to the tool. It is not a
+complete tax return. Before filing, include gains and losses from other assets, unused losses from
+earlier years, and any claims or reliefs.
 
 Use HMRC's guidance to
 [check whether the gains must be reported](https://www.gov.uk/capital-gains-tax/work-out-need-to-pay).
@@ -146,6 +128,26 @@ required records and retention period.
 
 Run `cgt-calc --help` for the complete list of available options. Use `--verbose` when you need more
 detail while investigating a warning or error.
+
+## Report part of a tax year (advanced)
+
+Use `--from` and `--to` instead of `--year` to report a period within one UK tax year. For example,
+the following reports sales and other disposals on or after 30 October 2024 for the
+[HMRC 2024/25 Capital Gains Tax adjustment](https://www.gov.uk/guidance/work-out-your-capital-gains-tax-adjustment-for-the-2024-to-2025-tax-year):
+
+```shell
+cgt-calc --from 2024-10-30 --to 2025-04-05 --schwab-file schwab_transactions.csv
+```
+
+cgt-calc still reads earlier transactions from the supplied history to establish the cost of the
+holding, but only reports the selected period. A purchase after the end date can still be matched to
+a sale or other disposal in the report under the 30-day rule if it is in the supplied history.
+
+A period report does not calculate the HMRC adjustment or divide the year's tax-free allowance for
+capital gains between periods. Use the **Gain** and **Loss** figures with the full-year report and
+HMRC guidance; do not treat its **Taxable gain** as your annual figure. Its dividend and interest
+figures are not annual totals either: they include only income received inside the period, and the
+dividend section still deducts the full-year dividend allowance.
 
 ## Terminal appearance
 


### PR DESCRIPTION
Make the getting-started documentation easier for employees with employer shares and people managing their own investments.

- explain essential tax terms at first use
- put the basic full-year report before specialist workflows
- clarify supported employer-share paths