### PR TITLE
Order a Revolut row against a same-day reorganisation

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -216,6 +216,7 @@ transferor
 transferor's
 txn
 ty
+tzinfo
 UCITS
 un
 unmapped

--- a/cgt_calc/ingestion.py
+++ b/cgt_calc/ingestion.py
@@ -606,7 +606,9 @@ class TransactionIngester:
             placement = relative_to_split(instants, row.source, other.source)
             if placement is None:
                 raise CalculationError(
-                    self._split_chronology_message(symbol, date_index, row, other)
+                    self._split_chronology_message(
+                        symbol, date_index, row, other, instants
+                    )
                 )
             (before_rows if placement == "before" else after_rows).append(other)
 
@@ -1800,14 +1802,34 @@ class TransactionIngester:
         date_index: datetime.date,
         row: BrokerTransaction,
         other: BrokerTransaction,
+        instants: tuple[datetime.datetime, ...],
     ) -> str:
-        """Explain why a same-day row cannot be placed around a reorganisation."""
-        return (
+        """Explain why a same-day row cannot be placed around a reorganisation.
+
+        Times the export does state are not always enough, so the reason has
+        to say which of the two situations this is. Telling someone whose
+        export already states its times to supply times would send them
+        looking for a file that does not exist.
+        """
+        preamble = (
             f"Cannot apply the reorganisation of {symbol} on {date_index}: "
             f"this row is on the same day and cannot be placed either side of "
             f"it, so there is no telling whether its count is stated in the "
             f"units before or after:\n  {other}\n"
             f"The reorganisation is:\n  {row}\n"
+        )
+        stated = other.source is not None and other.source.timestamp is not None
+        if len(instants) == 1 and stated:
+            return preamble + (
+                "Both rows state their times, but the reorganisation is a "
+                "single row, and the instant on it is when the broker booked "
+                "the entry rather than when the units changed: a share trades "
+                "in the new units from the opening of the ex-date, which need "
+                "not be when the broker wrote the row. Anything the export "
+                "booked after that row is in the new units; this row was not. "
+                "Work the day out by hand (consider professional advice)."
+            )
+        return preamble + (
             "The two come from different inputs, or from an export that gives "
             "neither times nor a documented order, or the row falls between "
             "the two halves of the reorganisation. Run again with the day's "

--- a/cgt_calc/ingestion.py
+++ b/cgt_calc/ingestion.py
@@ -97,14 +97,28 @@ def relative_to_split(
     stable ordering and its action priorities for gifts, spouse transfers and
     vests are calculation plumbing rather than evidence of corporate-action
     chronology. Returns None when it cannot be told.
+
+    What a lone instant proves is one-sided. An export that states the whole
+    holding on both sides of the event brackets the restatement in the
+    broker's own books, and its own counts are what the ratio comes from, so
+    a row outside that bracket is placed against a figure the broker stated.
+    An export that posts the event as one row states only when it booked the
+    entry: everything after it is in the new units, because the holding had
+    already been restated when the row was written, but a row before it may
+    have traded in either unit system - the market restates at the opening of
+    the ex-date, and nothing says the broker's book-keeping ran to the same
+    clock. Guessing there would not merely misplace that row: a single row
+    states a net change, so `before_quantity` is whatever was placed ahead of
+    it and the corporate ratio is derived from that. One row on the wrong
+    side rewrites the ratio for the entire holding.
     """
     if instants and other_source is not None and other_source.timestamp is not None:
-        if other_source.timestamp < min(instants):
-            return "before"
         if other_source.timestamp > max(instants):
             return "after"
-        # At or between the two halves of the reorganisation, where neither
-        # unit system can be proved.
+        if len(instants) > 1 and other_source.timestamp < min(instants):
+            return "before"
+        # At or between the two halves of the reorganisation, or ahead of a
+        # lone booking instant: no unit system can be proved.
         return None
     if (
         split_source is not None

--- a/cgt_calc/parsers/base_parsers.py
+++ b/cgt_calc/parsers/base_parsers.py
@@ -272,7 +272,14 @@ class StandardCSVParser[T: BrokerTransaction](BaseSingleFileParser[T]):
                     )
                 transaction = cls.read_row(row, file_path)
                 if transaction:
-                    transaction.source = TransactionSource(row=index)
+                    # Whatever `read_row` recorded is kept, because it knows
+                    # what the row itself stated and this only adds the line
+                    # it came from. Replacing the source outright would drop
+                    # an exported instant, which is the only evidence that
+                    # can order two rows sharing a date.
+                    transaction.source = dataclasses.replace(
+                        transaction.source or TransactionSource(), row=index
+                    )
                     transactions.append(transaction)
             except ParsingError as err:
                 err.add_row_context(index)

--- a/cgt_calc/parsers/revolut.py
+++ b/cgt_calc/parsers/revolut.py
@@ -13,7 +13,12 @@ from typing import TYPE_CHECKING, ClassVar, Final, Literal, TextIO, overload, ov
 
 from cgt_calc.const import TICKER_RENAMES, UK_TIMEZONE
 from cgt_calc.exceptions import ParsingError
-from cgt_calc.model import ActionType, BrokerTransaction, CurrencyCode
+from cgt_calc.model import (
+    ActionType,
+    BrokerTransaction,
+    CurrencyCode,
+    TransactionSource,
+)
 
 from .base_parsers import StandardCSVParser
 
@@ -40,12 +45,13 @@ HEADER_LINE: Final = ",".join(COLUMNS) + "\n"
 LOGGER = logging.getLogger(__name__)
 
 
-def _parse_date(value: str) -> datetime.date:
-    """Convert a Revolut timestamp to the UK date it fell on.
+def _parse_timestamp(value: str) -> datetime.datetime:
+    """Convert a Revolut timestamp to the UK instant it fell on.
 
     The export states its times in UTC, so a value without a zone is read
     as UTC too rather than as the machine's local time. The date that
-    drives the tax year and the matching rules is the UK one.
+    drives the tax year and the matching rules is the UK one, so the
+    instant is stated in UK time and the date taken from it.
     """
 
     try:
@@ -54,7 +60,7 @@ def _parse_date(value: str) -> datetime.date:
         raise ValueError(f"Invalid timestamp: {value!r}") from err
     if timestamp.tzinfo is None:
         timestamp = timestamp.replace(tzinfo=datetime.UTC)
-    return timestamp.astimezone(UK_TIMEZONE).date()
+    return timestamp.astimezone(UK_TIMEZONE)
 
 
 def _action_from_str(label: str, file: Path) -> ActionType:
@@ -154,7 +160,7 @@ class RevolutTransaction(BrokerTransaction):
     ):
         """Create transaction from a CSV row keyed by column name."""
         currency = CurrencyCode(row[RevolutColumn.CURRENCY])
-        date = _parse_date(row[RevolutColumn.DATE])
+        timestamp = _parse_timestamp(row[RevolutColumn.DATE])
         description = row[RevolutColumn.ACTION]
         action = _action_from_str(description, file)
         symbol = row[RevolutColumn.TICKER] or None
@@ -175,7 +181,7 @@ class RevolutTransaction(BrokerTransaction):
             price = total / quantity  # override CSV's rounding
         amount = -total if action is ActionType.BUY else total
         super().__init__(
-            date,
+            timestamp.date(),
             action,
             symbol,
             description,
@@ -186,6 +192,10 @@ class RevolutTransaction(BrokerTransaction):
             currency,
             "Revolut",
         )
+        # The export times every row, which is what tells the calculation
+        # whether a row sharing a date with a share reorganisation happened
+        # before or after it.
+        self.source = TransactionSource(timestamp=timestamp)
 
 
 class RevolutParser(StandardCSVParser[RevolutTransaction]):

--- a/cgt_calc/parsers/revolut.py
+++ b/cgt_calc/parsers/revolut.py
@@ -46,12 +46,16 @@ LOGGER = logging.getLogger(__name__)
 
 
 def _parse_timestamp(value: str) -> datetime.datetime:
-    """Convert a Revolut timestamp to the UK instant it fell on.
+    """Convert a Revolut timestamp to the instant it names, in UTC.
 
     The export states its times in UTC, so a value without a zone is read
-    as UTC too rather than as the machine's local time. The date that
-    drives the tax year and the matching rules is the UK one, so the
-    instant is stated in UK time and the date taken from it.
+    as UTC too rather than as the machine's local time. The instant is kept
+    in UTC rather than in UK time because two aware datetimes sharing one
+    `tzinfo` are compared by their wall clocks, ignoring `fold`: stated in
+    London, 00:30 UTC on the morning the clocks go back reads as 01:30 BST
+    and compares as later than 01:15 GMT, which is the instant 45 minutes
+    after it. The date is taken in UK time, where the tax year and the
+    matching rules are counted.
     """
 
     try:
@@ -60,7 +64,7 @@ def _parse_timestamp(value: str) -> datetime.datetime:
         raise ValueError(f"Invalid timestamp: {value!r}") from err
     if timestamp.tzinfo is None:
         timestamp = timestamp.replace(tzinfo=datetime.UTC)
-    return timestamp.astimezone(UK_TIMEZONE)
+    return timestamp.astimezone(datetime.UTC)
 
 
 def _action_from_str(label: str, file: Path) -> ActionType:
@@ -181,7 +185,7 @@ class RevolutTransaction(BrokerTransaction):
             price = total / quantity  # override CSV's rounding
         amount = -total if action is ActionType.BUY else total
         super().__init__(
-            timestamp.date(),
+            timestamp.astimezone(UK_TIMEZONE).date(),
             action,
             symbol,
             description,

--- a/tests/general/test_stock_splits.py
+++ b/tests/general/test_stock_splits.py
@@ -2220,6 +2220,65 @@ def test_a_row_stamped_after_the_event_is_left_alone() -> None:
     assert calculator.portfolio["FOO"].amount == Decimal(120)
 
 
+def test_a_row_stamped_before_a_lone_booking_instant_is_refused() -> None:
+    """One row states when the event was booked, not when the units changed.
+
+    A market restates at the opening of the ex-date and nothing says the
+    broker's book-keeping ran to the same clock, so a row ahead of a single
+    posted instant may have been made in either unit system. Placing it would
+    not merely misstate that row: a single row states a net change, so the
+    ratio for the whole holding is derived from what was placed before it.
+    """
+    with pytest.raises(CalculationError, match="cannot be placed either side"):
+        run(
+            [
+                trade(POOL_DAY, ActionType.BUY, "FOO", "10", "10"),
+                trade(
+                    EVENT_DAY,
+                    ActionType.BUY,
+                    "FOO",
+                    "2",
+                    "10",
+                    source=_stamped(SPLIT_OPENED - datetime.timedelta(minutes=1)),
+                ),
+                legacy_split(EVENT_DAY, "FOO", "10", source=_stamped(SPLIT_OPENED)),
+            ]
+        )
+
+
+def test_a_row_stamped_after_a_lone_booking_instant_is_left_alone() -> None:
+    """What a lone instant does prove is that the holding was already restated.
+
+    The broker wrote the row against the new count, so anything it booked
+    later is stated in the new units too.
+    """
+    calculator = run(
+        [
+            trade(
+                POOL_DAY,
+                ActionType.BUY,
+                "FOO",
+                "10",
+                "10",
+                source=_stamped(SPLIT_OPENED - datetime.timedelta(days=1)),
+            ),
+            legacy_split(EVENT_DAY, "FOO", "10", source=_stamped(SPLIT_OPENED)),
+            trade(
+                EVENT_DAY,
+                ActionType.BUY,
+                "FOO",
+                "2",
+                "10",
+                source=_stamped(SPLIT_CLOSED + datetime.timedelta(minutes=1)),
+            ),
+        ]
+    )
+    # Ten doubled to twenty, and the two bought after that are already twenty's
+    # units.
+    assert calculator.portfolio["FOO"].quantity == Decimal(22)
+    assert calculator.portfolio["FOO"].amount == Decimal(120)
+
+
 def test_a_day_that_sells_more_than_it_can_give_is_refused() -> None:
     """The day's own ledger has to survive the reorganisation."""
     with pytest.raises(CalculationError, match="would leave -10 units"):

--- a/tests/general/test_stock_splits.py
+++ b/tests/general/test_stock_splits.py
@@ -2229,7 +2229,7 @@ def test_a_row_stamped_before_a_lone_booking_instant_is_refused() -> None:
     not merely misstate that row: a single row states a net change, so the
     ratio for the whole holding is derived from what was placed before it.
     """
-    with pytest.raises(CalculationError, match="cannot be placed either side"):
+    with pytest.raises(CalculationError, match="cannot be placed either side") as error:
         run(
             [
                 trade(POOL_DAY, ActionType.BUY, "FOO", "10", "10"),
@@ -2244,6 +2244,11 @@ def test_a_row_stamped_before_a_lone_booking_instant_is_refused() -> None:
                 legacy_split(EVENT_DAY, "FOO", "10", source=_stamped(SPLIT_OPENED)),
             ]
         )
+    message = str(error.value)
+    assert "the instant on it is when the broker booked the entry" in message
+    # Both rows state their times, so asking for times would send the reader
+    # after a file that does not exist.
+    assert "in one input that states times" not in message
 
 
 def test_a_row_stamped_after_a_lone_booking_instant_is_left_alone() -> None:

--- a/tests/revolut/test_revolut.py
+++ b/tests/revolut/test_revolut.py
@@ -1,7 +1,7 @@
 """Test Revolut support."""
 
 import csv
-from datetime import date
+from datetime import UTC, date, datetime
 from decimal import Decimal
 import logging
 from pathlib import Path
@@ -341,3 +341,78 @@ def test_read_revolut_transactions_unknown_action(tmp_path: Path) -> None:
 
     with pytest.raises(ParsingError, match=", row 2: Unknown action: SPIN-OFF"):
         RevolutParser().load_from_file(path)
+
+
+def test_read_revolut_transactions_keep_the_exported_instant(tmp_path: Path) -> None:
+    """The export times every row, and the time is what orders a busy day."""
+    path = _write_csv(
+        tmp_path, [_default_row({RevolutColumn.DATE: "2021-11-02T12:34:56.789012Z"})]
+    )
+
+    (transaction,) = RevolutParser().load_from_file(path)
+
+    assert transaction.source is not None
+    assert transaction.source.timestamp == datetime(
+        2021, 11, 2, 12, 34, 56, 789012, tzinfo=UTC
+    )
+    # And the line the row came from is still recorded next to it.
+    assert transaction.source.row == 2
+
+
+def test_run_with_a_trade_before_a_same_day_split(
+    request: pytest.FixtureRequest, tmp_path: Path
+) -> None:
+    """A share bought hours before a split is pooled in pre-split units.
+
+    Nothing but the exported times can say which side of the reorganisation
+    the purchase falls on, so a run that discarded them would refuse the day.
+    """
+    path = _write_csv(
+        tmp_path,
+        [
+            _default_row(
+                {
+                    RevolutColumn.DATE: "2021-01-04T10:00:00.000000Z",
+                    RevolutColumn.TICKER: "",
+                    RevolutColumn.ACTION: "CASH TOP-UP",
+                    RevolutColumn.QUANTITY: "",
+                    RevolutColumn.PRICE_PER_SHARE: "",
+                    RevolutColumn.TOTAL_AMOUNT: "USD 20000",
+                }
+            ),
+            _default_row(
+                {
+                    RevolutColumn.DATE: "2021-07-20T09:00:00.000000Z",
+                    RevolutColumn.TICKER: "NVDA",
+                    RevolutColumn.ACTION: "BUY - MARKET",
+                    RevolutColumn.QUANTITY: "2",
+                    RevolutColumn.PRICE_PER_SHARE: "USD 500",
+                    RevolutColumn.TOTAL_AMOUNT: "USD 1000",
+                }
+            ),
+            _default_row(
+                {
+                    RevolutColumn.DATE: "2021-07-20T10:34:52.000000Z",
+                    RevolutColumn.TICKER: "NVDA",
+                    RevolutColumn.ACTION: "STOCK SPLIT",
+                    RevolutColumn.QUANTITY: "36",
+                    RevolutColumn.PRICE_PER_SHARE: "",
+                    RevolutColumn.TOTAL_AMOUNT: "USD 0",
+                }
+            ),
+        ],
+    )
+    cmd = build_cmd(
+        "--year",
+        "2021",
+        "--revolut-file",
+        str(path),
+        "--output",
+        report_path(request),
+    )
+
+    result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
+
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    # Two shares became 38 rather than the day being refused.
+    assert "NVDA: 38.00" in result.stdout

--- a/tests/revolut/test_revolut.py
+++ b/tests/revolut/test_revolut.py
@@ -359,45 +359,85 @@ def test_read_revolut_transactions_keep_the_exported_instant(tmp_path: Path) -> 
     assert transaction.source.row == 2
 
 
-def test_run_with_a_trade_before_a_same_day_split(
-    request: pytest.FixtureRequest, tmp_path: Path
+def test_read_revolut_transactions_order_across_the_autumn_clock_change(
+    tmp_path: Path,
 ) -> None:
-    """A share bought hours before a split is pooled in pre-split units.
+    """Instants are kept in UTC, where the clocks going back cannot reorder them.
 
-    Nothing but the exported times can say which side of the reorganisation
-    the purchase falls on, so a run that discarded them would refuse the day.
+    Two aware datetimes sharing one tzinfo are compared by their wall clocks,
+    ignoring `fold`. Stated in London the earlier of these reads as 01:30 BST
+    and the later as 01:15 GMT, so keeping them in UK time would put the
+    45 minutes between them the wrong way round.
     """
     path = _write_csv(
         tmp_path,
         [
+            _default_row({RevolutColumn.DATE: "2026-10-25T00:30:00.000000Z"}),
+            _default_row({RevolutColumn.DATE: "2026-10-25T01:15:00.000000Z"}),
+        ],
+    )
+
+    earlier, later = RevolutParser().load_from_file(path)
+
+    assert earlier.source is not None
+    assert later.source is not None
+    assert earlier.source.timestamp is not None
+    assert later.source.timestamp is not None
+    assert earlier.source.timestamp < later.source.timestamp
+    # And both fell on the same UK day, which is what the tax year counts.
+    assert earlier.date == later.date == date(2026, 10, 25)
+
+
+TOP_UP = {
+    RevolutColumn.DATE: "2021-01-04T10:00:00.000000Z",
+    RevolutColumn.TICKER: "",
+    RevolutColumn.ACTION: "CASH TOP-UP",
+    RevolutColumn.QUANTITY: "",
+    RevolutColumn.PRICE_PER_SHARE: "",
+    RevolutColumn.TOTAL_AMOUNT: "USD 20000",
+}
+OPENING_BUY = {
+    RevolutColumn.DATE: "2021-01-04T14:39:38.000000Z",
+    RevolutColumn.TICKER: "NVDA",
+    RevolutColumn.ACTION: "BUY - MARKET",
+    RevolutColumn.QUANTITY: "10",
+    RevolutColumn.PRICE_PER_SHARE: "USD 100",
+    RevolutColumn.TOTAL_AMOUNT: "USD 1000",
+}
+# NVIDIA's four-for-one split: ten shares became forty on 20 July 2021.
+SPLIT = {
+    RevolutColumn.DATE: "2021-07-20T10:34:52.000000Z",
+    RevolutColumn.TICKER: "NVDA",
+    RevolutColumn.ACTION: "STOCK SPLIT",
+    RevolutColumn.QUANTITY: "30",
+    RevolutColumn.PRICE_PER_SHARE: "",
+    RevolutColumn.TOTAL_AMOUNT: "USD 0",
+}
+
+
+def test_run_with_a_trade_after_a_same_day_split(
+    request: pytest.FixtureRequest, tmp_path: Path
+) -> None:
+    """A sale booked after the split is counted in the units it left behind.
+
+    The holding had already been restated when Revolut wrote the row, so the
+    eight shares sold are eight of the forty. Only the exported times say so,
+    and a run that discarded them would refuse the day.
+    """
+    path = _write_csv(
+        tmp_path,
+        [
+            _default_row(TOP_UP),
+            _default_row(OPENING_BUY),
+            _default_row(SPLIT),
             _default_row(
                 {
-                    RevolutColumn.DATE: "2021-01-04T10:00:00.000000Z",
-                    RevolutColumn.TICKER: "",
-                    RevolutColumn.ACTION: "CASH TOP-UP",
-                    RevolutColumn.QUANTITY: "",
-                    RevolutColumn.PRICE_PER_SHARE: "",
-                    RevolutColumn.TOTAL_AMOUNT: "USD 20000",
-                }
-            ),
-            _default_row(
-                {
-                    RevolutColumn.DATE: "2021-07-20T09:00:00.000000Z",
+                    RevolutColumn.DATE: "2021-07-20T14:00:00.000000Z",
                     RevolutColumn.TICKER: "NVDA",
-                    RevolutColumn.ACTION: "BUY - MARKET",
-                    RevolutColumn.QUANTITY: "2",
-                    RevolutColumn.PRICE_PER_SHARE: "USD 500",
-                    RevolutColumn.TOTAL_AMOUNT: "USD 1000",
-                }
-            ),
-            _default_row(
-                {
-                    RevolutColumn.DATE: "2021-07-20T10:34:52.000000Z",
-                    RevolutColumn.TICKER: "NVDA",
-                    RevolutColumn.ACTION: "STOCK SPLIT",
-                    RevolutColumn.QUANTITY: "36",
-                    RevolutColumn.PRICE_PER_SHARE: "",
-                    RevolutColumn.TOTAL_AMOUNT: "USD 0",
+                    RevolutColumn.ACTION: "SELL - MARKET",
+                    RevolutColumn.QUANTITY: "8",
+                    RevolutColumn.PRICE_PER_SHARE: "USD 25",
+                    RevolutColumn.TOTAL_AMOUNT: "USD 200",
                 }
             ),
         ],
@@ -414,5 +454,49 @@ def test_run_with_a_trade_before_a_same_day_split(
     result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
 
     assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-    # Two shares became 38 rather than the day being refused.
-    assert "NVDA: 38.00" in result.stdout
+    # Ten shares became forty, and eight of those forty were sold.
+    assert "NVDA: 32.00" in result.stdout
+
+
+def test_run_with_a_trade_before_a_same_day_split_is_refused(
+    request: pytest.FixtureRequest, tmp_path: Path
+) -> None:
+    """Revolut's split row says when it was booked, not when units changed.
+
+    A US share trades split-adjusted from the opening of the ex-date, which
+    need not be when Revolut posted the adjustment, so a purchase stamped
+    ahead of that row may have been made in either unit system. Nothing in
+    the export settles it, and guessing would rewrite the ratio derived for
+    the whole holding, so the day is refused.
+    """
+    path = _write_csv(
+        tmp_path,
+        [
+            _default_row(TOP_UP),
+            _default_row(OPENING_BUY),
+            _default_row(
+                {
+                    RevolutColumn.DATE: "2021-07-20T09:00:00.000000Z",
+                    RevolutColumn.TICKER: "NVDA",
+                    RevolutColumn.ACTION: "BUY - MARKET",
+                    RevolutColumn.QUANTITY: "2",
+                    RevolutColumn.PRICE_PER_SHARE: "USD 500",
+                    RevolutColumn.TOTAL_AMOUNT: "USD 1000",
+                }
+            ),
+            _default_row(SPLIT),
+        ],
+    )
+    cmd = build_cmd(
+        "--year",
+        "2021",
+        "--revolut-file",
+        str(path),
+        "--output",
+        report_path(request),
+    )
+
+    result = subprocess.run(cmd, capture_output=True, encoding="utf-8", check=False)
+
+    assert result.returncode != 0
+    assert "cannot be placed either side" in result.stderr

--- a/tests/revolut/test_revolut.py
+++ b/tests/revolut/test_revolut.py
@@ -500,3 +500,6 @@ def test_run_with_a_trade_before_a_same_day_split_is_refused(
 
     assert result.returncode != 0
     assert "cannot be placed either side" in result.stderr
+    assert "the instant on it is when the broker booked the entry" in result.stderr
+    # The export does state its times, so it must not be told to supply them.
+    assert "in one input that states times" not in result.stderr


### PR DESCRIPTION
Revolut stamps every row to the microsecond, but the parser kept only the UK date, so no row could be placed against a same-day stock split and the whole day was refused. Follow-up to #1027.

- `_parse_date` becomes `_parse_timestamp` and returns the instant in UTC; `RevolutTransaction` takes its UK date from that and records the instant in `TransactionSource.timestamp`.
- `StandardCSVParser.read_transactions` merges `row` into the source `read_row` built rather than replacing it, which is what `stamp_source` one class up already documents.
- `relative_to_split` takes a lone exported instant as proof only of what came after it. A single split row states when the broker booked the entry, not when the units changed, and `before_quantity` for such a row is whatever was placed ahead of it, so a wrong placement rewrites the ratio for the whole holding. A bracketing pair still settles both sides.
- The refusal for such a row explains that a lone instant is the broker's booking time rather than the unit boundary, instead of advising a timed input the user already supplied.

Rows ahead of a single split row are refused exactly as before; what changes is that a row booked after one now computes instead of failing the day.
