### PR TITLE
Reject non-finite decimals where the parsers read them

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -199,6 +199,7 @@ SpinOffs
 SplitHistory
 sqrt
 ss126
+StandardCSVParser
 stderr
 stdin
 stdout

--- a/cgt_calc/parsers/eri/raw.py
+++ b/cgt_calc/parsers/eri/raw.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import csv
 import datetime
-from decimal import Decimal, InvalidOperation
 from importlib import resources
 from typing import TYPE_CHECKING, Final, TextIO, override
 
@@ -19,6 +18,7 @@ from cgt_calc.exceptions import ParsingError, UnexpectedColumnCountError
 from cgt_calc.model import CurrencyCode, Isin, TransactionSource
 from cgt_calc.parsers.base_parsers import BaseSingleFileParser
 from cgt_calc.resources import RESOURCES_PACKAGE
+from cgt_calc.util import parse_decimal
 
 from .model import ERITransaction
 
@@ -59,8 +59,8 @@ class ERIRaw(ERITransaction):
             )
         price_str = row["Excess of reporting income over distribution"]
         try:
-            price = Decimal(price_str)
-        except (InvalidOperation, ValueError) as err:
+            price = parse_decimal(price_str, "ERI data")
+        except ValueError as err:
             raise ParsingError(
                 file, f"Invalid decimal '{price_str}' in ERI data"
             ) from err

--- a/cgt_calc/parsers/freetrade.py
+++ b/cgt_calc/parsers/freetrade.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import csv
 from datetime import UTC, datetime
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 from enum import StrEnum
 import logging
 from typing import TYPE_CHECKING, ClassVar, Final, TextIO, override
@@ -22,6 +22,7 @@ from cgt_calc.model import (
     Isin,
     TransactionSource,
 )
+from cgt_calc.util import parse_decimal
 
 from .base_parsers import BaseSingleFileParser
 
