### PR TITLE
Normalise exchange ticker aliases and narrow the ISIN mapping error

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -128,9 +128,11 @@ nixpkgs
 nonblank
 noqa
 num
+NVD
 NVDA
 NVIDIA
 OCI
+OpenFIGI
 OPRA
 OSError
 OTGLY
@@ -233,5 +235,6 @@ ValueError
 VanguardTransaction
 VTI
 worktree
+Xetra
 xtrackers
 yfinance

--- a/.harper-ignore.txt
+++ b/.harper-ignore.txt
@@ -37,3 +37,6 @@
 # "Trading 212's timestamp" is possessive; Harper reads the digits as the
 # end of a sentence and the "s" as a word of its own.
 ^trading212\.py:.*`s`
+# The ISIN in the comment on the exchange-alias table, naming the security
+# whose ticker code the sentence is about.
+^const\.py:.*`US67066G1040`

--- a/cgt_calc/const.py
+++ b/cgt_calc/const.py
@@ -12,7 +12,7 @@ from zoneinfo import ZoneInfo
 
 from dateutil.relativedelta import relativedelta
 
-from .model import TaxTreaty
+from .model import Isin, TaxTreaty
 
 # =============================================================================
 # Allowances
@@ -126,6 +126,18 @@ ERI_TAX_DATE_DELTA: Final = relativedelta(months=6)
 
 TICKER_RENAMES: Final[dict[str, str]] = {
     "FB": "META",
+}
+
+# Exchange-specific tickers for one security, mapped to the ticker the report
+# uses. Trading 212 lists the Xetra line of a US share under its German code,
+# so one holding arrives under two names and pools, matches and prices as two.
+# Keyed by ISIN as well as ticker, and deliberately not in TICKER_RENAMES: a
+# ticker code belongs to an exchange rather than to a security, so `NVD` is
+# NVDA only under US67066G1040, and TICKER_RENAMES is applied at parse time,
+# before any ISIN is known. Add a pair only once both listings are confirmed.
+ISIN_TICKER_ALIASES: Final[dict[tuple[Isin, str], str]] = {
+    (Isin("US67066G1040"), "NVD"): "NVDA",
+    (Isin("US11135F1012"), "1YD"): "AVGO",
 }
 
 # For ActionType.RENAME: set symbol=new_ticker, description=f"{RENAME_DESCRIPTION_PREFIX}{old_ticker}"

--- a/cgt_calc/isin_converter.py
+++ b/cgt_calc/isin_converter.py
@@ -115,6 +115,16 @@ class IsinConverter:
                     )
                 reverse_cache[symbol] = isin
 
+    def _isin_for_symbol(self, symbol: str) -> Isin | None:
+        """Return the one reference ISIN a ticker is known under, if any.
+
+        validate_data() guarantees at most one, so a match is unambiguous.
+        """
+        return next(
+            (isin for isin, symbols in self.data.items() if symbol in symbols),
+            None,
+        )
+
     def add_from_transaction(self, transaction: BrokerTransaction) -> None:
         """Normalise the transaction's ticker and record what it links to.
 
@@ -122,66 +132,72 @@ class IsinConverter:
         rest of the calculation reads, so the holding pools, matches and
         prices under one ticker instead of one per listing.
 
-        Anything else is recorded as this run's name for the ISIN. Only two
-        transactions disagreeing are refused, in either direction: one ISIN
+        A row without an ISIN is still checked when reference data already
+        ties its ticker to exactly one: a broker that never reports an ISIN
+        would otherwise let a holding split past every check below just by
+        leaving the field blank.
+
+        Anything else is recorded as this run's name for the ISIN. Two
+        transactions disagreeing is refused, in either direction: one ISIN
         arriving under two tickers, which splits its pool, and one ticker
         arriving under two ISINs, which pools two securities as one. A ticker
-        that merely differs from reference data - the bundled table, an
-        OpenFIGI result, the user's cache - does neither, and refusing it
-        turned a stale cache row from an earlier run into a failure of an
-        otherwise correct one.
+        that merely differs from reference data for the SAME ISIN does
+        neither, and refusing it turned a stale cache row from an earlier run
+        into a failure of an otherwise correct one - so only that direction
+        excuses a reference-only mismatch. The other direction stays refused
+        even against reference data: validate_data() already guarantees one
+        ISIN per ticker there, so a transaction reusing a ticker reference
+        already gave to a different security is exactly the case this check
+        exists for, not a stale row to look past.
         """
-        if not transaction.symbol or not transaction.isin:
+        if not transaction.symbol:
             return
 
-        canonical = ISIN_TICKER_ALIASES.get((transaction.isin, transaction.symbol))
-        if canonical is not None:
-            LOGGER.debug(
-                "ISIN %s: reporting exchange alias %s as %s",
-                transaction.isin,
-                transaction.symbol,
-                canonical,
-            )
-            transaction.symbol = canonical
+        isin = transaction.isin
+        if isin is not None:
+            canonical = ISIN_TICKER_ALIASES.get((isin, transaction.symbol))
+            if canonical is not None:
+                LOGGER.debug(
+                    "ISIN %s: reporting exchange alias %s as %s",
+                    isin,
+                    transaction.symbol,
+                    canonical,
+                )
+                transaction.symbol = canonical
+        else:
+            isin = self._isin_for_symbol(transaction.symbol)
+            if isin is None:
+                return
 
