### PR TITLE
Record every Interactive Brokers row in the account's base currency

### DIFF
--- a/cgt_calc/parsers/interactive_brokers.py
+++ b/cgt_calc/parsers/interactive_brokers.py
@@ -149,31 +149,45 @@ class InteractiveBrokersTransaction(BrokerTransaction):
         exchange_rate = (
             _parse_decimal(row, InteractiveBrokersColumn.EXCHANGE_RATE)
             if InteractiveBrokersColumn.EXCHANGE_RATE in row
-            else Decimal(1)
+            else None
         )
-
-        # The Gross/Net Amount and Commission columns are always in the account's base
-        # currency (GBP). When the Price is in a foreign currency, convert it to GBP so
-        # that the internal validation (quantity x price + fees ≈ |amount|) holds.
-        if price is not None and price_currency != "GBP" and exchange_rate is not None:
-            price = price * exchange_rate
-            price_currency = CurrencyCode("GBP")
 
         # An adjustment moves the cash balance and nothing else: the calculator
         # reads its amount and never its symbol, quantity or price. IBKR files a
         # Forex Trade Component under the currency pair and gives it both a
         # quantity and a price, so clear the columns that describe a security
-        # rather than leave a currency pair looking like a holding. All that is
-        # left is the Net Amount, which is in the account's base currency, so
-        # the transaction currency is that rather than whatever priced the leg:
-        # a row carrying Price Currency without an Exchange Rate keeps its
-        # foreign price_currency above and would otherwise move a USD balance.
+        # rather than leave a currency pair looking like a holding. Dropping the
+        # price before it is converted also keeps a pair priced in a currency
+        # the row states no rate for from being refused over a price nothing
+        # reads.
         if action is ActionType.ADJUSTMENT:
             symbol = None
             quantity = None
             price = None
             fees = Decimal(0)
-            price_currency = CurrencyCode("GBP")
+
+        # The Gross/Net Amount and Commission columns are always in the account's
+        # base currency (GBP), so that is the transaction's currency whatever
+        # priced the leg. Price Currency describes the price alone: convert a
+        # foreign price to the base currency where a rate is given. Only a Buy
+        # or Sell reads the price back, to check it against the amount
+        # (quantity x price + fees ≈ |amount|), so only those two are refused
+        # over a price nothing can convert; every other row's price is left
+        # foreign rather than blocking rows the calculator never checks it on.
+        if price is not None and price_currency != "GBP":
+            if exchange_rate is not None:
+                price = price * exchange_rate
+            elif action in {ActionType.BUY, ActionType.SELL}:
+                raise ParsingError(
+                    file_path,
+                    f"Price is in {price_currency} but the Exchange Rate column is "
+                    "missing or empty, so the price cannot be converted to the "
+                    "account's base currency (GBP), which Gross Amount, Commission "
+                    "and Net Amount are in. Re-export the statement with the "
+                    "Exchange Rate filled in for this row: a Buy or Sell always "
+                    "needs a price, so clearing it only trades this error for a "
+                    "missing-price one.",
+                )
 
         super().__init__(
             date=date,
@@ -184,7 +198,7 @@ class InteractiveBrokersTransaction(BrokerTransaction):
             price=price,
             fees=-fees,
             amount=amount,
-            currency=price_currency,
+            currency=CurrencyCode("GBP"),
             broker="Interactive Brokers",
             isin=_isin_from_description(row[InteractiveBrokersColumn.DESCRIPTION]),
         )

--- a/docs/brokers/interactive-brokers.md
+++ b/docs/brokers/interactive-brokers.md
@@ -64,9 +64,10 @@ The importer recognises these literal values from the CSV's `Transaction Type` c
 | `Adjustment`                  | Cash-balance adjustments such as `FX Translations P&L`       |
 | `Forex Trade Component`       | The base-currency net of a currency conversion; balance only |
 
-For a GBP-base account, IBKR reports gross amounts, commissions and net amounts in GBP. When the CSV
-also supplies `Price Currency` and `Exchange Rate`, cgt-calc converts a foreign-currency unit price
-to GBP before calculating the acquisition or disposal.
+For a GBP-base account, IBKR reports gross amounts, commissions and net amounts in GBP, so every row
+is recorded in GBP whatever the security is priced in. `Price Currency` describes the unit price
+alone: when the CSV also supplies an `Exchange Rate`, cgt-calc converts a foreign-currency unit
+price to GBP before calculating the acquisition or disposal.
 
 cgt-calc does not treat a currency conversion as a disposal. It applies the `Forex Trade Component`
 Net Amount to the cash balance and reports no gain or loss on the conversion itself.