@@ -89,13 +90,7 @@ IGNORED_TYPES: Final[frozenset[str]] = frozenset(
 
 def _parse_decimal(row: dict[str, str], column: FreetradeColumn) -> Decimal:
     """Parse Decimal value for column, raising ValueError with context on failure."""
-    value = row[column]
-    try:
-        return Decimal(value)
-    except InvalidOperation as err:
-        raise ValueError(
-            f"Invalid decimal in column '{column.value}': {value!r}"
-        ) from err
+    return parse_decimal(row[column], f"column '{column.value}'")
 
 
 def _parse_optional_decimal(row: dict[str, str], column: FreetradeColumn) -> Decimal:

--- a/cgt_calc/parsers/hl.py
+++ b/cgt_calc/parsers/hl.py
@@ -14,6 +14,7 @@ import pdfplumber
 from cgt_calc.exceptions import ParsingError
 from cgt_calc.model import ActionType, BrokerTransaction, CurrencyCode, Isin
 from cgt_calc.parsers.base_parsers import BaseDirParser, StandardCSVParser
+from cgt_calc.util import parse_decimal
 
 # PDF parser regexes
 DATE_REGEX = re.compile(r"Date[^\d]*(\d{2}/\d{2}/\d{4})", re.IGNORECASE)
@@ -177,9 +178,11 @@ class HargreavesLansdownParser(
         symbol = None
         isin = None
 
-        amount_str = row.get("Value (£)", "0").replace(",", "")
+        amount_str = row.get("Value (£)", "0")
         amount = (
-            Decimal(amount_str) if amount_str and amount_str != "n/a" else Decimal(0)
+            parse_decimal(amount_str, "column 'Value (£)'", strip=",")
+            if amount_str and amount_str != "n/a"
+            else Decimal(0)
         )
 
         # Live PDF lookup only when needed for buy/sell actions

--- a/cgt_calc/parsers/interactive_brokers.py
+++ b/cgt_calc/parsers/interactive_brokers.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import datetime
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 from enum import StrEnum
 from itertools import chain
 import re
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, ClassVar, Final, override
 from cgt_calc.const import TICKER_RENAMES
 from cgt_calc.exceptions import ParsingError
 from cgt_calc.model import ActionType, BrokerTransaction, CurrencyCode, Isin
+from cgt_calc.util import parse_decimal
 
 from .base_parsers import StandardCSVParser
 
@@ -113,11 +114,7 @@ def _parse_decimal(row: dict[str, str], column: str) -> Decimal | None:
     if value == "-":
         return None
 
-    normalized = value.replace(",", "")
-    try:
-        return Decimal(normalized)
-    except InvalidOperation as err:
-        raise ValueError(f"Invalid decimal in column '{column}': {value!r}") from err
+    return parse_decimal(value, f"column '{column}'", strip=",")
 
 
 class InteractiveBrokersTransaction(BrokerTransaction):

--- a/cgt_calc/parsers/mssb.py
+++ b/cgt_calc/parsers/mssb.py
@@ -9,13 +9,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import datetime
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 from enum import StrEnum
 from typing import TYPE_CHECKING, ClassVar, Final, TextIO, override
 
 from cgt_calc.const import TICKER_RENAMES
 from cgt_calc.exceptions import ParsingError
 from cgt_calc.model import ActionType, BrokerTransaction, CurrencyCode
+from cgt_calc.util import parse_decimal
 
 from .base_parsers import BaseDirParser, StandardCSVParser
 
@@ -91,14 +92,7 @@ STOCK_SPLIT_INFO = [
 def _parse_decimal(row: dict[str, str], column: StrEnum) -> Decimal:
     """Parse a decimal from the given row, annotating errors with column context."""
 
-    value = row[column]
-    cleaned = value.replace(",", "").replace("$", "")
-    try:
-        return Decimal(cleaned)
-    except InvalidOperation as err:
-        raise ValueError(
-            f"Invalid decimal in column '{column.value}': {value!r}"
-        ) from err
+    return parse_decimal(row[column], f"column '{column.value}'", strip=",$")
 
 
 class MSSBParser(

--- a/cgt_calc/parsers/raw.py
+++ b/cgt_calc/parsers/raw.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import csv
 import datetime
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 from enum import StrEnum
 import logging
 from typing import TYPE_CHECKING, ClassVar, Final, Literal, TextIO, overload, override
@@ -17,6 +17,7 @@ from cgt_calc.model import (
     CurrencyCode,
     TransactionSource,
 )
+from cgt_calc.util import parse_decimal
 
 from .base_parsers import BaseSingleFileParser
 
@@ -94,13 +95,7 @@ def _parse_decimal(
             return default
         raise ValueError(f"Missing value in column '{column.value}'")
 
-    normalized = value.replace(",", "")
-    try:
-        return Decimal(normalized)
-    except InvalidOperation as err:
-        raise ValueError(
-            f"Invalid decimal in column '{column.value}': {value!r}"
-        ) from err
+    return parse_decimal(value, f"column '{column.value}'", strip=",")
 
 
 class RawTransaction(BrokerTransaction):

--- a/cgt_calc/parsers/revolut.py
+++ b/cgt_calc/parsers/revolut.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import csv
 import datetime
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 from enum import StrEnum
 from itertools import chain
 import logging
@@ -19,6 +19,7 @@ from cgt_calc.model import (
     CurrencyCode,
     TransactionSource,
 )
+from cgt_calc.util import parse_decimal
 
 from .base_parsers import StandardCSVParser
 
@@ -145,13 +146,7 @@ def _parse_decimal(
                 f"'{column.value}' but found: {value!r}"
             )
         value = value.removeprefix(prefix).strip()
-    normalized = value.replace(",", "")
-    try:
-        return Decimal(normalized)
-    except InvalidOperation as err:
-        raise ValueError(
-            f"Invalid decimal in column '{column.value}': {value!r}"
-        ) from err
+    return parse_decimal(value, f"column '{column.value}'", strip=",")
 
 
 class RevolutTransaction(BrokerTransaction):

--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -7,7 +7,7 @@ from collections import OrderedDict, defaultdict
 import csv
 from dataclasses import dataclass, replace
 import datetime
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 from enum import StrEnum
 import itertools
 import logging
@@ -37,6 +37,7 @@ from cgt_calc.model import (
     TransactionSource,
 )
 from cgt_calc.parsers.schwab_cusip_bonds import adjust_cusip_bond_price
+from cgt_calc.util import parse_decimal
 
 from .base_parsers import BaseSingleFileParser, next_account_token
 
@@ -182,24 +183,17 @@ def action_from_str(label: str, file: Path) -> ActionType:
     raise ParsingError(file, f"Unknown action: '{label}'")
 
 
-def parse_decimal(
+def _parse_decimal(
     row: OrderedDict[str, str],
     column: RequiredTransactionsColumn,
 ) -> Decimal | None:
     """Convert Schwab CSV column into Decimal, allowing optional blanks."""
 
     raw_value = row[column]
-
-    normalized = raw_value.replace("$", "").replace(",", "").strip()
-    if normalized == "":
+    if raw_value.strip(" $,") == "":
         return None
 
-    try:
-        return Decimal(normalized)
-    except InvalidOperation as err:
-        raise ValueError(
-            f"Invalid decimal in column '{column.value}': {raw_value!r}"
-        ) from err
+    return parse_decimal(raw_value, f"column '{column.value}'", strip="$,")
 
 
 class SchwabTransaction(BrokerTransaction):
@@ -246,12 +240,12 @@ class SchwabTransaction(BrokerTransaction):
         ):
             # Withholding on account-level cash interest, not tied to a security.
             action = ActionType.INTEREST_TAX
-        price = parse_decimal(row_dict, RequiredTransactionsColumn.PRICE)
-        quantity = parse_decimal(row_dict, RequiredTransactionsColumn.QUANTITY)
-        fees = parse_decimal(
+        price = _parse_decimal(row_dict, RequiredTransactionsColumn.PRICE)
+        quantity = _parse_decimal(row_dict, RequiredTransactionsColumn.QUANTITY)
+        fees = _parse_decimal(
             row_dict, RequiredTransactionsColumn.FEES_AND_COMM
         ) or Decimal(0)
-        amount = parse_decimal(row_dict, RequiredTransactionsColumn.AMOUNT)
+        amount = _parse_decimal(row_dict, RequiredTransactionsColumn.AMOUNT)
 
         # Handle bonds/notes: CUSIP symbols have price per $100 face value
         price, fees = adjust_cusip_bond_price(symbol, price, quantity, amount, fees)
@@ -339,17 +333,13 @@ def _combine_cash_merger_pair(
     adjustment_quantity = cash_merger_adj.quantity
     if (
         amount is None
-        or not amount.is_finite()
         or amount < 0
         or cash_merger.quantity is not None
         or cash_merger.price is not None
         or adjustment_quantity is None
-        or not adjustment_quantity.is_finite()
         or adjustment_quantity >= 0
         or cash_merger_adj.amount is not None
         or cash_merger_adj.price is not None
-        or not cash_merger.fees.is_finite()
-        or not cash_merger_adj.fees.is_finite()
     ):
         raise ParsingError(
             transactions_file,
@@ -398,17 +388,13 @@ def _combine_full_redemption_pair(
     redemption_quantity = full_redemption.quantity
     if (
         amount is None
-        or not amount.is_finite()
         or amount < 0
         or full_redemption_adj.quantity is not None
         or full_redemption_adj.price is not None
         or redemption_quantity is None
-        or not redemption_quantity.is_finite()
         or redemption_quantity >= 0
         or full_redemption.price is not None
         or full_redemption.amount is not None
-        or not full_redemption_adj.fees.is_finite()
-        or not full_redemption.fees.is_finite()
     ):
         raise ParsingError(
             transactions_file,

--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -810,8 +810,10 @@ def _read_schwab_awards(
         except ValueError as err:
             # This file is read outside StandardCSVParser, so nothing else
             # turns the helper's ValueError into an error naming the row.
+            # The format splits each award over two rows and states the price
+            # on the lower one, which is the row the reader has to correct.
             raise ParsingError(
-                schwab_award_transactions_file, str(err), row_index=row_index
+                schwab_award_transactions_file, str(err), row_index=row_index + 1
             ) from err
         if symbol is not None and price is not None:
             symbol = TICKER_RENAMES.get(symbol, symbol)

--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -798,11 +798,21 @@ def _read_schwab_awards(
         fair_market_value_price_header = (
             RequiredAwardColumn.FAIR_MARKET_VALUE_PRICE.value
         )
-        price = (
-            Decimal(row_dict[fair_market_value_price_header].replace("$", ""))
-            if row_dict[fair_market_value_price_header] != ""
-            else None
-        )
+        price_str = row_dict[fair_market_value_price_header]
+        try:
+            price = (
+                parse_decimal(
+                    price_str, f"column '{fair_market_value_price_header}'", strip="$"
+                )
+                if price_str != ""
+                else None
+            )
+        except ValueError as err:
+            # This file is read outside StandardCSVParser, so nothing else
+            # turns the helper's ValueError into an error naming the row.
+            raise ParsingError(
+                schwab_award_transactions_file, str(err), row_index=row_index
+            ) from err
         if symbol is not None and price is not None:
             symbol = TICKER_RENAMES.get(symbol, symbol)
             initial_prices[date][symbol] = price

--- a/cgt_calc/parsers/sharesight.py
+++ b/cgt_calc/parsers/sharesight.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable, Iterator, Mapping
 import csv
 from dataclasses import dataclass
 from datetime import date, datetime
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 from enum import StrEnum
 import logging
 from typing import TYPE_CHECKING, ClassVar, Final, TextIO, override
@@ -23,6 +23,7 @@ from cgt_calc.model import (
     CurrencyCode,
     TransactionSource,
 )
+from cgt_calc.util import parse_decimal
 
 from .base_parsers import BaseDirParser
 
@@ -229,13 +230,7 @@ class SharesightParser(BaseDirParser[SharesightTransaction]):
         row_dict: Mapping[Col, str], column: Col
     ) -> Decimal:
         """Convert column value to Decimal."""
-        raw_value = row_dict[column]
-        try:
-            return Decimal(raw_value.replace(",", ""))
-        except InvalidOperation as err:
-            raise ValueError(
-                f"Invalid decimal in column '{column.value}': {raw_value!r}"
-            ) from err
+        return parse_decimal(row_dict[column], f"column '{column.value}'", strip=",")
 
     @classmethod
     def _maybe_decimal[Col: StrEnum](

--- a/cgt_calc/parsers/trading212.py
+++ b/cgt_calc/parsers/trading212.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 import csv
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 from enum import StrEnum
 from itertools import combinations
 import logging
@@ -30,7 +30,7 @@ from cgt_calc.stock_splits import (
     quantity_sign,
     recover_ratio,
 )
-from cgt_calc.util import approx_equal, approx_equal_scaled
+from cgt_calc.util import approx_equal, approx_equal_scaled, parse_decimal
 
 from .base_parsers import BaseDirParser
 
@@ -229,16 +229,7 @@ def decimal_or_none(
     value = row.get(column)
     if value is None or value in {"", "Not available"}:
         return None
-    try:
-        parsed = Decimal(value)
-    except InvalidOperation as err:
-        raise ValueError(f"Invalid decimal in {column.value}: {value!r}") from err
-    # "NaN" and "Infinity" parse as decimals but are not amounts. Refused
-    # here, with the row, rather than at the first arithmetic that touches
-    # them, which raises a bare decimal exception with no context at all.
-    if not parsed.is_finite():
-        raise ValueError(f"Invalid decimal in {column.value}: {value!r}")
-    return parsed
+    return parse_decimal(value, column.value)
 
 
 def datetime_from_str(value: str) -> datetime:

--- a/cgt_calc/parsers/vanguard.py
+++ b/cgt_calc/parsers/vanguard.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import csv
 import datetime
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 from enum import StrEnum
 import io
 import re
@@ -18,6 +18,7 @@ from cgt_calc.model import (
     CurrencyCode,
     TransactionSource,
 )
+from cgt_calc.util import parse_decimal
 
 from .base_parsers import BaseSingleFileParser
 
@@ -137,11 +138,7 @@ def action_from_str(label: str, file: Path) -> ActionType:
 def _parse_decimal(value: str, context: str) -> Decimal:
     """Parse decimal value, raising ValueError with contextual message on failure."""
 
-    normalized = value.replace(",", "")
-    try:
-        return Decimal(normalized)
-    except InvalidOperation as err:
-        raise ValueError(f"Invalid decimal in {context}: {value!r}") from err
+    return parse_decimal(value, context, strip=",")
 
 
 def _parse_details(

--- a/cgt_calc/util.py
+++ b/cgt_calc/util.py
@@ -3,10 +3,33 @@
 from collections.abc import Generator
 from contextlib import contextmanager
 import decimal
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 import sys
 from typing import TextIO
+
+
+def parse_decimal(value: str, context: str, *, strip: str = "") -> Decimal:
+    """Parse an exported field as a finite decimal amount.
+
+    `context` names the field in the error, in whatever wording the parser
+    already uses, e.g. `column 'Quantity'`. `strip` lists the characters to
+    remove before parsing, such as the thousands separators and currency
+    symbols a broker writes into a number; the error still quotes the field
+    as the export wrote it.
+
+    "NaN" and "Infinity" parse as decimals but are not amounts. Refused here,
+    where the field is still known, rather than at the first arithmetic that
+    touches them, which raises a bare decimal exception naming neither the
+    file nor the row.
+    """
+    try:
+        parsed = Decimal(value.translate(str.maketrans("", "", strip)))
+    except InvalidOperation as err:
+        raise ValueError(f"Invalid decimal in {context}: {value!r}") from err
+    if not parsed.is_finite():
+        raise ValueError(f"Invalid decimal in {context}: {value!r}")
+    return parsed
 
 
 def round_decimal(value: Decimal, digits: int = 0) -> Decimal:

--- a/tests/general/test_eri_raw.py
+++ b/tests/general/test_eri_raw.py
@@ -33,15 +33,16 @@ def test_read_eri_raw_raises_on_invalid_date(tmp_path: Path) -> None:
         ERIRawParser.load_from_file(file_path)
 
 
-def test_read_eri_raw_raises_on_invalid_decimal(tmp_path: Path) -> None:
-    """Raise ParsingError when ERI decimal field cannot be parsed."""
+@pytest.mark.parametrize("value", ["not-a-number", "NaN", "Infinity"])
+def test_read_eri_raw_raises_on_invalid_decimal(tmp_path: Path, value: str) -> None:
+    """Raise ParsingError when ERI decimal field is not a finite amount."""
     file_path = tmp_path / "eri.csv"
     file_path.write_text(
-        HEADER + f"{VALID_ISIN},01/02/2024,USD,not-a-number\n",
+        HEADER + f"{VALID_ISIN},01/02/2024,USD,{value}\n",
         encoding="utf8",
     )
 
-    with pytest.raises(ParsingError, match="Invalid decimal 'not-a-number'"):
+    with pytest.raises(ParsingError, match=f"Invalid decimal '{value}'"):
         ERIRawParser.load_from_file(file_path)
 
 

--- a/tests/general/test_parse_decimal.py
+++ b/tests/general/test_parse_decimal.py
@@ -1,0 +1,160 @@
+"""Every parser refuses a field that is not a finite number.
+
+"NaN" and "Infinity" parse as decimals, so a corrupt export used to reach the
+calculation and fail there as a bare decimal exception naming neither the file
+nor the row. Each parser's own helper now routes through
+`cgt_calc.util.parse_decimal`, which refuses them where the column is known.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cgt_calc.exceptions import ParsingError
+from cgt_calc.parsers import (
+    freetrade,
+    interactive_brokers,
+    mssb,
+    raw,
+    revolut,
+    schwab,
+    trading212,
+    vanguard,
+)
+from cgt_calc.parsers.sharesight import SharesightParser, TradeColumn
+from cgt_calc.util import parse_decimal
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+# Every spelling `Decimal` accepts but no export can mean as an amount.
+NON_FINITE = ["NaN", "-NaN", "sNaN", "Infinity", "-Infinity", "inf", "-INF"]
+
+# One decimal field per parser, called the way that parser calls its own helper.
+PARSER_FIELDS: list[tuple[str, Callable[[str], Decimal | None], str]] = [
+    (
+        "raw",
+        lambda value: raw._parse_decimal(  # noqa: SLF001
+            {raw.RawColumn.QUANTITY: value},
+            raw.RawColumn.QUANTITY,
+            allow_empty=False,
+        ),
+        "quantity",
+    ),
+    (
+        "revolut",
+        lambda value: revolut._parse_decimal(  # noqa: SLF001
+            {revolut.RevolutColumn.QUANTITY: value},
+            revolut.RevolutColumn.QUANTITY,
+            allow_empty=False,
+        ),
+        "Quantity",
+    ),
+    (
+        "mssb",
+        lambda value: mssb._parse_decimal(  # noqa: SLF001
+            {mssb.ReleaseColumn.QUANTITY: value}, mssb.ReleaseColumn.QUANTITY
+        ),
+        "Quantity",
+    ),
+    (
+        "interactive_brokers",
+        lambda value: interactive_brokers._parse_decimal(  # noqa: SLF001
+            {interactive_brokers.InteractiveBrokersColumn.QUANTITY: value},
+            interactive_brokers.InteractiveBrokersColumn.QUANTITY,
+        ),
+        "Quantity",
+    ),
+    (
+        "schwab",
+        lambda value: schwab._parse_decimal(  # noqa: SLF001
+            OrderedDict({schwab.RequiredTransactionsColumn.QUANTITY: value}),
+            schwab.RequiredTransactionsColumn.QUANTITY,
+        ),
+        "Quantity",
+    ),
+    (
+        "sharesight",
+        lambda value: SharesightParser._parse_decimal(  # noqa: SLF001
+            {TradeColumn.QUANTITY: value}, TradeColumn.QUANTITY
+        ),
+        "Quantity",
+    ),
+    (
+        "freetrade",
+        lambda value: freetrade._parse_decimal(  # noqa: SLF001
+            {freetrade.FreetradeColumn.QUANTITY: value},
+            freetrade.FreetradeColumn.QUANTITY,
+        ),
+        "Quantity",
+    ),
+    (
+        "vanguard",
+        lambda value: vanguard._parse_decimal(value, "Quantity"),  # noqa: SLF001
+        "Quantity",
+    ),
+    (
+        "trading212",
+        lambda value: trading212.decimal_or_none(
+            {trading212.Trading212Column.NO_OF_SHARES: value},
+            trading212.Trading212Column.NO_OF_SHARES,
+        ),
+        "No. of shares",
+    ),
+]
+
+
+@pytest.mark.parametrize("value", NON_FINITE)
+@pytest.mark.parametrize(
+    ("parse", "column"),
+    [pytest.param(parse, column, id=name) for name, parse, column in PARSER_FIELDS],
+)
+def test_non_finite_field_is_refused(
+    parse: Callable[[str], Decimal | None], column: str, value: str
+) -> None:
+    """A non-finite field raises, naming the column and quoting the value."""
+    with pytest.raises(ValueError, match=f"Invalid decimal in .*{column}"):
+        parse(value)
+
+
+@pytest.mark.parametrize("value", ["1", "-2.5", "0"])
+def test_finite_field_still_parses(value: str) -> None:
+    """The guard leaves ordinary amounts alone."""
+    for _, parse, _ in PARSER_FIELDS:
+        assert parse(value) == Decimal(value)
+
+
+def test_non_finite_field_reports_the_file_and_row(tmp_path: Path) -> None:
+    """The refusal reaches the user as a parse error, not a traceback.
+
+    Revolut states its amounts with a currency prefix, so this also covers a
+    value the parser cleans before it is read as a number.
+    """
+    header = "Date,Ticker,Type,Quantity,Price per share,Total Amount,Currency,FX Rate\n"
+    row = (
+        "2021-07-20T09:00:00.000000Z,NVDA,BUY - MARKET,10,USD 100.00,USD NaN,USD,0.72\n"
+    )
+    revolut_file = tmp_path / "revolut.csv"
+    revolut_file.write_text(header + row, encoding="utf-8")
+
+    with pytest.raises(
+        ParsingError, match="row 2: Invalid decimal in column 'Total Amount': 'NaN'"
+    ):
+        revolut.RevolutParser().load_from_file(revolut_file)
+
+
+def test_parse_decimal_strips_only_what_it_is_told_to() -> None:
+    """`strip` removes the separators a broker writes, and nothing else."""
+    assert parse_decimal("1,250.00", "column 'Amount'", strip=",") == Decimal("1250.00")
+    assert parse_decimal("$1,250.00", "column 'Amount'", strip=",$") == Decimal(
+        "1250.00"
+    )
+    with pytest.raises(
+        ValueError, match=r"Invalid decimal in column 'Amount': '1,250'"
+    ):
+        parse_decimal("1,250", "column 'Amount'")

--- a/tests/general/test_stock_splits.py
+++ b/tests/general/test_stock_splits.py
@@ -1704,14 +1704,8 @@ def test_two_accounts_in_different_files_still_do_not_conflict() -> None:
 
 def test_an_invalid_raw_override_keeps_its_named_quantity_error() -> None:
     """Override validation must not turn a bad RAW delta into a Decimal error."""
-    with pytest.raises(CalculationError, match="which is not a number of shares"):
-        run(
-            [
-                trade(POOL_DAY, ActionType.BUY, "FOO", "10", "10"),
-                legacy_split(EVENT_DAY, "FOO", "10"),
-                raw_split(EVENT_DAY, "FOO", "NaN"),
-            ]
-        )
+    with pytest.raises(ValueError, match="Invalid decimal in column 'quantity'"):
+        raw_split(EVENT_DAY, "FOO", "NaN")
 
 
 def test_two_raw_rows_for_one_day_are_still_refused() -> None:

--- a/tests/hl/test_hl.py
+++ b/tests/hl/test_hl.py
@@ -253,6 +253,20 @@ def test_read_row_interest() -> None:
     assert transaction.fees == Decimal(0)
 
 
+@pytest.mark.parametrize("value", ["NaN", "Infinity", "not-a-number"])
+def test_read_row_unreadable_value(value: str) -> None:
+    """Refuse a value column that is not a finite amount, naming the column."""
+    row = {
+        "Reference": "Interest",
+        "Description": "Gross interest",
+        "Trade date": "01/03/2026",
+        "Value (\u00a3)": value,
+    }
+
+    with pytest.raises(ValueError, match=r"Invalid decimal in column 'Value"):
+        HargreavesLansdownParser.read_row(row, Path("statement.csv"))
+
+
 def test_read_row_transfer_with_na_value() -> None:
     """Read a fee row where the value column is n/a."""
     row = {

--- a/tests/schwab/test_schwab.py
+++ b/tests/schwab/test_schwab.py
@@ -89,7 +89,9 @@ def test_award_price_that_is_not_a_finite_amount_is_reported(
     ) as exc_info:
         _read_schwab_awards(award_file)
 
-    assert exc_info.value.row_index == 2
+    # The price is stated on the lower half of the split award row, so the
+    # row to correct is 3: row 1 is the header and row 2 holds the upper half.
+    assert exc_info.value.row_index == 3
 
 
 def test_award_file_without_the_award_says_so() -> None:

--- a/tests/schwab/test_schwab.py
+++ b/tests/schwab/test_schwab.py
@@ -398,11 +398,6 @@ def test_invalid_cash_merger_pair() -> None:
         ('"-$100.00"', "-10", "", ""),
         # A positive quantity is not shares leaving the account.
         ('"$100.00"', "10", "", ""),
-        # Non-finite values would silently poison the derived price.
-        ("NaN", "-10", "", ""),
-        ('"$100.00"', "NaN", "", ""),
-        # Non-finite fees would silently poison the combined fees.
-        ('"$100.00"', "-10", "", "NaN"),
         # A price on the adjustment row is not part of the format.
         ('"$100.00"', "-10", "5", ""),
     ],
@@ -426,9 +421,6 @@ def test_cash_merger_pair_with_invalid_values(
     [
         ('"-$100.00"', "-10", ""),
         ('"$100.00"', "10", ""),
-        ("NaN", "-10", ""),
-        ('"$100.00"', "NaN", ""),
-        ('"$100.00"', "-10", "NaN"),
     ],
 )
 def test_full_redemption_pair_with_invalid_values(

--- a/tests/schwab/test_schwab.py
+++ b/tests/schwab/test_schwab.py
@@ -66,6 +66,32 @@ def test_award_rows_overlapping_in_a_column_are_reported(tmp_path: Path) -> None
     assert exc_info.value.row_index == 2
 
 
+@pytest.mark.parametrize("price", ["NaN", "$Infinity", "$not-a-number"])
+def test_award_price_that_is_not_a_finite_amount_is_reported(
+    tmp_path: Path, price: str
+) -> None:
+    """An unreadable award price names the file and row, not a late traceback.
+
+    The award file is read outside the CSV parser, so a bad price used to
+    reach the matching engine and fail there with nothing to point at.
+    """
+    award_file = tmp_path / "awards.csv"
+    award_file.write_text(
+        "Date,Action,Symbol,Description,Quantity,FeesAndCommissions,"
+        "DisbursementElection,Amount,AwardDate,AwardId,FairMarketValuePrice,"
+        "SalePrice,SharesSoldWithheldForTaxes,NetSharesDeposited,Taxes\n"
+        "08/15/2023,Lapse,BAR,Restricted Stock Lapse,400,,,,,,,,,,\n"
+        f',,,,,,,,03/21/2022,101883189,{price},,200,200,"$13,192.90"\n'
+    )
+
+    with pytest.raises(
+        ParsingError, match="Invalid decimal in column 'FairMarketValuePrice'"
+    ) as exc_info:
+        _read_schwab_awards(award_file)
+
+    assert exc_info.value.row_index == 2
+
+
 def test_award_file_without_the_award_says_so() -> None:
     """A file that lacks this particular award is a different mistake."""
     path = Path("tests") / "schwab" / "data" / "rsu_settlement" / "transactions.csv"

--- a/tests/schwab/test_schwab_parser.py
+++ b/tests/schwab/test_schwab_parser.py
@@ -69,6 +69,11 @@ def test_parse_valid_row() -> None:
         (RequiredTransactionsColumn.QUANTITY, "not-a-number"),
         (RequiredTransactionsColumn.FEES_AND_COMM, "$bogus"),
         (RequiredTransactionsColumn.AMOUNT, "$invalid"),
+        # "NaN" and "Infinity" parse as decimals but are not amounts.
+        (RequiredTransactionsColumn.PRICE, "NaN"),
+        (RequiredTransactionsColumn.QUANTITY, "Infinity"),
+        (RequiredTransactionsColumn.FEES_AND_COMM, "NaN"),
+        (RequiredTransactionsColumn.AMOUNT, "-Infinity"),
     ],
 )
 def test_parse_row_invalid_decimal_raises(


### PR DESCRIPTION
`Decimal("NaN")` and `Decimal("Infinity")` parse without complaint, so a corrupt field reached the calculation and failed there as a bare decimal exception naming neither the file nor the row. Only `trading212.py` refused them; every other parser had its own near-clone of the same unguarded helper.

- Add `cgt_calc.util.parse_decimal`, which refuses a non-finite value where the column is still known. Its `strip` argument lists the thousands separators and currency symbols an export writes into a number, and the error quotes the field as the export wrote it.
- Route the decimal helpers in `raw.py`, `revolut.py`, `mssb.py`, `interactive_brokers.py`, `schwab.py`, `sharesight.py`, `freetrade.py`, `vanguard.py`, `trading212.py` and `eri/raw.py` through it. Cleaning and error wording are unchanged, so only non-finite values are newly refused.
- Read the Schwab award file's `FairMarketValuePrice` column through it. That file is read outside `StandardCSVParser`, so a `NaN` price was accepted and failed later during matching, and a malformed one escaped as `InvalidOperation`; both now raise `ParsingError` naming the column and physical row.
- Read the Hargreaves Lansdown value column through it too. It had no `try`/`except` at all, so a malformed value escaped as `InvalidOperation`, which `StandardCSVParser` does not catch; it now raises `ParsingError` naming the column and row.
- Rename `schwab.parse_decimal` to `_parse_decimal`, matching every other parser, so it no longer shadows the shared helper.

Drops eight `is_finite()` repeats from `_combine_cash_merger_pair` and `_combine_full_redemption_pair` in `schwab.py`: every amount, quantity and fee they check now comes from the guarded helper, so those branches were unreachable. The calculation-layer checks in `ingestion.py` are kept - they also see computed values and rows the parsers do not build.