-        recorded = self.transaction_symbols.get(transaction.isin) or set()
-        known = self.data.get(transaction.isin) or set()
+        symbol = transaction.symbol
+        recorded = self.transaction_symbols.get(isin) or set()
+        known = self.data.get(isin) or set()
         # Reference data listing all of them on one row is a security known by
         # several names rather than two exports disagreeing. Those holdings
         # pool separately, as they always have: that is a wider problem than
         # this check, and failing here would not choose a ticker for them.
-        if (
-            recorded
-            and transaction.symbol not in recorded
-            and not recorded | {transaction.symbol} <= known
-        ):
+        if recorded and symbol not in recorded and not recorded | {symbol} <= known:
             raise InvalidTransactionError(
                 transaction,
-                f"Ticker {transaction.symbol} does not match "
+                f"Ticker {symbol} does not match "
                 f"{', '.join(sorted(recorded))}, used by another transaction for "
-                f"ISIN {transaction.isin}. One security under two tickers would "
+                f"ISIN {isin}. One security under two tickers would "
                 "be pooled and matched as two holdings. Check the exports; if "
                 "both are listings of the same security, report the ISIN and "
                 "both tickers so the pair can be added",
             )
 
-        # The other direction. Reference data cannot vouch for this one:
-        # validate_data already rules out a ticker linked to two ISINs there,
-        # so a second claim on one can only be two exports disagreeing.
-        owner = self.transaction_isins.get(transaction.symbol)
-        if owner is not None and owner != transaction.isin:
+        owner = self.transaction_isins.get(symbol) or self._isin_for_symbol(symbol)
+        if owner is not None and owner != isin:
             raise InvalidTransactionError(
                 transaction,
-                f"Ticker {transaction.symbol} is already used by another "
-                f"transaction for ISIN {owner}, so it cannot also stand for "
-                f"ISIN {transaction.isin}. Two securities under one ticker "
-                "would be pooled and matched as one holding",
+                f"Ticker {symbol} is already used for ISIN {owner}, so it "
+                f"cannot also stand for ISIN {isin}. Two securities under one "
+                "ticker would be pooled and matched as one holding",
             )
 
-        self.transaction_symbols.setdefault(transaction.isin, set()).add(
-            transaction.symbol
-        )
-        self.transaction_isins[transaction.symbol] = transaction.isin
+        self.transaction_symbols.setdefault(isin, set()).add(symbol)
+        self.transaction_isins[symbol] = isin
 
     def get_symbols(self, isin: Isin) -> set[str]:
         """Return the set of symbols associated with the input ISIN (may be empty).

--- a/cgt_calc/isin_converter.py
+++ b/cgt_calc/isin_converter.py
@@ -14,7 +14,12 @@ from pyrate_limiter.abstracts.rate import Duration
 from pyrate_limiter.extras.requests_limiter import RateLimitedRequestsSession
 from requests import exceptions as requests_exceptions
 
-from .const import CGT_MODE, INITIAL_ISIN_TRANSLATION_RESOURCE, RuntimeMode
+from .const import (
+    CGT_MODE,
+    INITIAL_ISIN_TRANSLATION_RESOURCE,
+    ISIN_TICKER_ALIASES,
+    RuntimeMode,
+)
 from .exceptions import (
     ExternalApiError,
     InvalidTransactionError,
@@ -73,8 +78,20 @@ class IsinConverter:
         )
         self.session = RateLimitedRequestsSession(limiter)
         self.isin_translation_file = isin_translation_file
+        # Reference data: the bundled table, the user's cache file and live
+        # OpenFIGI results. One consistent set of mappings, which is what
+        # validate_data checks, so the tickers this run's transactions carry
+        # are kept out of it and tracked below instead.
         self.data: dict[Isin, set[str]] = {}
+        # The subset written back to the cache file. That file caches OpenFIGI
+        # lookups; a ticker learned from a transaction stored there is what
+        # makes one run's holding conflict with the next run's.
         self.write_data: dict[Isin, set[str]] = {}
+        # The tickers this run's transactions carry, and the reverse index.
+        # Two transactions disagreeing about a security is the one case where
+        # a pool really splits, and the only one refused here.
+        self.transaction_symbols: dict[Isin, set[str]] = {}
+        self.transaction_isins: dict[str, Isin] = {}
         self._read_isin_translation_data()
         self.validate_data()
 
@@ -99,33 +116,88 @@ class IsinConverter:
                 reverse_cache[symbol] = isin
 
     def add_from_transaction(self, transaction: BrokerTransaction) -> None:
-        """Add the ISIN to symbol mapping from an existing transaction."""
-        if transaction.symbol and transaction.isin:
-            current_symbols = self.data.get(transaction.isin)
-            if current_symbols and transaction.symbol not in current_symbols:
-                raise InvalidTransactionError(
-                    transaction,
-                    f"Ticker {transaction.symbol} does not match existing mapping: "
-                    f"ISIN {transaction.isin} is linked to {', '.join(sorted(current_symbols))}",
-                )
+        """Normalise the transaction's ticker and record what it links to.
 