@@ -100,6 +101,17 @@ treaty applies.
 
 The CSV says that the account's base currency is not GBP. Changing the text in the file would not
 convert any amounts, so use a GBP-base account export instead.
+
+### `Price is in ... but the Exchange Rate column is missing or empty`
+
+A `Buy` or `Sell` row prices the trade in a currency other than GBP but gives no rate to convert it
+with, while its gross amount, commission and net amount are in GBP. The price cannot be checked
+against the amount, and a guessed rate would put a wrong cost or proceeds in the report, so the
+import stops. Re-export the statement with the `Exchange Rate` column filled in for that row — a
+`Buy` or `Sell` always needs a price, so clearing `Price` and `Price Currency` only trades this
+error for a missing-price one. Other row types are unaffected: only a trade's price feeds the
+calculation, so a dividend, fee or interest row keeps a foreign, unconverted `Price Currency` rather
+than being refused over a price nothing reads.
 
 ### `Couldn't find Transaction History header`
 

--- a/tests/interactive_brokers/test_interactive_brokers.py
+++ b/tests/interactive_brokers/test_interactive_brokers.py
@@ -3,10 +3,12 @@
 from datetime import date
 from decimal import Decimal
 from pathlib import Path
+import re
 import subprocess
 
 import pytest
 
+from cgt_calc.exceptions import ParsingError
 from cgt_calc.model import ActionType, BrokerTransaction, CurrencyCode
 from cgt_calc.parsers.interactive_brokers import InteractiveBrokersParser
 from tests.utils import build_cmd, report_path, stderr_alerts
@@ -300,6 +302,144 @@ Transaction History,Header,Date,Account,Description,Transaction Type,Symbol,Quan
         assert transactions[0].action == ActionType.ADJUSTMENT
         assert transactions[0].currency == CurrencyCode("GBP")
         assert transactions[0].amount == Decimal("0.18")
