### PR TITLE
Clarify the extra data and options guide

### DIFF
--- a/cgt_calc/args_parser.py
+++ b/cgt_calc/args_parser.py
@@ -89,8 +89,7 @@ Environment variables:
             "--initial-prices-file",
             type=existing_file_type,
             metavar="PATH",
-            help="stock prices in USD at key events (vesting, splits, etc.) "
-            "in CSV format",
+            help="stock-plan acquisition prices in USD in CSV format",
         ),
         shtab.FILE,
     )

--- a/cgt_calc/exceptions.py
+++ b/cgt_calc/exceptions.py
@@ -321,6 +321,6 @@ class MarketDataMissingError(CgtError):
         """Initialise."""
         super().__init__(
             f"No market data found for {symbol} around {date}. The ticker may "
-            "have been renamed or delisted; consider providing the price via "
-            "--initial-prices-file."
+            "have been renamed or delisted; check the ticker or work out the "
+            "spin-off outside cgt-calc."
         )

--- a/cgt_calc/parsers/broker_registry.py
+++ b/cgt_calc/parsers/broker_registry.py
@@ -206,7 +206,7 @@ class BrokerRegistry:
                 "to the --isin-translation-file cache%s. Give each ISIN a single "
                 "row listing every symbol it is known by: a row that leaves one "
                 "out replaces the existing mapping and can stop a later run. "
-                "See https://cgt-calc.uk/configuration/",
+                "See https://cgt-calc.uk/configuration/#isin-to-ticker-translation",
                 _as_csv_fields(unmapped_vanguard_symbols),
                 location,
             )

--- a/docs/brokers/raw.md
+++ b/docs/brokers/raw.md
@@ -101,11 +101,11 @@ If you are unsure, use `ADJUSTMENT`: it takes the money out of the balance witho
 cost, which is the safer way to be wrong.
 
 For a `SPIN_OFF`, cgt-calc needs to know which holding the new shares came from. It looks the new