-            if transaction.symbol not in (current_symbols or set()):
-                self.data.setdefault(transaction.isin, set()).add(transaction.symbol)
-                self.write_data.setdefault(transaction.isin, set()).add(
-                    transaction.symbol
-                )
-                self._write_isin_translation_file()
+        A known exchange alias is rewritten in place, on the transaction the
+        rest of the calculation reads, so the holding pools, matches and
+        prices under one ticker instead of one per listing.
+
+        Anything else is recorded as this run's name for the ISIN. Only two
+        transactions disagreeing are refused, in either direction: one ISIN
+        arriving under two tickers, which splits its pool, and one ticker
+        arriving under two ISINs, which pools two securities as one. A ticker
+        that merely differs from reference data - the bundled table, an
+        OpenFIGI result, the user's cache - does neither, and refusing it
+        turned a stale cache row from an earlier run into a failure of an
+        otherwise correct one.
+        """
+        if not transaction.symbol or not transaction.isin:
+            return
+
+        canonical = ISIN_TICKER_ALIASES.get((transaction.isin, transaction.symbol))
+        if canonical is not None:
+            LOGGER.debug(
+                "ISIN %s: reporting exchange alias %s as %s",
+                transaction.isin,
+                transaction.symbol,
+                canonical,
+            )
+            transaction.symbol = canonical
+
+        recorded = self.transaction_symbols.get(transaction.isin) or set()
+        known = self.data.get(transaction.isin) or set()
+        # Reference data listing all of them on one row is a security known by
+        # several names rather than two exports disagreeing. Those holdings
+        # pool separately, as they always have: that is a wider problem than
+        # this check, and failing here would not choose a ticker for them.
+        if (
+            recorded
+            and transaction.symbol not in recorded
+            and not recorded | {transaction.symbol} <= known
+        ):
+            raise InvalidTransactionError(
+                transaction,
+                f"Ticker {transaction.symbol} does not match "
+                f"{', '.join(sorted(recorded))}, used by another transaction for "
+                f"ISIN {transaction.isin}. One security under two tickers would "
+                "be pooled and matched as two holdings. Check the exports; if "
+                "both are listings of the same security, report the ISIN and "
+                "both tickers so the pair can be added",
+            )
+
+        # The other direction. Reference data cannot vouch for this one:
+        # validate_data already rules out a ticker linked to two ISINs there,
+        # so a second claim on one can only be two exports disagreeing.
+        owner = self.transaction_isins.get(transaction.symbol)
+        if owner is not None and owner != transaction.isin:
+            raise InvalidTransactionError(
+                transaction,
+                f"Ticker {transaction.symbol} is already used by another "
+                f"transaction for ISIN {owner}, so it cannot also stand for "
+                f"ISIN {transaction.isin}. Two securities under one ticker "
+                "would be pooled and matched as one holding",
+            )
+
+        self.transaction_symbols.setdefault(transaction.isin, set()).add(
+            transaction.symbol
+        )
+        self.transaction_isins[transaction.symbol] = transaction.isin
 
     def get_symbols(self, isin: Isin) -> set[str]:
-        """Return the set of symbols associated with the input ISIN (may be empty)."""
+        """Return the set of symbols associated with the input ISIN (may be empty).
+
+        A ticker this run's transactions carry answers for the ISIN as well as
+        a stored one does, and spares the lookup.
+        """
+        recorded = self.transaction_symbols.get(isin) or set()
         result = self.data.get(isin)
-        if result is None:
+        if result is None and not recorded:
             result = self._fetch_live(isin)
             self.data[isin] = result
             if result:
                 self.write_data[isin] = result
                 self._write_isin_translation_file()
-        return result
+        return (result or set()) | recorded
 
     def get_symbol_to_isin_map(self) -> dict[str, Isin]:
         """Return a map from symbols to ISINs.
@@ -140,6 +212,9 @@ class IsinConverter:
             for symbol in symbols:
                 if symbol:
                     symbol_to_isin[symbol] = isin
+        # Last, so that a ticker this run's transactions carry outranks a
+        # stored row that gives it to another ISIN.
+        symbol_to_isin.update(self.transaction_isins)
         return symbol_to_isin
 
     def _read_isin_translation_data(self) -> None:
@@ -185,6 +260,10 @@ class IsinConverter:
             self.data.update(self.write_data)
 
     def _write_isin_translation_file(self) -> None:
+        # Over every reference source, not just the rows about to be written:
+        # the next run reads this file alongside the bundled table, so a
+        # looked-up ticker that another ISIN already owns has to be refused
+        # here rather than break that run's construction.
         self.validate_data()
         if self.isin_translation_file is None or CGT_MODE != RuntimeMode.PROD:
             return

--- a/cgt_calc/isin_converter.py
+++ b/cgt_calc/isin_converter.py
@@ -132,10 +132,12 @@ class IsinConverter:
         rest of the calculation reads, so the holding pools, matches and
         prices under one ticker instead of one per listing.
 
-        A row without an ISIN is still checked when reference data already
-        ties its ticker to exactly one: a broker that never reports an ISIN
-        would otherwise let a holding split past every check below just by
-        leaving the field blank.
+        A row without an ISIN is resolved from reference data first, when its
+        ticker already ties to exactly one, and then treated exactly like a
+        row that carried that ISIN - alias rewriting included. A broker that
+        never reports an ISIN would otherwise let a holding split past every
+        check below, and past the alias table, just by leaving the field
+        blank.
 
         Anything else is recorded as this run's name for the ISIN. Two
         transactions disagreeing is refused, in either direction: one ISIN
