### PR TITLE
Collapse first-pass dicts into FirstPassTotals

### DIFF
--- a/cgt_calc/income.py
+++ b/cgt_calc/income.py
@@ -138,7 +138,7 @@ class IncomeProcessor:
                 )
             ]
 
-    def dividend_source_country(
+    def _dividend_source_country(
         self, symbol: str, currency: CurrencyCode
     ) -> str | None:
         """Return the country a dividend was paid from, or None if unknown.
@@ -313,7 +313,7 @@ class IncomeProcessor:
                         "Cannot apply taxation treaty for bond fund %s", symbol
                     )
                 else:
-                    country = self.dividend_source_country(symbol, currency)
+                    country = self._dividend_source_country(symbol, currency)
                     if country is None:
                         LOGGER.warning(
                             "Source country of the %s dividend is unknown (ticker: %s), "

--- a/cgt_calc/ingestion.py
+++ b/cgt_calc/ingestion.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import Counter, defaultdict
+from dataclasses import dataclass
 from decimal import Decimal
 from fractions import Fraction
 import logging
@@ -213,6 +214,21 @@ def _match_gifts_to_rows(
                 return True
             available[reading] += 1
     return False
+
+
+@dataclass(frozen=True)
+class FirstPassTotals:
+    """Running totals the first pass reports at the end.
+
+    `dividends` and `dividends_tax` are keyed by (symbol, currency); the
+    rest by (broker, currency).
+    """
+
+    balance: dict[tuple[str, CurrencyCode], Decimal]
+    dividends: dict[tuple[str, CurrencyCode], Decimal]
+    dividends_tax: dict[tuple[str, CurrencyCode], Decimal]
+    interests: dict[tuple[str, CurrencyCode], Decimal]
+    interest_taxes: dict[tuple[str, CurrencyCode], Decimal]
 
 
 class TransactionIngester:
@@ -1645,21 +1661,16 @@ class TransactionIngester:
                 dividends_tax[symbol, tax.currency] += tax.amount
 
         self.first_pass_report(
-            balance,
-            dividends,
-            dividends_tax,
-            interests,
-            interest_taxes,
+            FirstPassTotals(
+                balance=balance,
+                dividends=dividends,
+                dividends_tax=dividends_tax,
+                interests=interests,
+                interest_taxes=interest_taxes,
+            )
         )
 
-    def first_pass_report(
-        self,
-        balance: dict[tuple[str, CurrencyCode], Decimal],
-        dividends: dict[tuple[str, CurrencyCode], Decimal],
-        dividends_tax: dict[tuple[str, CurrencyCode], Decimal],
-        interests: dict[tuple[str, CurrencyCode], Decimal],
-        interest_taxes: dict[tuple[str, CurrencyCode], Decimal],
-    ) -> None:
+    def first_pass_report(self, totals: FirstPassTotals) -> None:
         """Print the results of the first pass."""
         LOGGER.info(
             "\n%s\n",
@@ -1675,19 +1686,21 @@ class TransactionIngester:
             print(f"{bul}{stock}: {position}")
         print()
         print(style_text("Final balance", colour=Style.BRIGHT, emoji="💰"))
-        for (broker, currency), amount in balance.items():
+        for (broker, currency), amount in totals.balance.items():
             print(f"{bul}{broker}: {round_decimal(amount, 2)} ({currency})")
         # Withholding can arrive without income in the same run, so taxed
         # symbols are listed even when no dividend was paid. A tax-only
         # entry whose withholding rounds to 0.00, or is a net refund, has
         # nothing to display, so it is left out entirely.
-        keys = list(dividends)
-        keys += [key for key in dividends_tax if key not in dividends]
+        keys = list(totals.dividends)
+        keys += [key for key in totals.dividends_tax if key not in totals.dividends]
         dividend_lines = []
         for symbol, currency in keys:
-            amount = dividends.get((symbol, currency), Decimal(0))
-            tax = round_decimal(-dividends_tax.get((symbol, currency), Decimal(0)), 2)
-            if (symbol, currency) not in dividends and tax <= 0:
+            amount = totals.dividends.get((symbol, currency), Decimal(0))
+            tax = round_decimal(
+                -totals.dividends_tax.get((symbol, currency), Decimal(0)), 2
+            )
+            if (symbol, currency) not in totals.dividends and tax <= 0:
                 continue
             tax_str = f", excluding {tax} taxed at source" if tax > 0 else ""
             dividend_lines.append(
@@ -1698,15 +1711,15 @@ class TransactionIngester:
             print(style_text("Dividends", colour=Style.BRIGHT, emoji="💵"))
             for line in dividend_lines:
                 print(line)
-        if interests:
+        if totals.interests:
             print()
             print(style_text("Interest", colour=Style.BRIGHT, emoji="🏦"))
-            for (broker, currency), amount in interests.items():
+            for (broker, currency), amount in totals.interests.items():
                 print(f"{bul}{broker}: {round_decimal(amount, 2)} ({currency})")
-        if interest_taxes:
+        if totals.interest_taxes:
             print()
             print(style_text("Interest taxes", colour=Style.BRIGHT, emoji="🧾"))
-            for (broker, currency), amount in interest_taxes.items():
+            for (broker, currency), amount in totals.interest_taxes.items():
                 print(f"{bul}{broker}: {round_decimal(-amount, 2)} ({currency})")
         print()
 

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -22,7 +22,6 @@ from .model import (
     BrokerTransaction,
     CalculationLog,
     CapitalGainsReport,
-    CurrencyCode,
     ExcessReportedIncomeLog,
     HmrcTransactionLog,
     PortfolioEntry,
@@ -35,6 +34,7 @@ if TYPE_CHECKING:
 
     from .currency_converter import CurrencyConverter
     from .current_price_fetcher import CurrentPriceFetcher
+    from .ingestion import FirstPassTotals
     from .initial_prices import InitialPrices
     from .isin_converter import IsinConverter
     from .spin_off_handler import SpinOffHandler
@@ -159,18 +159,9 @@ class CapitalGainsCalculator:
         """Convert broker transactions to HMRC transactions."""
         self.ingester.convert_to_hmrc_transactions(transactions)
 
-    def first_pass_report(
-        self,
-        balance: dict[tuple[str, CurrencyCode], Decimal],
-        dividends: dict[tuple[str, CurrencyCode], Decimal],
-        dividends_tax: dict[tuple[str, CurrencyCode], Decimal],
-        interests: dict[tuple[str, CurrencyCode], Decimal],
-        interest_taxes: dict[tuple[str, CurrencyCode], Decimal],
-    ) -> None:
+    def first_pass_report(self, totals: FirstPassTotals) -> None:
         """Print the results of the first pass."""
-        self.ingester.first_pass_report(
-            balance, dividends, dividends_tax, interests, interest_taxes
-        )
+        self.ingester.first_pass_report(totals)
 
     def process_dividends(self) -> None:
         """Process all dividend events and taxes."""

--- a/tests/general/test_first_pass_report.py
+++ b/tests/general/test_first_pass_report.py
@@ -6,6 +6,7 @@ import pytest
 
 from cgt_calc.currency_converter import CurrencyConverter
 from cgt_calc.current_price_fetcher import CurrentPriceFetcher
+from cgt_calc.ingestion import FirstPassTotals
 from cgt_calc.initial_prices import InitialPrices
 from cgt_calc.isin_converter import IsinConverter
 from cgt_calc.main import CapitalGainsCalculator
@@ -36,7 +37,14 @@ def _dividend_lines(
     dividends_tax: dict[tuple[str, CurrencyCode], Decimal],
 ) -> list[str]:
     """Run the report and return the printed dividend lines."""
-    _calculator().first_pass_report({}, dividends, dividends_tax, {}, {})
+    totals = FirstPassTotals(
+        balance={},
+        dividends=dividends,
+        dividends_tax=dividends_tax,
+        interests={},
+        interest_taxes={},
+    )
+    _calculator().first_pass_report(totals)
     lines = capsys.readouterr().out.splitlines()
     header = next((i for i, line in enumerate(lines) if "Dividends" in line), None)
     if header is None:


### PR DESCRIPTION
Collapses the five parallel first-pass dicts into one dataclass and closes an internal-only method that was left public after the main.py split.

- Add frozen `FirstPassTotals` dataclass in `ingestion.py` (`balance`, `dividends`, `dividends_tax`, `interests`, `interest_taxes`)
- `TransactionIngester.first_pass_report` and the `CapitalGainsCalculator.first_pass_report` facade delegate now take the single `totals` object instead of five positional dicts
- Rename `IncomeProcessor.dividend_source_country` to `_dividend_source_country`; no external callers since #1061

No behavior change: first-pass output, logs, and exception text are byte-identical.