### PR TITLE
Link PyPI from the documentation footer

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -94,6 +94,11 @@ icon = "fontawesome/brands/github"
 link = "https://github.com/cgt-calc/capital-gains-calculator"
 name = "GitHub repository"
 
+[[project.extra.social]]
+icon = "simple/pypi"
+link = "https://pypi.org/project/cgt-calc/"
+name = "cgt-calc on PyPI"
+
 [project.markdown_extensions]
 admonition = {}
 tables = {}

--- a/zensical.toml
+++ b/zensical.toml
@@ -95,7 +95,7 @@ link = "https://github.com/cgt-calc/capital-gains-calculator"
 name = "GitHub repository"
 
 [[project.extra.social]]
-icon = "simple/pypi"
+icon = "fontawesome/brands/python"
 link = "https://pypi.org/project/cgt-calc/"
 name = "cgt-calc on PyPI"
 


### PR DESCRIPTION
Make the published package easier to find from the documentation.

- add a Python icon to the footer
- link it to the cgt-calc project on PyPI
- provide an accessible link name