@@ -154,20 +156,20 @@ class IsinConverter:
             return
 
         isin = transaction.isin
-        if isin is not None:
-            canonical = ISIN_TICKER_ALIASES.get((isin, transaction.symbol))
-            if canonical is not None:
-                LOGGER.debug(
-                    "ISIN %s: reporting exchange alias %s as %s",
-                    isin,
-                    transaction.symbol,
-                    canonical,
-                )
-                transaction.symbol = canonical
-        else:
+        if isin is None:
             isin = self._isin_for_symbol(transaction.symbol)
             if isin is None:
                 return
+
+        canonical = ISIN_TICKER_ALIASES.get((isin, transaction.symbol))
+        if canonical is not None:
+            LOGGER.debug(
+                "ISIN %s: reporting exchange alias %s as %s",
+                isin,
+                transaction.symbol,
+                canonical,
+            )
+            transaction.symbol = canonical
 
         symbol = transaction.symbol
         recorded = self.transaction_symbols.get(isin) or set()

--- a/docs/brokers/trading212.md
+++ b/docs/brokers/trading212.md
@@ -113,6 +113,21 @@ winter and BST in summer, before taking the date. The tax year boundary and the 
 matching rules all run on UK calendar days, and the boundary always falls inside BST, so a
 transaction stamped after 23:00 UTC on 5 April belongs to the following tax year.
 