-ticker up in [`--spin-offs-file`](../configuration.md#manual-configuration-files), asks you when it
-is not there, and saves your answer to that file so it only asks once; a run that cannot ask, such
-as one in a script, stops and tells you to add the row yourself. It then looks up a closing price
-for the new and the old ticker on that date to divide the old holding's pooled cost between them, so
-a price for both has to be available.
+ticker up in [`--spin-offs-file`](../configuration.md#spin-off-source-mappings), asks you when it is
+not there, and saves your answer to that file so it only asks once; a run that cannot ask, such as
+one in a script, stops and tells you to add the row yourself. It then looks up a closing price for
+the new and the old ticker on that date to divide the old holding's pooled cost between them, so a
+price for both has to be available.
 
 ## Known limitations
 

--- a/docs/brokers/schwab.md
+++ b/docs/brokers/schwab.md
@@ -176,7 +176,7 @@ Two situations are refused rather than guessed:
 For a `Spin-off`, cgt-calc needs to know the old holding from which the new shares came. It asks for
 the old ticker during an interactive run and saves the answer in `out/spin_offs.csv`. For a
 non-interactive run, add the required `dst,src` row first or choose another cache with
-[`--spin-offs-file`](../configuration.md#manual-configuration-files). It then uses the two holdings'
+[`--spin-offs-file`](../configuration.md#spin-off-source-mappings). It then uses the two holdings'
 market values to divide the existing pooled cost. Check this result against the company's
 reorganisation documents.
 

--- a/docs/brokers/vanguard.md
+++ b/docs/brokers/vanguard.md
@@ -138,12 +138,12 @@ cgt-calc --year 2025 --vanguard-file vanguard.csv \
 This option selects a read/write cache, not a read-only input. cgt-calc may create or rewrite the
 file when it learns a mapping from a transaction or a successful Open FIGI lookup. Keep a separate
 copy of manually curated data if you need an immutable record; see
-[Configuration files](../configuration.md#automatic-data-fetching).
+[ISIN to ticker translation](../configuration.md#isin-to-ticker-translation).
 
 A missing mapping produces a warning naming each affected Vanguard symbol. Check that warning and
 the report rather than assuming that bundled ERI data was matched. Some bond-fund distributions are
 taxed as interest rather than dividends; see
-[Interest fund tickers](../configuration.md#manual-configuration-files).
+[Bond-fund income](../configuration.md#bond-fund-income).
 
 ## Known limitations
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,8 +51,8 @@ A spin-off row may name the new holding without naming the old holding it came f
 that link to divide the existing pooled cost between them. During an interactive run, it asks for
 the old ticker and saves the answer to `out/spin_offs.csv`.
 
-If the run cannot ask, it stops and tells you which `dst,src` row to add. Use `--spin-offs-file`
-only to select another file for these mappings.
+If the run cannot ask, it stops and tells you which `dst,src` row to add. Use `--spin-offs-file` to
+select another file for these mappings.
 
 ### Bond-fund income
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,4 +1,4 @@
-# Optional Settings and Files
+# Extra Data and Options
 
 Most users can generate a report from a supported broker export without these files or options.
 Start with your [broker guide](brokers/index.md). Return here only if cgt-calc asks for more

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,10 +16,10 @@ cgt-calc downloads monthly GBP exchange rates from the
 [HMRC's legacy service](https://www.hmrc.gov.uk/softwaredevelopers/2020-exrates.html) for earlier
 periods. It saves them to `out/exchange_rates.csv`.
 
-Use `--exchange-rates-file` only to select another file in the same format. Keep the completed file
-with the report to preserve the exchange rates used. cgt-calc may add missing months to the selected
-file, so retain the version used for the final report. This does not preserve other fetched data,
-such as Yahoo Finance prices.
+Use `--exchange-rates-file` to select another file in the same format. An empty value disables the
+cache. Keep the completed file with the report to preserve the exchange rates used. cgt-calc may add
+missing months to the selected file, so retain the version used for the final report. This does not
+preserve other fetched data, such as Yahoo Finance prices.
 
 ### ISIN to ticker translation
 
@@ -34,9 +34,7 @@ broker transactions. It starts with the bundled
 If you edit the cache, a row for an existing ISIN replaces its bundled symbols. Put every verified
 ticker for that ISIN on the same row.
 
-## Manual configuration files
-
-These are not part of the normal setup. Add one only in the situation described.
+## When extra information is needed
 
 ### Missing stock-plan prices
 
@@ -61,7 +59,8 @@ only to select another file for these mappings.
 Some offshore bond funds have income that must be reported as interest rather than dividends. After
 checking the fund's classification, pass its ticker to `--interest-fund-tickers`. Use a
 comma-separated list for several tickers. This setting applies to both cash distributions and ERI;
-see the [offshore-fund checklist](offshore-funds.md#what-to-check).
+see the [offshore-fund checklist](offshore-funds.md#what-to-check). It reports the income as foreign
+interest, so do not use it for a UK fund.
 
 ### CGT-exempt instruments (advanced)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,7 +60,8 @@ Some offshore bond funds have income that must be reported as interest rather th
 checking the fund's classification, pass its ticker to `--interest-fund-tickers`. Use a
 comma-separated list for several tickers. This setting applies to both cash distributions and ERI;
 see the [offshore-fund checklist](offshore-funds.md#what-to-check). It reports the income as foreign
-interest, so do not use it for a UK fund.
+interest, so do not use it for a UK fund. If cgt-calc reports a UK bond fund distribution as a
+dividend, adjust the income figures outside cgt-calc.
 
 ### CGT-exempt instruments (advanced)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,78 +1,100 @@
-# Configuration Files
+# Optional Settings and Files
 
-The following configuration files and options allow you to customize the calculator's behaviour:
+Most users can generate a report from a supported broker export without these files or options.
+Start with your [broker guide](brokers/index.md). Return here only if cgt-calc asks for more
+information or one of the tax settings below applies to your investments.
 
 ## Automatic data fetching
 
-- **Exchange rates.** Monthly GBP exchange rates are automatically downloaded from the
-    [UK Trade Tariff API](https://www.trade-tariff.service.gov.uk/exchange_rates) for 2021 onwards
-    and [HMRC's legacy service](https://www.hmrc.gov.uk/softwaredevelopers/2020-exrates.html) for
-    earlier periods, then saved to `out/exchange_rates.csv`. You can select another file in the same
-    format with `--exchange-rates-file`. Keep the completed file with the report to preserve the
-    exchange rates used. cgt-calc may add missing months to the selected file, so retain the version
-    used for the final report. This does not preserve other fetched data such as Yahoo Finance
-    prices.
+cgt-calc creates and updates these local files itself. You do not need to create or select them for
+a normal calculation.
 
-- **ISIN to ticker translation.** When an ERI row identifies a fund only by its ISIN, cgt-calc maps
-    it to ticker symbols. It uses existing mappings first and queries the
-    [Open FIGI API](https://www.openfigi.com/api/overview) only if needed. This is used for
-    calculating Excess Reported Income (ERI) on offshore funds. The default read/write cache is
-    `out/isin_translation.csv`; `--isin-translation-file` selects a different cache path. Existing
-    entries are read, and cgt-calc can create or rewrite the file after a successful Open FIGI
-    lookup or after learning a mapping from broker transactions. Pre-packaged mappings are available
-    in
-    [`initial_isin_translation.csv`](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/resources/initial_isin_translation.csv),
-    which you can extend using the cache file. A cache entry for an existing ISIN replaces the
-    bundled symbol set for that ISIN, so put every verified alias in additional columns on the same
-    CSV row.
+### Exchange rates
+
+cgt-calc downloads monthly GBP exchange rates from the
+[UK Trade Tariff API](https://www.trade-tariff.service.gov.uk/exchange_rates) for 2021 onwards and
+[HMRC's legacy service](https://www.hmrc.gov.uk/softwaredevelopers/2020-exrates.html) for earlier
+periods. It saves them to `out/exchange_rates.csv`.
+
+Use `--exchange-rates-file` only to select another file in the same format. Keep the completed file
+with the report to preserve the exchange rates used. cgt-calc may add missing months to the selected
+file, so retain the version used for the final report. This does not preserve other fetched data,
+such as Yahoo Finance prices.
+
+### ISIN to ticker translation
+
+When an ERI row identifies a fund only by its ISIN, cgt-calc maps it to ticker symbols. It checks
+existing mappings first and queries the [Open FIGI API](https://www.openfigi.com/api/overview) only
+if needed. It saves new mappings in `out/isin_translation.csv` by default; `--isin-translation-file`
+selects another path.
+
+cgt-calc can create or rewrite this file after a successful lookup or after learning a mapping from
+broker transactions. It starts with the bundled
+[`initial_isin_translation.csv`](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/resources/initial_isin_translation.csv).
+If you edit the cache, a row for an existing ISIN replaces its bundled symbols. Put every verified
+ticker for that ISIN on the same row.
 
 ## Manual configuration files
 
-- **Initial stock prices.** Required for special events like vesting, splits, or spin-offs when
-    historical prices aren't available from your broker. Prices should be in USD.
-    [`initial_prices.csv`](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/resources/initial_prices.csv)
-    comes pre-packaged. The program will inform you when a required price is missing, and you can
-    supply custom data with `--initial-prices-file`.
+These are not part of the normal setup. Add one only in the situation described.
 
-- **Spin-off transactions.** Provide additional details for spin-off events using the
-    `--spin-offs-file` option.
+### Missing stock-plan prices
 
-- **Interest fund tickers.** Some bond funds and ETFs should be taxed as interest rather than
-    dividends. Specify these funds via the `--interest-fund-tickers` CLI option, using a
-    comma-separated list of ticker symbols.
+A vest or other stock-plan acquisition needs a price per share to establish its cost. Broker files
+usually provide it, and cgt-calc includes some historical values in
+[`initial_prices.csv`](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/resources/initial_prices.csv).
 
-- **CGT-exempt instrument classification (advanced manual override).** Use `--cgt-exempt-tickers`
-    with a comma-separated list only when you have established that each instrument is exempt under
-    [TCGA 1992 s115](https://www.legislation.gov.uk/ukpga/1992/12/section/115).
+If cgt-calc stops with a **No initial price** error, create a CSV in the same format with the
+missing USD price and pass it with `--initial-prices-file`.
 
-    - This is your own unverified assertion. The calculator does not identify or validate gilts or
-        [qualifying corporate bonds (QCBs)](https://www.gov.uk/hmrc-internal-manuals/capital-gains-manual/cg53702),
-        and QCB status cannot be inferred from a ticker or name.
-    - The override disregards both gains and losses on disposals. Do not use it where a disposal can
-        still produce a charge: disposing of a QCB acquired on a takeover or reorganisation can
-        bring a
-        [deferred gain](https://www.gov.uk/government/publications/share-reorganisations-company-takeovers-and-capital-gains-tax-hs285-self-assessment-helpsheet)
-        back into charge, and the profit on a
-        [deeply discounted security](https://www.gov.uk/hmrc-internal-manuals/savings-and-investment-manual/saim3010)
-        is taxable as income. Neither is calculated here.
-    - The per-disposal breakdown in the PDF applies the ordinary same-day, 30-day and Section 104
-        share identification rules. Those are not the identification rules HMRC gives for gilts,
-        QCBs and other relevant securities, so read the breakdown as workings for the quantities
-        only. It has no effect on the figures reported, because the gain or loss is disregarded.
-    - Coupon and accrued interest remain taxable income. The calculator does not implement the
-        [Accrued Income Scheme](https://www.gov.uk/government/publications/accrued-income-scheme-hs343-self-assessment-helpsheet).
-    - The importers for [Freetrade](brokers/freetrade.md),
-        [Hargreaves Lansdown](brokers/hargreaves-lansdown.md) and
-        [Interactive Brokers](brokers/interactive-brokers.md) are documented as unvalidated for
-        bonds and gilts. This override does not validate them either.
-    - The override changes the capital gains calculation only. A coupon is reported in whichever box
-        its broker rows put it in. `--interest-fund-tickers` reports as foreign interest, so it is
-        not a fix for a UK gilt coupon. Check the interest and dividend figures against your own
-        records.
-    - Matching uses the ticker at the disposal, so an instrument renamed part-way through the
-        history has to be listed under both names.
-    - A gift of a listed instrument is reported as an exempt disposal and does not also appear in
-        the **Gifts at market value** section.
-    - Listing an instrument does not lift the restrictions on disposing of it in more than one way
-        on a single day. A sale and a gift to a connected person on the same day are still refused,
-        even though the loss they cannot apportion would be disregarded.
+### Spin-off source mappings
+
+A spin-off row may name the new holding without naming the old holding it came from. cgt-calc needs
+that link to divide the existing pooled cost between them. During an interactive run, it asks for
+the old ticker and saves the answer to `out/spin_offs.csv`.
+
+If the run cannot ask, it stops and tells you which `dst,src` row to add. Use `--spin-offs-file`
+only to select another file for these mappings.
+
+### Bond-fund income
+
+Some offshore bond funds have income that must be reported as interest rather than dividends. After
+checking the fund's classification, pass its ticker to `--interest-fund-tickers`. Use a
+comma-separated list for several tickers. This setting applies to both cash distributions and ERI;
+see the [offshore-fund checklist](offshore-funds.md#what-to-check).
+
+### CGT-exempt instruments (advanced)
+
+Most users should not use `--cgt-exempt-tickers`. Pass a comma-separated list only when you have
+established that each instrument is exempt under
+[TCGA 1992 s115](https://www.legislation.gov.uk/ukpga/1992/12/section/115).
+
+- This is your own unverified assertion. The calculator does not identify or validate gilts or
+    [qualifying corporate bonds (QCBs)](https://www.gov.uk/hmrc-internal-manuals/capital-gains-manual/cg53702),
+    and QCB status cannot be inferred from a ticker or name.
+- The override disregards both gains and losses on disposals. Do not use it where a disposal can
+    still produce a charge: disposing of a QCB acquired on a takeover or reorganisation can bring a
+    [deferred gain](https://www.gov.uk/government/publications/share-reorganisations-company-takeovers-and-capital-gains-tax-hs285-self-assessment-helpsheet)
+    back into charge, and the profit on a
+    [deeply discounted security](https://www.gov.uk/hmrc-internal-manuals/savings-and-investment-manual/saim3010)
+    is taxable as income. Neither is calculated here.
+- The per-disposal breakdown in the PDF applies the ordinary same-day, 30-day and Section 104 share
+    identification rules. Those are not the identification rules HMRC gives for gilts, QCBs and
+    other relevant securities, so read the breakdown as workings for the quantities only. It has no
+    effect on the figures reported, because the gain or loss is disregarded.
+- Coupon and accrued interest remain taxable income. The calculator does not implement the
+    [Accrued Income Scheme](https://www.gov.uk/government/publications/accrued-income-scheme-hs343-self-assessment-helpsheet).
+- The importers for [Freetrade](brokers/freetrade.md),
+    [Hargreaves Lansdown](brokers/hargreaves-lansdown.md) and
+    [Interactive Brokers](brokers/interactive-brokers.md) are documented as unvalidated for bonds
+    and gilts. This override does not validate them either.
+- The override changes the capital gains calculation only. A coupon is reported in whichever box its
+    broker rows put it in. `--interest-fund-tickers` reports as foreign interest, so it is not a fix
+    for a UK gilt coupon. Check the interest and dividend figures against your own records.
+- Matching uses the ticker at the disposal, so an instrument renamed part-way through the history
+    has to be listed under both names.
+- A gift of a listed instrument is reported as an exempt disposal and does not also appear in the
+    **Gifts at market value** section.
+- Listing an instrument does not lift the restrictions on disposing of it in more than one way on a
+    single day. A sale and a gift to a connected person on the same day are still refused, even
+    though the loss they cannot apportion would be disregarded.

--- a/docs/offshore-funds.md
+++ b/docs/offshore-funds.md
@@ -40,8 +40,8 @@ need. cgt-calc cannot detect a missing ERI row. If supplied ERI cannot be matche
 check the ISIN-to-ticker mapping below. Do not assume that missing or unmatched data means zero ERI.
 
 Bundled ERI data is indexed by ISIN. If your broker does not supply one, cgt-calc uses its
-ISIN-to-ticker mapping to match the holding. To check or override the mapping, see **ISIN to ticker
-translation** on the [Configuration files](configuration.md) page.
+ISIN-to-ticker mapping to match the holding. To check or override the mapping, see
+[ISIN to ticker translation](configuration.md#isin-to-ticker-translation).
 
 ## Unsupported functionality
 

--- a/tests/general/test_broker_registry.py
+++ b/tests/general/test_broker_registry.py
@@ -131,7 +131,7 @@ def test_vanguard_symbol_without_isin_mapping_warns(
     # Appending a row that drops an alias breaks a later run, so the advice
     # has to say how the cache is keyed, not just where it lives.
     assert "single row listing every symbol it is known by" in warning
-    assert "https://cgt-calc.uk/configuration/" in warning
+    assert "https://cgt-calc.uk/configuration/#isin-to-ticker-translation" in warning
 
 
 def test_vanguard_warning_omits_cache_path_when_flag_is_cleared(

--- a/zensical.toml
+++ b/zensical.toml
@@ -31,7 +31,7 @@ nav = [
     ] },
     { "Offshore funds (ERI)" = "offshore-funds.md" },
     { "Custom ERI data" = "custom-eri-data.md" },
-    { "Configuration files" = "configuration.md" },
+    { "Optional settings" = "configuration.md" },
   ] },
   { "Privacy & disclaimer" = "privacy.md" },
   { "Development" = [

--- a/zensical.toml
+++ b/zensical.toml
@@ -31,7 +31,7 @@ nav = [
     ] },
     { "Offshore funds (ERI)" = "offshore-funds.md" },
     { "Custom ERI data" = "custom-eri-data.md" },
-    { "Optional settings" = "configuration.md" },
+    { "Extra data and options" = "configuration.md" },
   ] },
   { "Privacy & disclaimer" = "privacy.md" },
   { "Development" = [


### PR DESCRIPTION
Make clear that normal broker exports do not need configuration.

- separate automatic caches from inputs added when needed
- explain missing stock-plan prices and spin-off mappings
- distinguish bond-fund and CGT-exempt classifications
- rename the page to `Extra data and options` and point cross-references at the new sections
- drop the `--initial-prices-file` suggestion from the market data error: that file is only read for stock-plan acquisitions