+
+    @pytest.mark.parametrize("exchange_rate", ["-", "1.32"])
+    def test_priced_row_without_a_price_records_the_base_currency_amount(
+        self, tmp_path: Path, exchange_rate: str
+    ) -> None:
+        """Price Currency describes the price, not the Net Amount.
+
+        A dividend row can name the currency the security trades in while
+        stating no price of its own, with or without an Exchange Rate. Net
+        Amount is in the account's base currency either way, so the
+        transaction is in GBP and nothing is left to convert.
+        """
+        csv_file = tmp_path / "transactions.csv"
+        csv_file.write_text(
+            self.base_header_with_foreign_currency
+            + "Transaction History,Data,2025-10-02,U***00000,"
+            "VT(US9220427424) Cash Dividend,Dividend,VT,-,-,USD,100.0,-,100.0,"
+            f"{exchange_rate}\n"
+        )
+
+        transactions = InteractiveBrokersParser().load_from_file(csv_file)
+
+        assert len(transactions) == 1
+        assert transactions[0].currency == CurrencyCode("GBP")
+        assert transactions[0].amount == Decimal("100.0")
+        assert transactions[0].price is None
+
+    def test_dividend_priced_in_a_foreign_currency_is_not_converted(
+        self, tmp_path: Path
+    ) -> None:
+        """A base-currency dividend must not be reported in the price currency.
+
+        Taking Price Currency as the transaction currency filed a GBP 100
+        dividend as USD 100, moved a USD balance the account never held and
+        converted the proceeds down to about GBP 73.
+        """
+        csv_file = tmp_path / "transactions.csv"
+        csv_file.write_text(
+            self.base_header_with_foreign_currency
+            + "Transaction History,Data,2025-01-01,U***00000,"
+            "Electronic Fund Transfer,Deposit,-,-,-,-,1000.0,-,1000.0,-\n"
+            + "Transaction History,Data,2025-10-02,U***00000,"
+            "VT(US9220427424) Cash Dividend,Dividend,VT,-,-,USD,100.0,-,100.0,-\n"
+        )
+
+        cmd = build_cmd(
+            "--year",
+            "2025",
+            "--interactive-brokers-file",
+            str(csv_file),
+            "--output",
+            str(tmp_path / "out"),
+        )
+        result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
+        if result.returncode:
+            pytest.fail(
+                "Integration test failed\n"
+                f"stdout:\n{result.stdout}\n"
+                f"stderr:\n{result.stderr}"
+            )
+        assert stderr_alerts(result.stderr) == []
+        assert "(USD)" not in result.stdout
+        assert "Final balance\n  Interactive Brokers: 1100.00 (GBP)" in result.stdout
+        assert "VT: 100.00 (GBP)" in result.stdout
+        assert re.search(r"Proceeds:\s+£100\.00", result.stdout)
+
+    def test_foreign_price_without_an_exchange_rate_is_refused(
+        self, tmp_path: Path
+    ) -> None:
+        """A price nothing can convert cannot be checked against the amount.
+
+        The amount columns are in GBP, so a EUR price with no Exchange Rate
+        would fail the quantity x price + fees check anyway. Say why instead
+        of guessing a rate or dropping the price.
+        """
+        csv_file = tmp_path / "transactions.csv"
+        csv_file.write_text(
+            self.base_header_with_foreign_currency
+            + "Transaction History,Data,2023-02-10,U***9143,"
+            "ISHARES MSCI WORLD EUR-H,Buy,IWDE,217,67.71,EUR,"
+            "-13009.5380394,-6.5047690197,-13016.0428084197,-\n"
+        )
+
+        with pytest.raises(ParsingError) as excinfo:
+            InteractiveBrokersParser().load_from_file(csv_file)
+
+        assert "Price is in EUR" in str(excinfo.value)
+        assert "Exchange Rate" in str(excinfo.value)
+
+    def test_foreign_price_without_an_exchange_rate_column_is_refused(
+        self, tmp_path: Path
+    ) -> None:
+        """Price Currency and Exchange Rate are independent optional columns.
+
+        A header can carry the first and not the second. Reading the missing
+        column as a 1:1 rate would pass a EUR price off as a GBP one, so such
+        a row is refused just like one whose Exchange Rate is empty.
+        """
+        header = self.base_header_with_foreign_currency.replace(
+            ",Exchange Rate\n", "\n"
+        )
+        assert "Exchange Rate" not in header
+        csv_file = tmp_path / "transactions.csv"
+        csv_file.write_text(
+            header + "Transaction History,Data,2023-02-10,U***9143,"
+            "ISHARES MSCI WORLD EUR-H,Buy,IWDE,217,67.71,EUR,"
+            "-13009.5380394,-6.5047690197,-13016.0428084197\n"
+        )
+
+        with pytest.raises(ParsingError) as excinfo:
+            InteractiveBrokersParser().load_from_file(csv_file)
+
+        assert "Price is in EUR" in str(excinfo.value)
+        assert "Exchange Rate" in str(excinfo.value)
+
+    def test_foreign_priced_fee_without_an_exchange_rate_is_not_refused(
+        self, tmp_path: Path
+    ) -> None:
+        """Only a Buy or Sell reads the price back to check it against the amount.
+
+        add_management_fee never reads a fee row's price, so a Price Currency
+        with no Exchange Rate to convert it is left as is rather than refusing
+        a row the calculation does not check it on.
+        """
+        csv_file = tmp_path / "transactions.csv"
+        csv_file.write_text(
+            self.base_header_with_foreign_currency
+            + "Transaction History,Data,2025-10-03,U***00000,"
+            "CNX1 ADR Fee,Other Fee,CNX1,-,1.5,USD,-1.5,-,-1.5,-\n"
+        )
+
+        transactions = InteractiveBrokersParser().load_from_file(csv_file)
+
+        assert len(transactions) == 1
+        assert transactions[0].action == ActionType.FEE
+        assert transactions[0].currency == CurrencyCode("GBP")
+        assert transactions[0].amount == Decimal("-1.5")
+        assert transactions[0].price == Decimal("1.5")
 
     def test_forex_trade_component_leaves_no_fee_in_the_report(
         self, tmp_path: Path


### PR DESCRIPTION
Fixes #1006

`InteractiveBrokersTransaction` used Price Currency as the transaction currency, but Gross Amount, Commission and Net Amount are always in the account's base currency (GBP). An extended-format row naming a foreign Price Currency with an empty Price or Exchange Rate kept `price_currency` foreign, so it was handed on as the transaction currency while a GBP amount was applied to it. A GBP 100 dividend with Price Currency USD and no Exchange Rate was reported as USD 100 and converted down to about GBP 73.

- Always construct the transaction in GBP; Price Currency now describes only the unit price.
- Refuse a `Buy` or `Sell` that prices the trade in a foreign currency without an Exchange Rate: only a trade's price feeds the calculation, so the check applies there and leaves other rows alone. The error says to re-export with the rate filled in, since a `Buy` or `Sell` always needs a price.
- Clear an adjustment's price before conversion, so a `Forex Trade Component` priced in a currency the row states no rate for is not refused over a price the calculator never reads.
- Removed the `ADJUSTMENT`-only GBP override, which is now redundant since every row is built in the base currency.
- Documented the transaction currency and the new error in `docs/brokers/interactive-brokers.md`.