### PR TITLE
Clarify Revolut import limitations

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -73,8 +73,10 @@ env
 ERI
 ESPP
 etc
+ETCs
 ETF
 ETFs
+ETNs
 expanduser
 f
 FeesAndCommissions

--- a/docs/brokers/revolut.md
+++ b/docs/brokers/revolut.md
@@ -156,8 +156,13 @@ whose columns were reordered or removed would be read incorrectly.
 ### `Reached a negative balance`
 
 Check that the period was set to **All time** so that the top ups, transfers and sales that funded
-later purchases are all present. Do not add a made-up top up or use `--no-balance-check` just to
-silence the error; establish the missing cash or holdings from your Revolut records first.
+later purchases are all present. Do not add a made-up top up to silence the error; establish the
+missing cash or holdings from your Revolut records first.
+
+Revolut can report a cash balance of `-0.01` even when your transaction history is complete. If your
+records account for every transaction and the shortfall is a hundredth of a unit or so, rerun with
+`--no-balance-check`. This disables the check for every input in the run, so compare each amount in
+the terminal's **Final balance** list with your broker records.
 
 ### The portfolio or dividends look wrong
 

--- a/docs/brokers/revolut.md
+++ b/docs/brokers/revolut.md
@@ -111,10 +111,11 @@ transaction stamped at or after 23:00 UTC on 5 April belongs to the following ta
 
 ### Dividends and withholding tax
 
-The CSV can contain a `DIVIDEND` amount and a separate `DIVIDEND TAX (CORRECTION)` amount. cgt-calc
-treats the first as gross dividend income and the second as tax withheld. In the first-pass terminal
-output, the value after `excluding ... taxed at source` comes from the tax-correction rows; it is
-not calculated from the dividend amount.
+cgt-calc cannot tell whether a CSV `DIVIDEND` amount is before or after withholding tax, so it
+treats the amount as gross dividend income. It treats a separate `DIVIDEND TAX (CORRECTION)` amount
+as tax withheld. In the terminal's **Dividends** list printed after **Final balance**, the value
+after `excluding ... taxed at source` comes from the tax-correction rows; it is not calculated from
+the dividend amount.
 
 For each dividend, open **Invest**, then **Portfolio** → **Transactions** → **Dividend**. Revolut
 shows the withholding tax in the transaction details

--- a/docs/brokers/revolut.md
+++ b/docs/brokers/revolut.md
@@ -52,15 +52,15 @@ The filename does not matter. `--year 2025` means 6 April 2025 to 5 April 2026. 
 
 The importer recognises these exact values from the CSV's `Type` column:
 