+### Tickers and exchange listings
+
+Trading 212 names a security by the ticker of the listing you traded, so one security can appear
+under two tickers: the Xetra line of a US share carries its German code. cgt-calc pools, matches and
+prices holdings by ticker, so it rewrites the aliases it has confirmed to the ticker of the primary
+listing, and the report shows one holding rather than two. `NVD` under `US67066G1040` is reported as
+`NVDA`, and `1YD` under `US11135F1012` as `AVGO`. The rewrite is scoped to that ISIN: the same
+ticker code under another security is left alone.
+
+Only confirmed pairs are rewritten. Where your exports disagree about a security, cgt-calc refuses
+rather than guess: an unrecognised second ticker for one ISIN, or one ticker used for two ISINs.
+Combining the wrong two holdings, or splitting one, changes the gain. If you hit that, please
+[open an issue](https://github.com/cgt-calc/capital-gains-calculator/issues/new) with the ISIN and
+both tickers.
+
 ### Known limitations
 
 - Dividends are recorded at the CSV `Total`, which is net of withholding tax. The `Withholding tax`

--- a/docs/extra-data-and-options.md
+++ b/docs/extra-data-and-options.md
@@ -28,8 +28,9 @@ existing mappings first and queries the [Open FIGI API](https://www.openfigi.com
 if needed. It saves new mappings in `out/isin_translation.csv` by default; `--isin-translation-file`
 selects another path.
 
-cgt-calc can create or rewrite this file after a successful lookup or after learning a mapping from
-broker transactions. It starts with the bundled
+cgt-calc can create or rewrite this file after a successful lookup. Tickers read from your broker
+transactions are used for the run but never written to the file: cached, they would be read back as
+reference data and could contradict a later run. It starts with the bundled
 [`initial_isin_translation.csv`](https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/resources/initial_isin_translation.csv).
 If you edit the cache, a row for an existing ISIN replaces its bundled symbols. Put every verified
 ticker for that ISIN on the same row.

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -862,6 +862,77 @@ def _rename_transaction(date: datetime.date, old: str, new: str) -> BrokerTransa
     )
 
 
+@pytest.mark.parametrize(
+    ("isin", "alias", "canonical"),
+    [
+        (Isin("US67066G1040"), "NVD", "NVDA"),
+        (Isin("US11135F1012"), "1YD", "AVGO"),
+    ],
+)
+def test_exchange_alias_pools_under_one_ticker(
+    isin: Isin, alias: str, canonical: str
+) -> None:
+    """One security bought under two of its listings is one Section 104 pool.
+
+    Trading 212 exports the Xetra line of a US share under its German code,
+    so a history can hold both. Pooling and matching are keyed by ticker, so
+    without normalisation the two halves never meet: the sale below has only
+    half the units it needs under its own name.
+    """
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    buy_alias = BrokerTransaction(
+        date=datetime.date(2024, 5, 1),
+        action=ActionType.BUY,
+        symbol=alias,
+        description=f"buy {alias}",
+        quantity=Decimal(10),
+        price=Decimal(10),
+        fees=Decimal(0),
+        amount=Decimal(-100),
+        currency=CurrencyCode("GBP"),
+        broker="Trading 212",
+        isin=isin,
+    )
+    transactions: list[BrokerTransaction] = [
+        buy_alias,
+        BrokerTransaction(
+            date=datetime.date(2024, 6, 1),
+            action=ActionType.BUY,
+            symbol=canonical,
+            description=f"buy {canonical}",
+            quantity=Decimal(10),
+            price=Decimal(20),
+            fees=Decimal(0),
+            amount=Decimal(-200),
+            currency=CurrencyCode("GBP"),
+            broker="Trading 212",
+            isin=isin,
+        ),
+        BrokerTransaction(
+            date=datetime.date(2024, 9, 1),
+            action=ActionType.SELL,
+            symbol=canonical,
+            description=f"sell {canonical}",
+            quantity=Decimal(15),
+            price=Decimal(30),
+            fees=Decimal(0),
+            amount=Decimal(450),
+            currency=CurrencyCode("GBP"),
+            broker="Trading 212",
+            isin=isin,
+        ),
+    ]
+
+    report = get_report(calculator, transactions)
+
+    assert buy_alias.symbol == canonical
+    assert alias not in calculator.portfolio
+    # 20 units costing 300 in one pool: 15 sold for 450 leaves 5 costing 75.
+    assert calculator.portfolio[canonical].quantity == Decimal(5)
+    assert calculator.portfolio[canonical].amount == Decimal(75)
+    assert report.total_gain() == Decimal(225)
+
+
 def test_rename_transfers_pool_to_new_ticker() -> None:
     """RENAME moves pool cost and quantity from old to new ticker; logs a RENAME entry."""
     calculator = create_calculator(tax_year=2024, balance_check=False)

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -933,6 +933,70 @@ def test_exchange_alias_pools_under_one_ticker(
     assert report.total_gain() == Decimal(225)
 
 
+def test_exchange_alias_pools_under_one_ticker_without_a_transaction_isin() -> None:
+    """The alias still normalises when a broker never reports an ISIN.
+
+    docs/extra-data-and-options.md documents putting every verified ticker
+    for an ISIN on one cache row, such as ``US67066G1040,NVD,NVDA``. A broker
+    that never supplies an ISIN has its ISIN resolved from that row alone, so
+    the alias has to be applied there too: resolving the ISIN without then
+    normalising the ticker would leave this pooling as two holdings, exactly
+    as it did before either check existed.
+    """
+    isin = Isin("US67066G1040")
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    calculator.isin_converter.data[isin] = {"NVD", "NVDA"}
+
+    buy_alias = BrokerTransaction(
+        date=datetime.date(2024, 5, 1),
+        action=ActionType.BUY,
+        symbol="NVD",
+        description="buy NVD",
+        quantity=Decimal(10),
+        price=Decimal(10),
+        fees=Decimal(0),
+        amount=Decimal(-100),
+        currency=CurrencyCode("GBP"),
+        broker="Test",
+    )
+    transactions: list[BrokerTransaction] = [
+        buy_alias,
+        BrokerTransaction(
+            date=datetime.date(2024, 6, 1),
+            action=ActionType.BUY,
+            symbol="NVDA",
+            description="buy NVDA",
+            quantity=Decimal(10),
+            price=Decimal(20),
+            fees=Decimal(0),
+            amount=Decimal(-200),
+            currency=CurrencyCode("GBP"),
+            broker="Test",
+        ),
+        BrokerTransaction(
+            date=datetime.date(2024, 9, 1),
+            action=ActionType.SELL,
+            symbol="NVDA",
+            description="sell NVDA",
+            quantity=Decimal(5),
+            price=Decimal(30),
+            fees=Decimal(0),
+            amount=Decimal(150),
+            currency=CurrencyCode("GBP"),
+            broker="Test",
+        ),
+    ]
+
+    report = get_report(calculator, transactions)
+
+    assert buy_alias.symbol == "NVDA"
+    assert "NVD" not in calculator.portfolio
+    # 20 units costing 300 in one pool: 5 sold for 150 leaves 15 costing 225.
+    assert calculator.portfolio["NVDA"].quantity == Decimal(15)
+    assert calculator.portfolio["NVDA"].amount == Decimal(225)
+    assert report.total_gain() == Decimal(75)
+
+
 def test_transaction_ticker_cannot_reassign_a_reference_owned_isin() -> None:
     """A transaction cannot silently move a reference-linked ticker to a new ISIN.
 

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -933,6 +933,54 @@ def test_exchange_alias_pools_under_one_ticker(
     assert report.total_gain() == Decimal(225)
 
 
+def test_transaction_ticker_cannot_reassign_a_reference_owned_isin() -> None:
+    """A transaction cannot silently move a reference-linked ticker to a new ISIN.
+
+    Regression test: the ISIN/ticker link is also read to route ERI reports
+    to the right pool via ``get_symbols``. If a transaction were allowed to
+    quietly reassign a ticker reference already gave to a different ISIN,
+    an ERI report for that other ISIN would be applied to both the correct
+    holding and the one that stole its ticker, inflating the wrong pool's
+    cost. This must be refused up front instead.
+    """
+    reassigned_isin = Isin("US0378331005")
+    reference_isin = Isin("US5949181045")
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    calculator.isin_converter.data[reference_isin] = {"SAME"}
+
+    transactions: list[BrokerTransaction] = [
+        BrokerTransaction(
+            date=datetime.date(2024, 5, 1),
+            action=ActionType.BUY,
+            symbol="SAME",
+            description="buy SAME",
+            quantity=Decimal(10),
+            price=Decimal(10),
+            fees=Decimal(0),
+            amount=Decimal(-100),
+            currency=CurrencyCode("GBP"),
+            broker="Test",
+            isin=reassigned_isin,
+        ),
+        BrokerTransaction(
+            date=datetime.date(2024, 5, 1),
+            action=ActionType.BUY,
+            symbol="B2",
+            description="buy B2",
+            quantity=Decimal(10),
+            price=Decimal(10),
+            fees=Decimal(0),
+            amount=Decimal(-100),
+            currency=CurrencyCode("GBP"),
+            broker="Test",
+            isin=reference_isin,
+        ),
+    ]
+
+    with pytest.raises(InvalidTransactionError, match="already used for"):
+        calculator.convert_to_hmrc_transactions(transactions)
+
+
 def test_rename_transfers_pool_to_new_ticker() -> None:
     """RENAME moves pool cost and quantity from old to new ticker; logs a RENAME entry."""
     calculator = create_calculator(tax_year=2024, balance_check=False)

--- a/tests/general/test_isin_converter.py
+++ b/tests/general/test_isin_converter.py
@@ -269,6 +269,27 @@ def test_add_from_transaction_normalises_exchange_alias(
     assert converter.get_symbols(isin) == {canonical}
 
 
+def test_add_from_transaction_normalises_alias_resolved_from_reference() -> None:
+    """Rewrite a known alias on a row with no ISIN of its own, too.
+
+    docs/extra-data-and-options.md documents listing every verified ticker
+    for an ISIN on one cache row, such as ``US67066G1040,NVD,NVDA``. A broker
+    that never reports an ISIN still has its ISIN resolved from that row, so
+    the alias must be applied there as well - resolving the ISIN without
+    then normalising the ticker would leave NVD and NVDA pooling separately
+    exactly as before.
+    """
+    converter = IsinConverter()
+    converter.data[NVIDIA_ISIN] = {"NVD", "NVDA"}
+
+    aliased = _transaction(None, "NVD")
+    converter.add_from_transaction(aliased)
+    converter.add_from_transaction(_transaction(None, "NVDA"))
+
+    assert aliased.symbol == "NVDA"
+    assert converter.transaction_symbols[NVIDIA_ISIN] == {"NVDA"}
+
+
 def test_add_from_transaction_alias_is_scoped_to_its_isin() -> None:
     """The same ticker code under another ISIN is left alone.
 

--- a/tests/general/test_isin_converter.py
+++ b/tests/general/test_isin_converter.py
@@ -101,7 +101,7 @@ class FakeSession:
         return FakeResponse(self._payload)
 
 
-def _transaction(isin: Isin, symbol: str | None) -> BrokerTransaction:
+def _transaction(isin: Isin | None, symbol: str | None) -> BrokerTransaction:
     """Create a minimal transaction with the given ISIN and symbol."""
     return BrokerTransaction(
         date=datetime.date(2023, 1, 1),
@@ -293,22 +293,57 @@ def test_add_from_transaction_rejects_one_ticker_under_two_isins() -> None:
     converter = IsinConverter()
     converter.add_from_transaction(_transaction(ISIN_A, "SAME"))
 
-    with pytest.raises(InvalidTransactionError, match="already used by another"):
+    with pytest.raises(InvalidTransactionError, match="already used for"):
         converter.add_from_transaction(_transaction(ISIN_B, "SAME"))
 
 
-def test_add_from_transaction_accepts_reference_only_isin_conflict() -> None:
-    """A stored row giving the ticker to another ISIN is not a conflict.
+def test_add_from_transaction_rejects_reference_owned_ticker_reassignment() -> None:
+    """A stored row giving the ticker to another ISIN is still a conflict.
 
-    Only the transaction's claim describes this run's holdings, so it wins the
-    symbol map rather than failing the run.
+    Unlike a same-ISIN mismatch, this direction cannot be a stale cache row:
+    validate_data() already guarantees one ISIN per reference ticker, so a
+    transaction reusing one reference gave to a different security is the
+    real thing this check exists to catch, not a false positive to excuse.
     """
     converter = IsinConverter()
     converter.data[ISIN_B] = {"SAME"}
 
-    converter.add_from_transaction(_transaction(ISIN_A, "SAME"))
+    with pytest.raises(InvalidTransactionError, match="already used for"):
+        converter.add_from_transaction(_transaction(ISIN_A, "SAME"))
 
-    assert converter.get_symbol_to_isin_map()["SAME"] == ISIN_A
+
+def test_add_from_transaction_checks_isin_less_rows_against_reference() -> None:
+    """A row with no ISIN is still checked when reference data names one.
+
+    A broker that never reports an ISIN would otherwise let its rows split a
+    holding past every check above just by leaving the field blank: the
+    ticker alone is enough to find the ISIN reference already links it to.
+    """
+    converter = IsinConverter()
+    converter.data[ISIN_A] = {"FOO"}
+    converter.add_from_transaction(_transaction(ISIN_A, "BAR"))
+
+    with pytest.raises(InvalidTransactionError, match="does not match BAR"):
+        converter.add_from_transaction(_transaction(None, "FOO"))
+
+
+def test_add_from_transaction_links_isin_less_row_without_conflict() -> None:
+    """A row with no ISIN is recorded once reference data resolves one."""
+    converter = IsinConverter()
+    converter.data[ISIN_A] = {"FOO"}
+
+    converter.add_from_transaction(_transaction(None, "FOO"))
+
+    assert converter.transaction_symbols[ISIN_A] == {"FOO"}
+
+
+def test_add_from_transaction_ignores_isin_less_unknown_ticker() -> None:
+    """A row with no ISIN and no reference match records nothing."""
+    converter = IsinConverter()
+
+    converter.add_from_transaction(_transaction(None, "UNKNOWN"))
+
+    assert converter.transaction_symbols == {}
 
 
 def test_add_from_transaction_accepts_a_bundled_multi_ticker_row() -> None:

--- a/tests/general/test_isin_converter.py
+++ b/tests/general/test_isin_converter.py
@@ -58,6 +58,13 @@ def test_live_isin_lookup_announces_itself(
 ISIN_A = Isin("US0378331005")
 ISIN_B = Isin("US5949181045")
 
+# ISINs with a curated exchange alias.
+NVIDIA_ISIN = Isin("US67066G1040")
+BROADCOM_ISIN = Isin("US11135F1012")
+
+# A bundled row listing one security under two tickers.
+VANGUARD_ISIN = Isin("IE00B3XXRP09")
+
 FigiData = list[dict[str, str]]
 
 
@@ -214,13 +221,119 @@ def test_validate_data_rejects_conflicting_symbols() -> None:
         converter.validate_data()
 
 
-def test_add_from_transaction_rejects_mismatched_symbol() -> None:
-    """Reject transactions conflicting with the existing mapping."""
+def test_add_from_transaction_rejects_two_transaction_symbols() -> None:
+    """Reject a second, unrecognised ticker for an ISIN this run has seen.
+
+    Both tickers come from transactions, so the holding really would be
+    pooled and matched as two.
+    """
+    converter = IsinConverter()
+    converter.add_from_transaction(_transaction(ISIN_A, "FOO"))
+
+    with pytest.raises(InvalidTransactionError, match="does not match FOO"):
+        converter.add_from_transaction(_transaction(ISIN_A, "BAR"))
+
+
+def test_add_from_transaction_accepts_reference_only_conflict() -> None:
+    """Accept a ticker that only disagrees with stored reference data.
+
+    A cache row left by an earlier run says FOO; this run's transactions all
+    say BAR. Nothing splits, so the run has to go through with BAR recorded
+    as another name for the ISIN.
+    """
     converter = IsinConverter()
     converter.data[ISIN_A] = {"FOO"}
 
-    with pytest.raises(InvalidTransactionError, match="does not match"):
-        converter.add_from_transaction(_transaction(ISIN_A, "BAR"))
+    transaction = _transaction(ISIN_A, "BAR")
+    converter.add_from_transaction(transaction)
+
+    assert transaction.symbol == "BAR"
+    assert converter.get_symbols(ISIN_A) == {"FOO", "BAR"}
+
+
+@pytest.mark.parametrize(
+    ("isin", "alias", "canonical"),
+    [(NVIDIA_ISIN, "NVD", "NVDA"), (BROADCOM_ISIN, "1YD", "AVGO")],
+)
+def test_add_from_transaction_normalises_exchange_alias(
+    isin: Isin, alias: str, canonical: str
+) -> None:
+    """Rewrite a known exchange alias, on the transaction itself."""
+    converter = IsinConverter()
+
+    aliased = _transaction(isin, alias)
+    converter.add_from_transaction(aliased)
+    converter.add_from_transaction(_transaction(isin, canonical))
+
+    assert aliased.symbol == canonical
+    assert converter.get_symbols(isin) == {canonical}
+
+
+def test_add_from_transaction_alias_is_scoped_to_its_isin() -> None:
+    """The same ticker code under another ISIN is left alone.
+
+    Ticker codes belong to an exchange, not to a security, so NVD is only
+    NVDA for the ISIN it was confirmed against.
+    """
+    converter = IsinConverter()
+
+    unrelated = _transaction(ISIN_A, "NVD")
+    converter.add_from_transaction(unrelated)
+
+    assert unrelated.symbol == "NVD"
+
+
+def test_add_from_transaction_rejects_one_ticker_under_two_isins() -> None:
+    """Reject a ticker this run has already tied to a different ISIN.
+
+    Both claims come from transactions, so the two securities would be pooled
+    and matched as one holding. Reference data cannot excuse this one:
+    validate_data already forbids a ticker linked to two ISINs there.
+    """
+    converter = IsinConverter()
+    converter.add_from_transaction(_transaction(ISIN_A, "SAME"))
+
+    with pytest.raises(InvalidTransactionError, match="already used by another"):
+        converter.add_from_transaction(_transaction(ISIN_B, "SAME"))
+
+
+def test_add_from_transaction_accepts_reference_only_isin_conflict() -> None:
+    """A stored row giving the ticker to another ISIN is not a conflict.
+
+    Only the transaction's claim describes this run's holdings, so it wins the
+    symbol map rather than failing the run.
+    """
+    converter = IsinConverter()
+    converter.data[ISIN_B] = {"SAME"}
+
+    converter.add_from_transaction(_transaction(ISIN_A, "SAME"))
+
+    assert converter.get_symbol_to_isin_map()["SAME"] == ISIN_A
+
+
+def test_add_from_transaction_accepts_a_bundled_multi_ticker_row() -> None:
+    """Accept every ticker of a bundled row listing a security under several.
+
+    IE00B3XXRP09 ships as VUSA and VUSD, and those holdings pool separately
+    today. That silent split predates the exchange-alias work and is not what
+    this check is for, so both tickers go through as they always have.
+    """
+    converter = IsinConverter()
+    assert converter.data[VANGUARD_ISIN] == {"VUSA", "VUSD"}
+
+    converter.add_from_transaction(_transaction(VANGUARD_ISIN, "VUSA"))
+    converter.add_from_transaction(_transaction(VANGUARD_ISIN, "VUSD"))
+
+    assert converter.transaction_symbols[VANGUARD_ISIN] == {"VUSA", "VUSD"}
+
+
+def test_add_from_transaction_ignores_rows_without_both_fields() -> None:
+    """A row missing a ticker or an ISIN records nothing."""
+    converter = IsinConverter()
+
+    converter.add_from_transaction(_transaction(ISIN_A, None))
+
+    assert converter.transaction_symbols == {}
 
 
 def test_add_from_transaction_adds_mapping() -> None:
@@ -255,12 +368,17 @@ def test_symbol_map_skips_unknown_tickers() -> None:
 def test_translation_file_roundtrip(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Write learned mappings to the translation file and read them back."""
+    """Write looked-up mappings to the translation file and read them back."""
     monkeypatch.setattr(cgt_calc.isin_converter, "CGT_MODE", RuntimeMode.PROD)
     translation_file = tmp_path / "isin_translation.csv"
 
     converter = IsinConverter(isin_translation_file=translation_file)
-    converter.add_from_transaction(_transaction(ISIN_A, "FOO"))
+    monkeypatch.setattr(
+        converter,
+        "session",
+        FakeSession([{"data": [{"ticker": "FOO", "exchCode": "LN"}]}]),
+    )
+    assert converter.get_symbols(ISIN_A) == {"FOO"}
 
     assert (
         translation_file.read_text(encoding="utf-8") == f"ISIN,symbol\n{ISIN_A},FOO\n"
@@ -268,6 +386,49 @@ def test_translation_file_roundtrip(
 
     restored = IsinConverter(isin_translation_file=translation_file)
     assert restored.get_symbols(ISIN_A) == {"FOO"}
+
+
+def test_translation_file_excludes_transaction_symbols(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Never cache a ticker learned from a transaction.
+
+    The file caches OpenFIGI lookups. A transaction ticker stored there is
+    read back as reference data by the next run, which is how a history
+    holding one listing of a security used to fail a later run holding the
+    other.
+    """
+    monkeypatch.setattr(cgt_calc.isin_converter, "CGT_MODE", RuntimeMode.PROD)
+    translation_file = tmp_path / "isin_translation.csv"
+
+    converter = IsinConverter(isin_translation_file=translation_file)
+    converter.add_from_transaction(_transaction(ISIN_A, "FOO"))
+
+    assert converter.write_data == {}
+    assert not translation_file.exists()
+
+
+def test_live_lookup_refuses_a_ticker_another_isin_owns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Refuse to cache a looked-up ticker the bundled table already assigns.
+
+    The cache is read back alongside the bundled table, so writing the row
+    would leave a file that fails the next run's construction.
+    """
+    monkeypatch.setattr(cgt_calc.isin_converter, "CGT_MODE", RuntimeMode.PROD)
+    translation_file = tmp_path / "isin_translation.csv"
+    converter = IsinConverter(isin_translation_file=translation_file)
+    monkeypatch.setattr(
+        converter,
+        "session",
+        FakeSession([{"data": [{"ticker": "VUSA", "exchCode": "LN"}]}]),
+    )
+
+    with pytest.raises(IsinTranslationError, match="already linked"):
+        converter.get_symbols(UNKNOWN_ISIN)
+
+    assert not translation_file.exists()
 
 
 def test_translation_file_empty(tmp_path: Path) -> None:


### PR DESCRIPTION
Trading 212 lists the same security under exchange-specific tickers sharing one ISIN (`NVD`/`NVDA`, `1YD`/`AVGO`), which used to raise `InvalidTransactionError` or, worked around by hand, split one holding into two Section 104 pools.
Now covers:
- Normalise the two known alias pairs to their canonical ticker via a new `ISIN_TICKER_ALIASES` table in `const.py`, scoped by ISIN rather than `TICKER_RENAMES`, which is global and ticker-only.
- Rewrite the alias on the transaction in place, before pooling, matching, or price lookups run, whether the ISIN comes from the transaction itself or is resolved from reference data for a broker that never reports one.
- Track this run's transaction-derived ISIN/ticker facts separately from reference data (bundled CSV, user's cache file, live Open FIGI results) in `IsinConverter`.
- Stop raising when a transaction ticker only conflicts with stale reference data for the SAME ISIN; keep raising when two transaction tickers disagree for one ISIN, or when a ticker is claimed for a second ISIN, even against reference data, since that direction can only be a real collision.
- Document the alias behaviour in `trading212.md` and correct the cache description in `extra-data-and-options.md`.
Removed the old blanket "any mismatch against known data raises" check in favour of the narrower invariants above; safe because every case that could actually split or merge a pool incorrectly still raises.

Fixes #1011