### PR TITLE
Add --autoconvert-currency for mixed-currency dividends

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -14,6 +14,8 @@ ArgumentParser
 ArgumentTypeError
 arm64
 AttributeError
+autoconvert
+autoconverted
 autosale
 BaseDirParser
 BaseSingleFileParser

--- a/cgt_calc/args_parser.py
+++ b/cgt_calc/args_parser.py
@@ -144,9 +144,10 @@ Environment variables:
         "--autoconvert-currency",
         action="store_true",
         default=False,
-        help="attempt to convert multicurrency dividends (e.g. across different brokers) "
-        "and intelligently infer any applicable double taxation treaty "
-        "where no ISIN is available",
+        help=(
+            "combine GBP and one foreign currency for the same dividend; "
+            "different foreign currencies remain an error"
+        ),
     )
     calc_group.add_argument(
         "--unrealized-gains",

--- a/cgt_calc/args_parser.py
+++ b/cgt_calc/args_parser.py
@@ -141,6 +141,14 @@ Environment variables:
         help="skip balance verification (useful for partial transaction records)",
     )
     calc_group.add_argument(
+        "--autoconvert-currency",
+        action="store_true",
+        default=False,
+        help="attempt to convert multicurrency dividends (e.g. across different brokers) "
+        "and intelligently infer any applicable double taxation treaty "
+        "where no ISIN is available",
+    )
+    calc_group.add_argument(
         "--unrealized-gains",
         dest="calc_unrealized_gains",
         action="store_true",

--- a/cgt_calc/calculator_state.py
+++ b/cgt_calc/calculator_state.py
@@ -81,10 +81,12 @@ class CalculatorState:
     # Withholding is matched to a dividend of the same broker as well as
     # the same symbol, so both are keyed by broker. The dividends stay
     # merged across brokers in dividend_list, which is what the report
-    # rows are built from.
-    dividend_tax_list: dict[tuple[str, str, datetime.date], ForeignCurrencyAmount] = (
-        field(default_factory=lambda: defaultdict(ForeignCurrencyAmount))
-    )
+    # rows are built from. The currency is part of the key so that rows in
+    # different ones are combined at the date of the dividend they are
+    # attributed to, not the date they happened to post on.
+    dividend_tax_list: dict[
+        tuple[str, str, datetime.date, CurrencyCode], ForeignCurrencyAmount
+    ] = field(default_factory=lambda: defaultdict(ForeignCurrencyAmount))
     dividend_dates: dict[tuple[str, str], set[datetime.date]] = field(
         default_factory=lambda: defaultdict(set)
     )

--- a/cgt_calc/cli.py
+++ b/cgt_calc/cli.py
@@ -58,6 +58,7 @@ def calculate_cgt(args: argparse.Namespace) -> None:
         args.interest_fund_tickers,
         cgt_exempt_tickers=args.cgt_exempt_tickers,
         balance_check=args.balance_check,
+        autoconvert_currency=args.autoconvert_currency,
         calc_unrealized_gains=args.calc_unrealized_gains,
         period_start=args.period_from,
         period_end=args.period_to,

--- a/cgt_calc/currency_converter.py
+++ b/cgt_calc/currency_converter.py
@@ -16,10 +16,10 @@ from pyrate_limiter.abstracts.rate import Duration
 from pyrate_limiter.extras.requests_limiter import RateLimitedRequestsSession
 from requests.adapters import HTTPAdapter, Retry
 
-from .const import CGT_MODE, RuntimeMode
+from .const import CGT_MODE, UK_CURRENCY, RuntimeMode
 from .dates import is_date
 from .exceptions import ExchangeRateMissingError, ExternalApiError, ParsingError
-from .model import CurrencyCode
+from .model import CurrencyCode, ForeignCurrencyAmount
 from .util import exclusive_lock, open_with_parents
 
 if TYPE_CHECKING:
@@ -303,6 +303,82 @@ class CurrencyConverter:
     def to_gbp_for(self, amount: Decimal, transaction: BrokerTransaction) -> Decimal:
         """Convert amount from transaction currency to GBP."""
         return self.to_gbp(amount, transaction.currency, transaction.date)
+
+    def convert(
+        self,
+        amount: Decimal,
+        source: CurrencyCode,
+        target: CurrencyCode,
+        date: datetime.date,
+    ) -> Decimal:
+        """Convert amount between two currencies at the given date.
+
+        HMRC publishes one rate per currency against GBP, so a rate between
+        two other currencies is the pair of them.
+        """
+        if source == target:
+            return amount
+        gbp = self.to_gbp(amount, source, date)
+        if target == UK_CURRENCY:
+            return gbp
+        return gbp * self.currency_to_gbp_rate(target, date)
+
+    def combined_currency(
+        self,
+        first: ForeignCurrencyAmount,
+        second: ForeignCurrencyAmount,
+        date: datetime.date,
+    ) -> CurrencyCode | None:
+        """Return the currency to state a mix of the two in, None if they agree.
+
+        A foreign currency is kept in preference to GBP: the currency a
+        dividend was paid in is evidence of where it came from, and losing it
+        costs the double taxation treaty that the source country decides.
+        Where both are foreign, the larger of the two by value decides, since
+        the greater part of the payment is the better evidence of its source.
+        Equal parts are settled on the code, so that the answer does not
+        depend on the order the rows happened to be read in.
+        """
+        first_currency = first.currency
+        second_currency = second.currency
+        assert first_currency is not None
+        assert second_currency is not None
+        if first_currency == second_currency:
+            return None
+        if first_currency == UK_CURRENCY:
+            return second_currency
+        if second_currency == UK_CURRENCY:
+            return first_currency
+        first_value = abs(self.to_gbp(first.amount, first_currency, date))
+        second_value = abs(self.to_gbp(second.amount, second_currency, date))
+        if first_value == second_value:
+            return min(first_currency, second_currency)
+        return first_currency if first_value > second_value else second_currency
+
+    def combine_amounts(
+        self,
+        first: ForeignCurrencyAmount,
+        second: ForeignCurrencyAmount,
+        date: datetime.date,
+        *,
+        autoconvert: bool,
+    ) -> ForeignCurrencyAmount:
+        """Add two amounts that belong to the same report row.
+
+        Adding them refuses a mismatch in currency, because a figure the
+        report states in one currency cannot be the sum of two currencies.
+        With `autoconvert`, both are converted at `date` to the currency
+        `combined_currency` picks and the sum is stated in that.
+        """
+        if autoconvert and first.currency is not None and second.currency is not None:
+            target = self.combined_currency(first, second, date)
+            if target is not None:
+                return ForeignCurrencyAmount(
+                    self.convert(first.amount, first.currency, target, date)
+                    + self.convert(second.amount, second.currency, target, date),
+                    target,
+                )
+        return first + second
 
 
 class TestCurrencyConverter(CurrencyConverter):

--- a/cgt_calc/currency_converter.py
+++ b/cgt_calc/currency_converter.py
@@ -18,7 +18,12 @@ from requests.adapters import HTTPAdapter, Retry
 
 from .const import CGT_MODE, UK_CURRENCY, RuntimeMode
 from .dates import is_date
-from .exceptions import ExchangeRateMissingError, ExternalApiError, ParsingError
+from .exceptions import (
+    CalculationError,
+    ExchangeRateMissingError,
+    ExternalApiError,
+    ParsingError,
+)
 from .model import CurrencyCode, ForeignCurrencyAmount
 from .util import exclusive_lock, open_with_parents
 
@@ -304,57 +309,6 @@ class CurrencyConverter:
         """Convert amount from transaction currency to GBP."""
         return self.to_gbp(amount, transaction.currency, transaction.date)
 
-    def convert(
-        self,
-        amount: Decimal,
-        source: CurrencyCode,
-        target: CurrencyCode,
-        date: datetime.date,
-    ) -> Decimal:
-        """Convert amount between two currencies at the given date.
-
-        HMRC publishes one rate per currency against GBP, so a rate between
-        two other currencies is the pair of them.
-        """
-        if source == target:
-            return amount
-        gbp = self.to_gbp(amount, source, date)
-        if target == UK_CURRENCY:
-            return gbp
-        return gbp * self.currency_to_gbp_rate(target, date)
-
-    def combined_currency(
-        self,
-        first: ForeignCurrencyAmount,
-        second: ForeignCurrencyAmount,
-        date: datetime.date,
-    ) -> CurrencyCode | None:
-        """Return the currency to state a mix of the two in, None if they agree.
-
-        A foreign currency is kept in preference to GBP: the currency a
-        dividend was paid in is evidence of where it came from, and losing it
-        costs the double taxation treaty that the source country decides.
-        Where both are foreign, the larger of the two by value decides, since
-        the greater part of the payment is the better evidence of its source.
-        Equal parts are settled on the code, so that the answer does not
-        depend on the order the rows happened to be read in.
-        """
-        first_currency = first.currency
-        second_currency = second.currency
-        assert first_currency is not None
-        assert second_currency is not None
-        if first_currency == second_currency:
-            return None
-        if first_currency == UK_CURRENCY:
-            return second_currency
-        if second_currency == UK_CURRENCY:
-            return first_currency
-        first_value = abs(self.to_gbp(first.amount, first_currency, date))
-        second_value = abs(self.to_gbp(second.amount, second_currency, date))
-        if first_value == second_value:
-            return min(first_currency, second_currency)
-        return first_currency if first_value > second_value else second_currency
-
     def combine_amounts(
         self,
         first: ForeignCurrencyAmount,
@@ -367,17 +321,39 @@ class CurrencyConverter:
 
         Adding them refuses a mismatch in currency, because a figure the
         report states in one currency cannot be the sum of two currencies.
-        With `autoconvert`, both are converted at `date` to the currency
-        `combined_currency` picks and the sum is stated in that.
+        With `autoconvert`, a GBP row is converted at `date` into the one
+        foreign currency present and the sum is stated in that, so that the
+        currency the payment arrived in survives to name its source country.
+        Two foreign currencies are still refused: picking one of them would
+        decide the double taxation treaty on nothing better than which row
+        was larger or came first.
         """
-        if autoconvert and first.currency is not None and second.currency is not None:
-            target = self.combined_currency(first, second, date)
-            if target is not None:
-                return ForeignCurrencyAmount(
-                    self.convert(first.amount, first.currency, target, date)
-                    + self.convert(second.amount, second.currency, target, date),
-                    target,
+        if (
+            autoconvert
+            and first.currency is not None
+            and second.currency is not None
+            and first.currency != second.currency
+        ):
+            if UK_CURRENCY not in {first.currency, second.currency}:
+                raise CalculationError(
+                    "Cannot combine amounts in different currencies: "
+                    f"{first.currency} and {second.currency}. "
+                    "--autoconvert-currency combines GBP with one foreign "
+                    "currency, and cannot choose between two foreign "
+                    "currencies without also choosing which double taxation "
+                    "treaty applies. Report these rows in one currency."
                 )
+            foreign, sterling = (
+                (second, first) if first.currency == UK_CURRENCY else (first, second)
+            )
+            assert foreign.currency is not None
+            # ponytail: only GBP plus one foreign currency; retain all source
+            # currencies before widening this rule.
+            return ForeignCurrencyAmount(
+                foreign.amount
+                + sterling.amount * self.currency_to_gbp_rate(foreign.currency, date),
+                foreign.currency,
+            )
         return first + second
 
 

--- a/cgt_calc/currency_converter.py
+++ b/cgt_calc/currency_converter.py
@@ -324,9 +324,9 @@ class CurrencyConverter:
         With `autoconvert`, a GBP row is converted at `date` into the one
         foreign currency present and the sum is stated in that, so that the
         currency the payment arrived in survives to name its source country.
-        Two foreign currencies are still refused: picking one of them would
-        decide the double taxation treaty on nothing better than which row
-        was larger or came first.
+        Two foreign currencies are still refused: where no ISIN names the
+        source country, picking one of them decides the double taxation
+        treaty on nothing better than which row was larger or came first.
         """
         if (
             autoconvert
@@ -339,9 +339,8 @@ class CurrencyConverter:
                     "Cannot combine amounts in different currencies: "
                     f"{first.currency} and {second.currency}. "
                     "--autoconvert-currency combines GBP with one foreign "
-                    "currency, and cannot choose between two foreign "
-                    "currencies without also choosing which double taxation "
-                    "treaty applies. Report these rows in one currency."
+                    "currency; it does not convert between foreign "
+                    "currencies. Report these rows in one currency."
                 )
             foreign, sterling = (
                 (second, first) if first.currency == UK_CURRENCY else (first, second)

--- a/cgt_calc/income.py
+++ b/cgt_calc/income.py
@@ -316,10 +316,13 @@ class IncomeProcessor:
             # only for tax deducted from an ordinary holding let a refund, or
             # any tax on a bond fund, be converted as though it were in the
             # dividend's currency. With --autoconvert-currency each is
-            # converted at its own rate instead.
+            # converted at its own rate instead, but only where either
+            # currency is GBP: converting between two foreign currencies would
+            # leave no single currency to read the source country from.
             tax_currency = tax.currency or currency
             if tax.amount and tax_currency != currency:
-                if not self.autoconvert_currency:
+                gbp_involved = UK_CURRENCY in {currency, tax_currency}
+                if not self.autoconvert_currency or not gbp_involved:
                     raise CalculationError(
                         f"Dividend and withholding tax currencies do not match "
                         f"for {symbol} on {date}: dividend "

--- a/cgt_calc/income.py
+++ b/cgt_calc/income.py
@@ -251,7 +251,7 @@ class IncomeProcessor:
         """
         matched: ForeignAmountLog = defaultdict(ForeignCurrencyAmount)
         unmatched: ForeignAmountLog = defaultdict(ForeignCurrencyAmount)
-        for (broker, symbol, date), tax in self.state.dividend_tax_list.items():
+        for (broker, symbol, date, _), tax in self.state.dividend_tax_list.items():
             if not tax.amount:
                 continue
             candidates = self._dividends_for_tax(

--- a/cgt_calc/income.py
+++ b/cgt_calc/income.py
@@ -47,6 +47,8 @@ class IncomeProcessor:
         isin_converter: IsinConverter,
         interest_fund_tickers: list[str],
         date_in_tax_year: Callable[[datetime.date], bool],
+        *,
+        autoconvert_currency: bool = False,
     ):
         """Create income processor object."""
         self.state = state
@@ -54,6 +56,7 @@ class IncomeProcessor:
         self.isin_converter = isin_converter
         self.interest_fund_tickers = interest_fund_tickers
         self.date_in_tax_year = date_in_tax_year
+        self.autoconvert_currency = autoconvert_currency
         self._attributed_dividend_tax: DividendTaxAttribution | None = None
 
     def _group_by_month(
@@ -255,14 +258,29 @@ class IncomeProcessor:
                 date, self.state.dividend_dates.get((broker, symbol), set())
             )
             if len(candidates) == 1:
-                matched[symbol, candidates[0]] += tax
+                # Dated on the dividend it belongs to, so that is the date
+                # its currency is converted at where two brokers withheld in
+                # different ones.
+                matched[symbol, candidates[0]] = (
+                    self.currency_converter.combine_amounts(
+                        matched[symbol, candidates[0]],
+                        tax,
+                        candidates[0],
+                        autoconvert=self.autoconvert_currency,
+                    )
+                )
                 continue
             # Either nothing is near enough, or two payments are and the
             # export does not say which one this is. Guessing between them
             # puts a wrong figure in the report; leaving it out and saying so
             # does not.
             self._warn_unattributed_dividend_tax(symbol, date, tax, candidates)
-            unmatched[symbol, date] += tax
+            unmatched[symbol, date] = self.currency_converter.combine_amounts(
+                unmatched[symbol, date],
+                tax,
+                date,
+                autoconvert=self.autoconvert_currency,
+            )
         return DividendTaxAttribution(matched, unmatched)
 
     def dividend_tax_attribution(self) -> DividendTaxAttribution:
@@ -292,17 +310,28 @@ class IncomeProcessor:
             currency = foreign_amount.currency
             assert currency is not None, f"Dividend for {symbol} has no currency"
 
-            # The tax is converted at the dividend's rate below, so the two
-            # have to be in one currency whichever way the tax runs and
-            # whatever the holding is. Checking this only for tax deducted
-            # from an ordinary holding let a refund, or any tax on a bond
-            # fund, be converted as though it were in the dividend's
-            # currency.
-            if tax.amount and tax.currency != currency:
-                raise CalculationError(
-                    f"Dividend and withholding tax currencies do not match "
-                    f"for {symbol} on {date}: dividend "
-                    f"{foreign_amount.currency}, tax {tax.currency}"
+            # The payment and the tax taken from it have to be in one currency
+            # whichever way the tax runs and whatever the holding is, because
+            # converting one at the other's rate misstates it. Checking this
+            # only for tax deducted from an ordinary holding let a refund, or
+            # any tax on a bond fund, be converted as though it were in the
+            # dividend's currency. With --autoconvert-currency each is
+            # converted at its own rate instead.
+            tax_currency = tax.currency or currency
+            if tax.amount and tax_currency != currency:
+                if not self.autoconvert_currency:
+                    raise CalculationError(
+                        f"Dividend and withholding tax currencies do not match "
+                        f"for {symbol} on {date}: dividend "
+                        f"{foreign_amount.currency}, tax {tax.currency}"
+                    )
+                LOGGER.debug(
+                    "Converting the %s dividend and its %s tax for %s on %s "
+                    "to GBP separately",
+                    currency,
+                    tax_currency,
+                    symbol,
+                    date,
                 )
 
             treaty = None
@@ -331,14 +360,25 @@ class IncomeProcessor:
                     else:
                         treaty = DIVIDEND_DOUBLE_TAXATION_RULES[country]
                         expected_tax = treaty.country_rate * -foreign_amount.amount
-                        if not approx_equal(expected_tax, tax.amount):
+                        deducted_tax = tax.amount
+                        if tax_currency != currency:
+                            # Autoconverted: the rate the treaty expects is a
+                            # proportion of the payment, so the two sides are
+                            # only comparable once both are in GBP.
+                            expected_tax = self.currency_converter.to_gbp(
+                                expected_tax, currency, date
+                            )
+                            deducted_tax = self.currency_converter.to_gbp(
+                                deducted_tax, tax_currency, date
+                            )
+                        if not approx_equal(expected_tax, deducted_tax):
                             LOGGER.warning(
                                 "Determined double taxation treaty does not match the "
                                 "base taxation rules (expected %.2f base tax for %s "
                                 "but %.2f was deducted) for %s ticker!",
                                 expected_tax,
                                 treaty.country,
-                                tax.amount,
+                                deducted_tax,
                                 symbol,
                             )
                             treaty = None
@@ -346,7 +386,7 @@ class IncomeProcessor:
             amount = self.currency_converter.to_gbp(
                 foreign_amount.amount, currency, date
             )
-            tax_amount = self.currency_converter.to_gbp(tax.amount, currency, date)
+            tax_amount = self.currency_converter.to_gbp(tax.amount, tax_currency, date)
 
             dividend = Dividend(
                 date=date,

--- a/cgt_calc/ingestion.py
+++ b/cgt_calc/ingestion.py
@@ -260,6 +260,7 @@ class TransactionIngester:
         interest_fund_tickers: list[str],
         *,
         balance_check: bool,
+        autoconvert_currency: bool = False,
         date_in_tax_year: Callable[[datetime.date], bool],
     ):
         """Create transaction ingester object."""
@@ -272,6 +273,7 @@ class TransactionIngester:
         self.initial_prices = initial_prices
         self.interest_fund_tickers = interest_fund_tickers
         self.balance_check = balance_check
+        self.autoconvert_currency = autoconvert_currency
         self.date_in_tax_year = date_in_tax_year
 
     def add_acquisition(
@@ -1571,8 +1573,13 @@ class TransactionIngester:
                 symbol = get_symbol_or_fail(transaction)
                 currency = transaction.currency
                 new_balance += amount
-                self.state.dividend_list[symbol, transaction.date] += (
-                    ForeignCurrencyAmount(amount, currency)
+                self.state.dividend_list[symbol, transaction.date] = (
+                    self.currency_converter.combine_amounts(
+                        self.state.dividend_list[symbol, transaction.date],
+                        ForeignCurrencyAmount(amount, currency),
+                        transaction.date,
+                        autoconvert=self.autoconvert_currency,
+                    )
                 )
                 self.state.dividend_dates[transaction.broker, symbol].add(
                     transaction.date
@@ -1584,9 +1591,15 @@ class TransactionIngester:
                 symbol = get_symbol_or_fail(transaction)
                 currency = transaction.currency
                 new_balance += amount
-                self.state.dividend_tax_list[
-                    transaction.broker, symbol, transaction.date
-                ] += ForeignCurrencyAmount(amount, currency)
+                tax_key = (transaction.broker, symbol, transaction.date)
+                self.state.dividend_tax_list[tax_key] = (
+                    self.currency_converter.combine_amounts(
+                        self.state.dividend_tax_list[tax_key],
+                        ForeignCurrencyAmount(amount, currency),
+                        transaction.date,
+                        autoconvert=self.autoconvert_currency,
+                    )
+                )
             # Cash moves and nothing else: a deposit or withdrawal, a
             # correction, or an incoming wire. No shares change hands.
             elif transaction.action in {

--- a/cgt_calc/ingestion.py
+++ b/cgt_calc/ingestion.py
@@ -1591,14 +1591,9 @@ class TransactionIngester:
                 symbol = get_symbol_or_fail(transaction)
                 currency = transaction.currency
                 new_balance += amount
-                tax_key = (transaction.broker, symbol, transaction.date)
-                self.state.dividend_tax_list[tax_key] = (
-                    self.currency_converter.combine_amounts(
-                        self.state.dividend_tax_list[tax_key],
-                        ForeignCurrencyAmount(amount, currency),
-                        transaction.date,
-                        autoconvert=self.autoconvert_currency,
-                    )
+                tax_key = (transaction.broker, symbol, transaction.date, currency)
+                self.state.dividend_tax_list[tax_key] += ForeignCurrencyAmount(
+                    amount, currency
                 )
             # Cash moves and nothing else: a deposit or withdrawal, a
             # correction, or an incoming wire. No shares change hands.

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -62,6 +62,7 @@ class CapitalGainsCalculator:
         *,
         cgt_exempt_tickers: list[str] | None = None,
         balance_check: bool = True,
+        autoconvert_currency: bool = False,
         calc_unrealized_gains: bool = False,
         period_start: datetime.date | None = None,
         period_end: datetime.date | None = None,
@@ -84,6 +85,7 @@ class CapitalGainsCalculator:
         self.spin_off_handler = spin_off_handler
         self.initial_prices = initial_prices
         self.balance_check = balance_check
+        self.autoconvert_currency = autoconvert_currency
         self.calc_unrealized_gains = calc_unrealized_gains
         self.interest_fund_tickers = interest_fund_tickers
         self.cgt_exempt_tickers = frozenset(
@@ -96,6 +98,7 @@ class CapitalGainsCalculator:
             isin_converter,
             interest_fund_tickers,
             self.date_in_tax_year,
+            autoconvert_currency=autoconvert_currency,
         )
         self.ingester = TransactionIngester(
             self.state,
@@ -107,6 +110,7 @@ class CapitalGainsCalculator:
             initial_prices,
             interest_fund_tickers,
             balance_check=balance_check,
+            autoconvert_currency=autoconvert_currency,
             date_in_tax_year=self.date_in_tax_year,
         )
         self.matcher = Matcher(

--- a/docs/extra-data-and-options.md
+++ b/docs/extra-data-and-options.md
@@ -79,17 +79,26 @@ dividend, adjust the income figures outside cgt-calc.
 
 ### Income reported in more than one currency
 
-Dividends and withholding tax reported in different currencies can cause **Cannot combine amounts in
-different currencies**. If the rows describe the same dividend and use GBP plus one foreign
-currency, pass `--autoconvert-currency` to convert the GBP rows at the HMRC rate used for that date:
+Two brokers reporting the same dividend in different currencies, or a dividend and its withholding
+tax in different currencies, stop the calculation with **Cannot combine amounts in different
+currencies** or **Dividend and withholding tax currencies do not match**.
+
+If the rows really are the same dividend and use GBP plus one foreign currency, pass
+`--autoconvert-currency`:
 
 ```shell
 cgt-calc --year 2024 --revolut-file revolut.csv --trading212-dir trading212/ --autoconvert-currency
 ```
 
-The option is off by default. It does not detect whether rows with the same ticker and date describe
-the same security or payment. Check that before enabling it. Two different non-GBP currencies still
-produce an error; correct the input rather than choosing one currency.
+cgt-calc then reports them as one figure, converting the foreign amounts at the HMRC rate for the
+date of the dividend. Withholding posted in a later month is converted at that same rate, not the
+rate for the month it posted in. Amounts already in GBP are used as they are.
+
+The option is off by default, and it cannot tell whether two rows with the same ticker and date
+describe the same security and payment. Compare the ISIN and payment details on each broker's
+statement before enabling it. Two different non-GBP currencies remain an error: the option does not
+convert between foreign currencies. If your broker cannot provide a verified amount in one currency,
+report that dividend outside cgt-calc.
 
 Where an ISIN is available, cgt-calc uses it to determine the dividend's source country. Without an
 ISIN, it falls back to the currency of the dividend itself, never that of the tax. For a dividend

--- a/docs/extra-data-and-options.md
+++ b/docs/extra-data-and-options.md
@@ -79,16 +79,30 @@ dividend, adjust the income figures outside cgt-calc.
 
 ### Income reported in more than one currency
 
-Dividends & withholding tax reported in different currencies (e.g. across different brokers) cause
-an error (**Cannot combine amounts in different currencies**). Use `--autoconvert-currency` to
-suppress this error, and instead convert the rows at that date's HMRC rate:
+Dividends and withholding tax reported in different currencies can cause **Cannot combine amounts in
+different currencies**. If the rows describe the same dividend and use GBP plus one foreign
+currency, pass `--autoconvert-currency` to convert the GBP rows at the HMRC rate used for that date:
 
 ```shell
 cgt-calc --year 2024 --revolut-file revolut.csv --trading212-dir trading212/ --autoconvert-currency
 ```
 
-The foreign currency is favoured over GBP so that (where no ISIN is available), the currency can be
-used to infer any applicable double taxation treaty.
+The option is off by default. It does not detect whether rows with the same ticker and date describe
+the same security or payment. Check that before enabling it. Two different non-GBP currencies still
+produce an error; correct the input rather than choosing one currency.
+
+Where an ISIN is available, cgt-calc uses it to determine the dividend's source country. Without an
+ISIN, it falls back to the currency of the dividend itself, never that of the tax. For a dividend
+your broker reports already converted to GBP, cgt-calc therefore cannot determine a treaty
+automatically: it warns that the source country is unknown and leaves the relief out of the report.
+
+A payment currency does not prove where the paying company is resident, especially when a broker
+converts payments into your account currency.
+[HMRC's dividend treaty guidance](https://www.gov.uk/hmrc-internal-manuals/international-manual/intm164020)
+bases treaty treatment on the residence of the company paying the dividend. Check that residence and
+the tax deducted on your broker's tax voucher. If the fallback is wrong or missing, add a verified
+mapping under [ISIN to ticker translation](#isin-to-ticker-translation); if you cannot, calculate
+the relief outside cgt-calc rather than relying on the treaty figure in the report.
 
 ### CGT-exempt instruments (advanced)
 

--- a/docs/extra-data-and-options.md
+++ b/docs/extra-data-and-options.md
@@ -77,6 +77,19 @@ see the [offshore-fund checklist](offshore-funds.md#what-to-check). It reports t
 interest, so do not use it for a UK fund. If cgt-calc reports a UK bond fund distribution as a
 dividend, adjust the income figures outside cgt-calc.
 
+### Income reported in more than one currency
+
+Dividends & withholding tax reported in different currencies (e.g. across different brokers) cause
+an error (**Cannot combine amounts in different currencies**). Use `--autoconvert-currency` to
+suppress this error, and instead convert the rows at that date's HMRC rate:
+
+```shell
+cgt-calc --year 2024 --revolut-file revolut.csv --trading212-dir trading212/ --autoconvert-currency
+```
+
+The foreign currency is favoured over GBP so that (where no ISIN is available), the currency can be
+used to infer any applicable double taxation treaty.
+
 ### CGT-exempt instruments (advanced)
 
 Most users should not use `--cgt-exempt-tickers`. Pass a comma-separated list only when you have

--- a/tests/general/test_args_parser.py
+++ b/tests/general/test_args_parser.py
@@ -977,3 +977,11 @@ def test_from_rejects_invalid_date() -> None:
         parser.parse_args(["--from", "2024-13-01", "--to", "2024-12-31"])
 
     assert exc_info.value.code == 2
+
+
+def test_autoconvert_currency_is_opt_in() -> None:
+    """Currency mismatches remain errors unless the user enables conversion."""
+    parser = create_parser()
+
+    assert parser.parse_args([]).autoconvert_currency is False
+    assert parser.parse_args(["--autoconvert-currency"]).autoconvert_currency is True

--- a/tests/general/test_currency_converter.py
+++ b/tests/general/test_currency_converter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 from decimal import Decimal
+from itertools import permutations
 import logging
 import re
 from typing import TYPE_CHECKING, NoReturn
@@ -18,8 +19,13 @@ from cgt_calc.currency_converter import (
     StrictTestCurrencyConverter,
     TestCurrencyConverter as RecordingCurrencyConverter,
 )
-from cgt_calc.exceptions import ExchangeRateMissingError, ExternalApiError, ParsingError
-from cgt_calc.model import CurrencyCode
+from cgt_calc.exceptions import (
+    CalculationError,
+    ExchangeRateMissingError,
+    ExternalApiError,
+    ParsingError,
+)
+from cgt_calc.model import CurrencyCode, ForeignCurrencyAmount
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -282,6 +288,9 @@ def test_hmrc_response_malformed_currency_code_raises_api_error(
 
 
 DATE = datetime.date(2024, 1, 1)
+GBP = CurrencyCode("GBP")
+USD = CurrencyCode("USD")
+PLN = CurrencyCode("PLN")
 
 
 class FakeResponse:
@@ -445,3 +454,57 @@ def test_strict_converter_refuses_to_fetch() -> None:
 
     with pytest.raises(RuntimeError, match="HMRC values missing for 2024-01"):
         converter.currency_to_gbp_rate(CurrencyCode("USD"), DATE)
+
+
+def test_combine_amounts_is_order_independent_for_gbp_and_one_foreign() -> None:
+    """Any ordering of supported rows produces the same foreign amount."""
+    converter = CurrencyConverter(initial_data={DATE: {USD: Decimal("1.25")}})
+    rows = [
+        ForeignCurrencyAmount(Decimal(100), USD),
+        ForeignCurrencyAmount(Decimal(40), GBP),
+        ForeignCurrencyAmount(Decimal(40), GBP),
+    ]
+
+    for ordered in permutations(rows):
+        total = ForeignCurrencyAmount()
+        for row in ordered:
+            total = converter.combine_amounts(total, row, DATE, autoconvert=True)
+        assert total == ForeignCurrencyAmount(Decimal(200), USD)
+
+
+def test_combine_amounts_keeps_mixed_currency_error_without_opt_in() -> None:
+    """The new conversion never weakens the default validation."""
+    converter = CurrencyConverter(initial_data={DATE: {USD: Decimal("1.25")}})
+
+    with pytest.raises(CalculationError, match="different currencies: USD and GBP"):
+        converter.combine_amounts(
+            ForeignCurrencyAmount(Decimal(100), USD),
+            ForeignCurrencyAmount(Decimal(80), GBP),
+            DATE,
+            autoconvert=False,
+        )
+
+
+@pytest.mark.parametrize(
+    "pln_amount",
+    [
+        # Equal to the USD row by value in GBP, so only a tie-break could
+        # pick a winner.
+        pytest.param(Decimal(400), id="equal-value"),
+        # The larger row by value, so only its size could pick a winner.
+        pytest.param(Decimal(4000), id="larger-value"),
+    ],
+)
+def test_combine_amounts_refuses_two_foreign_currencies_with_opt_in(
+    pln_amount: Decimal,
+) -> None:
+    """A row's size or position cannot choose a source country."""
+    converter = CurrencyConverter(
+        initial_data={DATE: {USD: Decimal("1.25"), PLN: Decimal(5)}}
+    )
+    usd = ForeignCurrencyAmount(Decimal(100), USD)
+    pln = ForeignCurrencyAmount(pln_amount, PLN)
+
+    for first, second in ((usd, pln), (pln, usd)):
+        with pytest.raises(CalculationError, match="different currencies"):
+            converter.combine_amounts(first, second, DATE, autoconvert=True)

--- a/tests/general/test_dividend_tax_attribution.py
+++ b/tests/general/test_dividend_tax_attribution.py
@@ -780,3 +780,27 @@ def test_autoconvert_gbp_dividend_with_foreign_tax_reports_no_treaty(
         "Source country of the GBP dividend is unknown" in record.message
         for record in caplog.records
     )
+
+
+def test_autoconvert_converts_withholding_at_its_dividend_date() -> None:
+    """Withholding posted in a later rate month still converts at the dividend.
+
+    The report states the tax at the rate of the dividend it was taken from,
+    so combining the rows at the date they happened to post would convert the
+    GBP part at one rate and read the total back at another.
+    """
+    tax_date = datetime.date(2024, 7, 1)
+    transactions = [
+        _dividend_at(DIVIDEND_DATE, 100, "A", USD),
+        _tax_in_currency(tax_date, -10, USD, "A"),
+        _tax_in_currency(tax_date, -4, GBP, "A"),
+    ]
+
+    assert _reported(
+        transactions,
+        autoconvert_currency=True,
+        gbp_prices={
+            DIVIDEND_DATE: {USD: Decimal("1.25")},
+            tax_date: {USD: Decimal(2)},
+        },
+    ) == [(DIVIDEND_DATE, Decimal(80), Decimal(-12), True)]

--- a/tests/general/test_dividend_tax_attribution.py
+++ b/tests/general/test_dividend_tax_attribution.py
@@ -19,7 +19,9 @@ from cgt_calc.spin_off_handler import SpinOffHandler
 
 from .calc_test_data import dividend_tax_transaction, dividend_transaction
 
+GBP = CurrencyCode("GBP")
 USD = CurrencyCode("USD")
+PLN = CurrencyCode("PLN")
 
 # The tax year under test, a dividend inside it, and withholding placed at
 # various distances from that dividend: two days away, exactly at the
@@ -36,11 +38,19 @@ BORDER_TAX_DATE = datetime.date(2025, 4, 8)
 
 
 def _calculator(
-    transactions: list[BrokerTransaction], tax_year: int = TAX_YEAR
+    transactions: list[BrokerTransaction],
+    tax_year: int = TAX_YEAR,
+    *,
+    autoconvert_currency: bool = False,
+    gbp_prices: dict[datetime.date, dict[CurrencyCode, Decimal]] | None = None,
 ) -> CapitalGainsCalculator:
-    """Create a calculator with a flat 1:1 USD rate for the dates in use."""
-    gbp_prices = {t.date: {USD: Decimal(1)} for t in transactions}
-    currency_converter = CurrencyConverter(None, gbp_prices)
+    """Create a calculator with supplied rates or flat 1:1 USD rates."""
+    rates = (
+        gbp_prices
+        if gbp_prices is not None
+        else {t.date: {USD: Decimal(1)} for t in transactions}
+    )
+    currency_converter = CurrencyConverter(None, rates)
     return CapitalGainsCalculator(
         tax_year,
         currency_converter,
@@ -50,14 +60,24 @@ def _calculator(
         InitialPrices(),
         interest_fund_tickers=[],
         balance_check=False,
+        autoconvert_currency=autoconvert_currency,
     )
 
 
 def _reported(
-    transactions: list[BrokerTransaction], tax_year: int = TAX_YEAR
+    transactions: list[BrokerTransaction],
+    tax_year: int = TAX_YEAR,
+    *,
+    autoconvert_currency: bool = False,
+    gbp_prices: dict[datetime.date, dict[CurrencyCode, Decimal]] | None = None,
 ) -> list[tuple[datetime.date, Decimal, Decimal, bool]]:
     """Return date, amount, tax and whether a treaty applied, per reported row."""
-    calculator = _calculator(transactions, tax_year)
+    calculator = _calculator(
+        transactions,
+        tax_year,
+        autoconvert_currency=autoconvert_currency,
+        gbp_prices=gbp_prices,
+    )
     calculator.convert_to_hmrc_transactions(transactions)
     calculator.process_dividends()
     rows = []
@@ -117,7 +137,12 @@ def _summary_dividend_lines(
     return section[: section.index("")] if "" in section else section
 
 
-def _dividend_at(date: datetime.date, amount: float, broker: str) -> BrokerTransaction:
+def _dividend_at(
+    date: datetime.date,
+    amount: float,
+    broker: str,
+    currency: CurrencyCode = USD,
+) -> BrokerTransaction:
     """Create a dividend held at a named broker."""
     return BrokerTransaction(
         date,
@@ -128,7 +153,7 @@ def _dividend_at(date: datetime.date, amount: float, broker: str) -> BrokerTrans
         price=None,
         fees=Decimal(0),
         amount=Decimal(str(amount)),
-        currency=USD,
+        currency=currency,
         broker=broker,
     )
 
@@ -203,7 +228,10 @@ def test_tax_on_a_payment_day_is_never_in_doubt(
 
 
 def _tax_in_currency(
-    date: datetime.date, amount: float, currency: CurrencyCode
+    date: datetime.date,
+    amount: float,
+    currency: CurrencyCode,
+    broker: str = "A",
 ) -> BrokerTransaction:
     """Create withholding denominated in a given currency."""
     return BrokerTransaction(
@@ -216,7 +244,7 @@ def _tax_in_currency(
         fees=Decimal(0),
         amount=Decimal(str(amount)),
         currency=currency,
-        broker="A",
+        broker=broker,
     )
 
 
@@ -662,3 +690,93 @@ def test_dividend_without_withholding_leaves_no_entry(
 
     assert _reported(transactions) == [(DIVIDEND_DATE, Decimal(100), Decimal(0), False)]
     assert _unattributed_warnings(transactions, caplog) == []
+
+
+def test_autoconvert_combines_gbp_and_foreign_dividends_across_brokers() -> None:
+    """The intended multi-broker case reports one correct GBP total."""
+    transactions = [
+        _dividend_at(DIVIDEND_DATE, 100, "A", USD),
+        _tax_in_currency(DIVIDEND_DATE, -15, USD, "A"),
+        _dividend_at(DIVIDEND_DATE, 80, "B", GBP),
+        _tax_in_currency(DIVIDEND_DATE, -12, GBP, "B"),
+    ]
+
+    assert _reported(
+        transactions,
+        autoconvert_currency=True,
+        gbp_prices={DIVIDEND_DATE: {USD: Decimal("1.25")}},
+    ) == [(DIVIDEND_DATE, Decimal(160), Decimal(-24), True)]
+
+
+def test_autoconvert_handles_gbp_tax_on_a_foreign_dividend() -> None:
+    """Dividend and withholding use their own rates before comparison."""
+    transactions = [
+        _dividend_at(DIVIDEND_DATE, 100, "A", USD),
+        _tax_in_currency(DIVIDEND_DATE, -12, GBP, "A"),
+    ]
+
+    assert _reported(
+        transactions,
+        autoconvert_currency=True,
+        gbp_prices={DIVIDEND_DATE: {USD: Decimal("1.25")}},
+    ) == [(DIVIDEND_DATE, Decimal(80), Decimal(-12), True)]
+
+
+def test_autoconvert_refuses_dividend_and_tax_in_two_foreign_currencies() -> None:
+    """A second foreign currency cannot silently choose treaty treatment."""
+    transactions = [
+        _dividend_at(DIVIDEND_DATE, 100, "A", USD),
+        _tax_in_currency(DIVIDEND_DATE, -60, PLN, "A"),
+    ]
+
+    with pytest.raises(CalculationError, match="currencies do not match"):
+        _reported(
+            transactions,
+            autoconvert_currency=True,
+            gbp_prices={DIVIDEND_DATE: {USD: Decimal("1.25"), PLN: Decimal(5)}},
+        )
+
+
+def test_autoconvert_refuses_two_foreign_currencies_for_one_dividend() -> None:
+    """Two brokers paying the same dividend in different foreign currencies."""
+    transactions = [
+        _dividend_at(DIVIDEND_DATE, 100, "A", USD),
+        _dividend_at(DIVIDEND_DATE, 400, "B", PLN),
+    ]
+
+    with pytest.raises(CalculationError, match="cannot choose between two foreign"):
+        _reported(
+            transactions,
+            autoconvert_currency=True,
+            gbp_prices={DIVIDEND_DATE: {USD: Decimal("1.25"), PLN: Decimal(5)}},
+        )
+
+
+def test_autoconvert_gbp_dividend_with_foreign_tax_reports_no_treaty(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The source-country fallback reads the dividend's currency, not the tax's.
+
+    A broker that reports the payment already converted to GBP leaves nothing
+    to name the source country with. The tax is still converted at its own
+    rate, but the relief is left out and said to be missing rather than
+    guessed from the currency the withholding happened to be taken in.
+    """
+    transactions = [
+        _dividend_at(DIVIDEND_DATE, 80, "A", GBP),
+        _tax_in_currency(DIVIDEND_DATE, -15, USD, "A"),
+    ]
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="cgt_calc.income"):
+        reported = _reported(
+            transactions,
+            autoconvert_currency=True,
+            gbp_prices={DIVIDEND_DATE: {USD: Decimal("1.25")}},
+        )
+
+    assert reported == [(DIVIDEND_DATE, Decimal(80), Decimal(-12), False)]
+    assert any(
+        "Source country of the GBP dividend is unknown" in record.message
+        for record in caplog.records
+    )

--- a/tests/general/test_dividend_tax_attribution.py
+++ b/tests/general/test_dividend_tax_attribution.py
@@ -744,7 +744,9 @@ def test_autoconvert_refuses_two_foreign_currencies_for_one_dividend() -> None:
         _dividend_at(DIVIDEND_DATE, 400, "B", PLN),
     ]
 
-    with pytest.raises(CalculationError, match="cannot choose between two foreign"):
+    with pytest.raises(
+        CalculationError, match="does not convert between foreign currencies"
+    ):
         _reported(
             transactions,
             autoconvert_currency=True,


### PR DESCRIPTION
Combines a dividend and its withholding tax when brokers report them in GBP plus one foreign currency, instead of failing with `Cannot combine amounts in different currencies`. Off by default.

- `CurrencyConverter.combine_amounts()` converts GBP rows into the sole foreign currency, keeping that currency for the existing ISIN-first source-country lookup.
- Two different non-GBP currencies are refused with an error naming the flag's limit, rather than picking a winner by size or row order, which would decide the double taxation treaty.
- `IncomeProcessor.process_dividends()` enforces the same boundary between a dividend and its withholding tax.
- `dividend_tax_list` is keyed by currency, so withholding in more than one currency is combined at the date of the dividend it is attributed to rather than the date it posted on. Combining at the posting date converted the GBP part at one month's rate and read the total back at another.
- Documents that without an ISIN the source-country fallback reads the dividend's currency, never the tax's.

Removes the `convert()` and `combined_currency()` helpers, which had no other callers.
