### PR TITLE
Accept comma-grouped Schwab award fair market values

### DIFF
--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -802,7 +802,7 @@ def _read_schwab_awards(
         try:
             price = (
                 parse_decimal(
-                    price_str, f"column '{fair_market_value_price_header}'", strip="$"
+                    price_str, f"column '{fair_market_value_price_header}'", strip="$,"
                 )
                 if price_str != ""
                 else None

--- a/tests/schwab/test_schwab.py
+++ b/tests/schwab/test_schwab.py
@@ -94,6 +94,22 @@ def test_award_price_that_is_not_a_finite_amount_is_reported(
     assert exc_info.value.row_index == 3
 
 
+def test_award_price_with_thousands_separators_is_parsed(tmp_path: Path) -> None:
+    """Schwab groups prices over 999 with commas, such as $1,250.00."""
+    award_file = tmp_path / "awards.csv"
+    award_file.write_text(
+        "Date,Action,Symbol,Description,Quantity,FeesAndCommissions,"
+        "DisbursementElection,Amount,AwardDate,AwardId,FairMarketValuePrice,"
+        "SalePrice,SharesSoldWithheldForTaxes,NetSharesDeposited,Taxes\n"
+        "08/15/2023,Lapse,BAR,Restricted Stock Lapse,400,,,,,,,,,,\n"
+        ',,,,,,,,03/21/2022,101883189,"$1,250.00",,200,200,"$13,192.90"\n'
+    )
+
+    awards = _read_schwab_awards(award_file)
+
+    assert awards.award_prices[datetime.date(2023, 8, 15)]["BAR"] == Decimal("1250.00")
+
+
 def test_award_file_without_the_award_says_so() -> None:
     """A file that lacks this particular award is a different mistake."""
     path = Path("tests") / "schwab" / "data" / "rsu_settlement" / "transactions.csv"


### PR DESCRIPTION
`_read_schwab_awards()` rejected valid Schwab award exports whenever `FairMarketValuePrice` was $1,000 or more, because it stripped `$` but not the thousands-separator commas Schwab writes into that column, and #1079 made `parse_decimal()` refuse anything it cannot parse outright.

- Strip `,` as well as `$` from `FairMarketValuePrice` in `_read_schwab_awards()` (`cgt_calc/parsers/schwab.py`), matching the sibling `_parse_decimal()` call in the same file that already reads the transactions file this way.
- Add a regression test parsing a quoted `"$1,250.00"` award price into `Decimal("1250.00")`.

Non-finite and malformed prices are still refused, and the error still names the correct physical row of the split award pair.