-| Type                             | How cgt-calc handles it                                              |
-| -------------------------------- | -------------------------------------------------------------------- |
-| `BUY - MARKET`, `BUY - LIMIT`    | Share acquisitions                                                   |
-| `SELL - MARKET`, `SELL - LIMIT`  | Share disposals                                                      |
-| `DIVIDEND`                       | Net dividend income; see [Dividends](#dividends-and-withholding-tax) |
-| `DIVIDEND TAX (CORRECTION)`      | Corrections to dividend withholding tax                              |
-| `STOCK SPLIT`                    | Changes the share count without changing the existing pooled cost    |
-| `CUSTODY FEE`                    | Cash leaving the broker balance                                      |
-| `CASH TOP-UP`, `CASH WITHDRAWAL` | Cash added to or removed from the broker balance                     |
+| Type                             | How cgt-calc handles it                                                      |
+| -------------------------------- | ---------------------------------------------------------------------------- |
+| `BUY - MARKET`, `BUY - LIMIT`    | Share acquisitions                                                           |
+| `SELL - MARKET`, `SELL - LIMIT`  | Share disposals                                                              |
+| `DIVIDEND`                       | Reported as dividend income; see [Dividends](#dividends-and-withholding-tax) |
+| `DIVIDEND TAX (CORRECTION)`      | Reported as tax at source                                                    |
+| `STOCK SPLIT`                    | Changes the share count without changing the existing pooled cost            |
+| `CUSTODY FEE`                    | Cash leaving the broker balance                                              |
+| `CASH TOP-UP`, `CASH WITHDRAWAL` | Cash added to or removed from the broker balance                             |
 
 cgt-calc also ignores these two exact `Type` values because moving cash or holdings between Revolut
 entities is not a disposal or acquisition:
@@ -97,28 +97,33 @@ transaction stamped at or after 23:00 UTC on 5 April belongs to the following ta
 - Only the types listed above are mapped. Any other value stops the import with `Unknown action`; do
     not delete a financial transaction merely to make the calculation run, because the missing
     activity could make the resulting holdings and gains incorrect.
-- A Revolut `STOCK SPLIT` row states only the change in that account. cgt-calc stops if you also
-    hold the ticker through another input. It also stops if Revolut booked another transaction for
-    the ticker earlier on the same day, because the export does not say whether that transaction's
-    share count is before or after the split. Follow the error's instructions to provide a complete
-    [`STOCK_SPLIT` row](raw.md#share-reorganisations), or calculate the event outside cgt-calc.
+- A Revolut `STOCK SPLIT` row states only the change in that account. If you also hold the ticker
+    through another input, cgt-calc stops. Follow the error's instructions to provide a complete
+    [`STOCK_SPLIT` row](raw.md#share-reorganisations) for the whole holding, or calculate the event
+    outside cgt-calc.
+- cgt-calc also stops if Revolut booked another transaction for the ticker earlier on the day of a
+    split. The export does not say whether that transaction's share count is before or after the
+    split, and a RAW `STOCK_SPLIT` row cannot resolve this. Work out the day's transactions and
+    split outside cgt-calc.
 - A custody fee reduces the broker balance but is not treated as an allowable cost against a gain.
 - The statement covers the investment account only. Commodities and interest on savings products are
     not part of this export.
 
 ### Dividends and withholding tax
 
-The `DIVIDEND` amount in the Revolut CSV is after withholding tax, but the CSV does not state the
-gross dividend or the original tax deducted. cgt-calc reports the net amount as **Proceeds**. HMRC
-calculates foreign income before direct foreign tax is deducted, so this figure is too low
-([HMRC guidance](https://www.gov.uk/hmrc-internal-manuals/international-manual/intm165030)). A
-`DIVIDEND TAX (CORRECTION)` row records only a later correction.
+The CSV can contain a `DIVIDEND` amount and a separate `DIVIDEND TAX (CORRECTION)` amount. cgt-calc
+treats the first as gross dividend income and the second as tax withheld. In the first-pass terminal
+output, the value after `excluding ... taxed at source` comes from the tax-correction rows; it is
+not calculated from the dividend amount.
 
 For each dividend, open **Invest**, then **Portfolio** → **Transactions** → **Dividend**. Revolut
 shows the withholding tax in the transaction details
 ([Revolut dividend guide](https://help.revolut.com/help/wealth/stocks/corporate-events/receiving-dividends/)).
-Use those details to establish the gross dividend and tax withheld, then adjust the dividend and
-foreign-tax figures outside cgt-calc.
+HMRC calculates foreign income before direct foreign tax is deducted
+([HMRC guidance](https://www.gov.uk/hmrc-internal-manuals/international-manual/intm165030)). Use the
+Revolut details to check that the CSV's `DIVIDEND` amount is the gross dividend and that the
+`taxed at source` figure is the total tax withheld. If either figure differs, adjust the dividend
+and foreign-tax figures outside cgt-calc.
 
 ## Troubleshooting
 

--- a/docs/brokers/revolut.md
+++ b/docs/brokers/revolut.md
@@ -10,9 +10,12 @@ The CSV does not identify the account type, so cgt-calc cannot separate the acco
 
 ## Export your account statement
 
+Follow the
+[Revolut account statement instructions](https://help.revolut.com/help/wealth/stocks/getting-started-with-trading/managing-your-trading-account/trading-statements/accessing-my-trading-statements-and-reports/):
+
 1. In Revolut, open **Invest**.
 2. Select **More**, then **Documents**.
-3. Choose **General Investment**, then **Account statement**.
+3. Choose **Stocks**, select your **General Investment** account, then **Account statement**.
 4. Choose the **CSV** format rather than PDF.
 5. Set the Period to **All time**.
 6. Generate the CSV file.
@@ -23,6 +26,17 @@ needed.
 
 Keep the exported columns unchanged.
 
+### Check the investments in the export
+
+Check each holding's product type in Revolut. The CSV does not identify whether a ticker is a
+company share, fund, bond or another product. cgt-calc treats every `BUY` and `SELL` row as a share
+transaction and cannot detect when another tax treatment is needed.
+
+- For an ETF or other fund, check whether it is an offshore fund and follow the
+    [offshore-fund guide](../offshore-funds.md).
+- cgt-calc does not identify or validate the tax treatment of bonds, ETNs, ETCs or other
+    instruments. Calculate them outside cgt-calc.
+
 ## Generate the report
 
 For the 2025/26 tax year, run:
@@ -31,23 +45,28 @@ For the 2025/26 tax year, run:
 cgt-calc --year 2025 --revolut-file revolut.csv
 ```
 
-The filename does not matter. `--year 2025` means 6 April 2025 to 5 April 2026. Follow
-[Generate Your First Report](../usage.md) to find and check the output.
+The filename does not matter. `--year 2025` means 6 April 2025 to 5 April 2026. Follow the
+[report guide](../usage.md) to find and check the output.
 
 ## Supported activity
 
-The importer recognises these literal values from the CSV's `Type` column:
+The importer recognises these exact values from the CSV's `Type` column:
 
-| Type                                       | How cgt-calc handles it                                                        |
-| ------------------------------------------ | ------------------------------------------------------------------------------ |
-| `BUY - MARKET`, `BUY - LIMIT`              | Share acquisitions                                                             |
-| `SELL - MARKET`, `SELL - LIMIT`            | Share disposals                                                                |
-| `DIVIDEND`                                 | Dividend income after withholding tax                                          |
-| `DIVIDEND TAX (CORRECTION)`                | Corrections to dividend withholding tax                                        |
-| `STOCK SPLIT`                              | The extra shares are pooled at zero cost, and the ratio adjusts share matching |
-| `CUSTODY FEE`                              | Cash leaving the broker balance                                                |
-| `CASH TOP-UP`, `CASH WITHDRAWAL`           | Cash added to or removed from the broker balance                               |
-| `TRANSFER FROM REVOLUT ... TO REVOLUT ...` | Ignored: the move between Revolut entities is not a disposal or acquisition    |
+| Type                             | How cgt-calc handles it                                              |
+| -------------------------------- | -------------------------------------------------------------------- |
+| `BUY - MARKET`, `BUY - LIMIT`    | Share acquisitions                                                   |
+| `SELL - MARKET`, `SELL - LIMIT`  | Share disposals                                                      |
+| `DIVIDEND`                       | Net dividend income; see [Dividends](#dividends-and-withholding-tax) |
+| `DIVIDEND TAX (CORRECTION)`      | Corrections to dividend withholding tax                              |
+| `STOCK SPLIT`                    | Changes the share count without changing the existing pooled cost    |
+| `CUSTODY FEE`                    | Cash leaving the broker balance                                      |
+| `CASH TOP-UP`, `CASH WITHDRAWAL` | Cash added to or removed from the broker balance                     |
+
+cgt-calc also ignores these two exact `Type` values because moving cash or holdings between Revolut
+entities is not a disposal or acquisition:
+
+- `TRANSFER FROM REVOLUT BANK UAB TO REVOLUT SECURITIES EUROPE UAB`
+- `TRANSFER FROM REVOLUT TRADING LTD TO REVOLUT SECURITIES EUROPE UAB`
 
 The `Price per share` and `Total Amount` columns each carry a currency prefix, such as `USD 134.50`,
 which must match the `Currency` column of the same row. cgt-calc recalculates the price as
@@ -61,32 +80,52 @@ The `FX Rate` column is not used. cgt-calc converts foreign currency amounts usi
 shown by Revolut.
 
 A `STOCK SPLIT` row states the number of shares added, not the new total holding, and its
-`Total Amount` is zero.
+`Total Amount` is zero. cgt-calc treats it as a share reorganisation: nothing is bought or sold, and
+the pooled cost is unchanged and spread over the new share count
+([HMRC CG51805](https://www.gov.uk/hmrc-internal-manuals/capital-gains-manual/cg51805)). The ratio
+also adjusts share matching.
 
 ### Dates and time zones
 
 Revolut timestamps every transaction in UTC. cgt-calc converts each one to UK time, GMT in winter
 and BST in summer, before taking the date. The tax year boundary and the same-day and 30-day
 matching rules all run on UK calendar days, and the boundary always falls inside BST, so a
-transaction stamped after 23:00 UTC on 5 April belongs to the following tax year.
+transaction stamped at or after 23:00 UTC on 5 April belongs to the following tax year.
 
 ## Known limitations
 
 - Only the types listed above are mapped. Any other value stops the import with `Unknown action`; do
     not delete a financial transaction merely to make the calculation run, because the missing
     activity could make the resulting holdings and gains incorrect.
-- Revolut reports dividend amounts after withholding tax, but does not export the tax amount.
+- A Revolut `STOCK SPLIT` row states only the change in that account. cgt-calc stops if you also
+    hold the ticker through another input. It also stops if Revolut booked another transaction for
+    the ticker earlier on the same day, because the export does not say whether that transaction's
+    share count is before or after the split. Follow the error's instructions to provide a complete
+    [`STOCK_SPLIT` row](raw.md#share-reorganisations), or calculate the event outside cgt-calc.
 - A custody fee reduces the broker balance but is not treated as an allowable cost against a gain.
 - The statement covers the investment account only. Commodities and interest on savings products are
     not part of this export.
+
+### Dividends and withholding tax
+
+The `DIVIDEND` amount in the Revolut CSV is after withholding tax, but the CSV does not state the
+gross dividend or the original tax deducted. cgt-calc reports the net amount as **Proceeds**. HMRC
+calculates foreign income before direct foreign tax is deducted, so this figure is too low
+([HMRC guidance](https://www.gov.uk/hmrc-internal-manuals/international-manual/intm165030)). A
+`DIVIDEND TAX (CORRECTION)` row records only a later correction.
+
+For each dividend, open **Invest**, then **Portfolio** → **Transactions** → **Dividend**. Revolut
+shows the withholding tax in the transaction details
+([Revolut dividend guide](https://help.revolut.com/help/wealth/stocks/corporate-events/receiving-dividends/)).
+Use those details to establish the gross dividend and tax withheld, then adjust the dividend and
+foreign-tax figures outside cgt-calc.
 
 ## Troubleshooting
 
 ### `Unknown action`
 
 Revolut might add a new transaction type. First, upgrade cgt-calc using the same method you used to
-install it and try again. If the error remains, open a
-[GitHub issue](https://github.com/cgt-calc/capital-gains-calculator/issues/new) containing:
+install it and try again. If the error remains, open a GitHub issue containing:
 
 - your cgt-calc version from `cgt-calc --version`;
 - the complete error message; and
@@ -117,5 +156,6 @@ silence the error; establish the missing cash or holdings from your Revolut reco
 ### The portfolio or dividends look wrong
 
 Check the terminal section headed “Portfolio at the end of … tax year” against your Revolut holdings
-on 5 April, and compare dividends and withholding with the statement. If a real exported row
-disagrees with the report, open a GitHub issue with sanitised values from that row.
+on 5 April. Compare each net dividend with the CSV and check its gross amount and withholding tax as
+described above. If a real exported row disagrees with the report, open a GitHub issue with
+sanitised values from that row.

--- a/lychee.toml
+++ b/lychee.toml
@@ -12,6 +12,9 @@ timeout = 20
 # markdown-link-check config needed for the Trade Tariff site.
 user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
 
+# Revolut Help uses a Cloudflare browser challenge and rejects link checkers.
+exclude = ["^https://help\\.revolut\\.com/"]
+
 # Reuse results between runs so unchanged links are not fetched again.
 cache = true
 max_cache_age = "1d"


### PR DESCRIPTION
Clarify how Revolut exports affect tax figures.

- distinguish share transactions from funds and other instruments
- explain how cgt-calc reports dividends and withholding tax
- explain stock splits, transfers, time zones and small negative balances
- link current Revolut and HMRC guidance
- exclude Revolut Help from link checks because it blocks automated clients