### PR TITLE
Correct the recovery hint when the spin-offs cache is disabled

### DIFF
--- a/cgt_calc/exceptions.py
+++ b/cgt_calc/exceptions.py
@@ -303,25 +303,25 @@ class ExternalApiError(CgtError):
 class InteractiveInputRequiredError(CgtError):
     """Raised when a prompt is needed but stdin is not a terminal."""
 
-    def __init__(
-        self, symbol: str, date: datetime.date, spin_offs_file: Path | None
-    ) -> None:
+    def __init__(self, symbol: str, date: datetime.date, spin_offs_file: Path | None):
         """Initialise."""
         if spin_offs_file is None:
-            message = (
-                f"Cannot ask which stock {symbol} was spun off from on {date}: "
-                "standard input is not a terminal (this also applies when piping "
-                f"transactions via '-'). Pass a real --spin-offs-file path for "
-                "non-interactive runs, or provide the mapping interactively."
+            # An empty --spin-offs-file disables the cache, so there is no file
+            # to add the row to: naming one would send the user in a circle.
+            hint = (
+                "Pass a non-empty --spin-offs-file path containing a "
+                f"'{symbol},<source>' row (header 'dst,src') and rerun."
             )
         else:
-            message = (
-                f"Cannot ask which stock {symbol} was spun off from on {date}: "
-                "standard input is not a terminal (this also applies when piping "
-                f"transactions via '-'). Add a '{symbol},<source>' row to "
-                f"{spin_offs_file} (header 'dst,src') and rerun."
+            hint = (
+                f"Add a '{symbol},<source>' row to {spin_offs_file} "
+                "(header 'dst,src') and rerun."
             )
-        super().__init__(message)
+        super().__init__(
+            f"Cannot ask which stock {symbol} was spun off from on {date}: "
+            "standard input is not a terminal (this also applies when piping "
+            f"transactions via '-'). {hint}"
+        )
 
 
 class MarketDataMissingError(CgtError):

--- a/cgt_calc/exceptions.py
+++ b/cgt_calc/exceptions.py
@@ -303,14 +303,25 @@ class ExternalApiError(CgtError):
 class InteractiveInputRequiredError(CgtError):
     """Raised when a prompt is needed but stdin is not a terminal."""
 
-    def __init__(self, symbol: str, date: datetime.date, spin_offs_file: Path):
+    def __init__(
+        self, symbol: str, date: datetime.date, spin_offs_file: Path | None
+    ) -> None:
         """Initialise."""
-        super().__init__(
-            f"Cannot ask which stock {symbol} was spun off from on {date}: "
-            "standard input is not a terminal (this also applies when piping "
-            f"transactions via '-'). Add a '{symbol},<source>' row to "
-            f"{spin_offs_file} (header 'dst,src') and rerun."
-        )
+        if spin_offs_file is None:
+            message = (
+                f"Cannot ask which stock {symbol} was spun off from on {date}: "
+                "standard input is not a terminal (this also applies when piping "
+                f"transactions via '-'). Pass a real --spin-offs-file path for "
+                "non-interactive runs, or provide the mapping interactively."
+            )
+        else:
+            message = (
+                f"Cannot ask which stock {symbol} was spun off from on {date}: "
+                "standard input is not a terminal (this also applies when piping "
+                f"transactions via '-'). Add a '{symbol},<source>' row to "
+                f"{spin_offs_file} (header 'dst,src') and rerun."
+            )
+        super().__init__(message)
 
 
 class MarketDataMissingError(CgtError):

--- a/cgt_calc/spin_off_handler.py
+++ b/cgt_calc/spin_off_handler.py
@@ -7,7 +7,6 @@ import logging
 import sys
 from typing import TYPE_CHECKING, Final
 
-from .const import DEFAULT_SPIN_OFF_FILE
 from .exceptions import InteractiveInputRequiredError, ParsingError
 from .util import open_with_parents
 
@@ -67,7 +66,7 @@ class SpinOffHandler:
 
         if not sys.stdin.isatty():
             raise InteractiveInputRequiredError(
-                symbol, date, self.spin_offs_file or DEFAULT_SPIN_OFF_FILE
+                symbol, date, self.spin_offs_file
             )
 
         while True:
@@ -80,7 +79,7 @@ class SpinOffHandler:
                 )
             except EOFError as err:
                 raise InteractiveInputRequiredError(
-                    symbol, date, self.spin_offs_file or DEFAULT_SPIN_OFF_FILE
+                    symbol, date, self.spin_offs_file
                 ) from err
             if ticker in portfolio:
                 break

--- a/cgt_calc/spin_off_handler.py
+++ b/cgt_calc/spin_off_handler.py
@@ -65,9 +65,7 @@ class SpinOffHandler:
             return self.cache[symbol]
 
         if not sys.stdin.isatty():
-            raise InteractiveInputRequiredError(
-                symbol, date, self.spin_offs_file
-            )
+            raise InteractiveInputRequiredError(symbol, date, self.spin_offs_file)
 
         while True:
             # This would ideally be fetched from some stock DB but yfinance does not

--- a/docs/brokers/raw.md
+++ b/docs/brokers/raw.md
@@ -103,7 +103,7 @@ cost, which is the safer way to be wrong.
 For a `SPIN_OFF`, cgt-calc needs to know which holding the new shares came from. It looks the new
 ticker up in [`--spin-offs-file`](../extra-data-and-options.md#spin-off-source-mappings), asks you
 when it is not there, and saves your answer to that file so it only asks once; a run that cannot
-ask, such as one in a script, stops and tells you to add the row yourself. It then looks up a
+ask, such as one in a script, stops and tells you how to supply the row yourself. It then looks up a
 closing price for the new and the old ticker on that date to divide the old holding's pooled cost
 between them, so a price for both has to be available.
 

--- a/docs/extra-data-and-options.md
+++ b/docs/extra-data-and-options.md
@@ -52,8 +52,9 @@ A spin-off row may name the new holding without naming the old holding it came f
 that link to divide the existing pooled cost between them. During an interactive run, it asks for
 the old ticker and saves the answer to `out/spin_offs.csv`.
 
-If the run cannot ask, it stops and tells you which `dst,src` row to add. Use `--spin-offs-file` to
-select another file for these mappings.
+If the run cannot ask you for the old ticker, add the required `dst,src` row to a mapping file, pass
+that file with `--spin-offs-file`, and rerun. An empty value disables the cache, so cgt-calc does
+not read or save spin-off mappings.
 
 ### Estimate unrealized gains
 

--- a/tests/general/test_spin_off_handler.py
+++ b/tests/general/test_spin_off_handler.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from cgt_calc.const import DEFAULT_SPIN_OFF_FILE
 from cgt_calc.exceptions import InteractiveInputRequiredError
 from cgt_calc.model import Position
 from cgt_calc.spin_off_handler import SpinOffHandler
@@ -51,14 +50,16 @@ def test_non_interactive_run_raises_clear_error(
 def test_error_names_default_file_when_none_configured(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """With no spin-offs file configured the error points at the default path."""
+    """With no spin-offs file configured the error explains how to fix it."""
     handler = SpinOffHandler()
     monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
 
     with pytest.raises(InteractiveInputRequiredError) as excinfo:
         handler.get_spin_off_source("NEW", SPIN_OFF_DATE, {})
 
-    assert str(DEFAULT_SPIN_OFF_FILE) in str(excinfo.value)
+    message = str(excinfo.value)
+    assert "--spin-offs-file" in message
+    assert "non-interactive" in message
 
 
 def test_eof_during_prompt_raises_clear_error(
@@ -91,3 +92,20 @@ def test_recording_spin_off_creates_missing_parent_directories(
     assert source == "OLD"
     content = spin_offs_file.read_text(encoding="utf8")
     assert content.splitlines() == ["dst,src", "NEW,OLD"]
+
+
+def test_disabled_cache_error_mentions_spin_offs_file_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With cache disabled (--spin-offs-file '') the error names the flag."""
+    handler = SpinOffHandler(spin_offs_file=None)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+
+    with pytest.raises(InteractiveInputRequiredError) as excinfo:
+        handler.get_spin_off_source("NEW", SPIN_OFF_DATE, {})
+
+    message = str(excinfo.value)
+    assert "--spin-offs-file" in message
+    assert "non-interactive" in message
+    # Must NOT point at a file that won't actually be read
+    assert "spin_offs.csv" not in message

--- a/tests/general/test_spin_off_handler.py
+++ b/tests/general/test_spin_off_handler.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from cgt_calc.const import DEFAULT_SPIN_OFF_FILE
 from cgt_calc.exceptions import InteractiveInputRequiredError
 from cgt_calc.model import Position
 from cgt_calc.spin_off_handler import SpinOffHandler
@@ -47,21 +48,6 @@ def test_non_interactive_run_raises_clear_error(
     assert "dst,src" in message
 
 
-def test_error_names_default_file_when_none_configured(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """With no spin-offs file configured the error explains how to fix it."""
-    handler = SpinOffHandler()
-    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
-
-    with pytest.raises(InteractiveInputRequiredError) as excinfo:
-        handler.get_spin_off_source("NEW", SPIN_OFF_DATE, {})
-
-    message = str(excinfo.value)
-    assert "--spin-offs-file" in message
-    assert "non-interactive" in message
-
-
 def test_eof_during_prompt_raises_clear_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -94,10 +80,10 @@ def test_recording_spin_off_creates_missing_parent_directories(
     assert content.splitlines() == ["dst,src", "NEW,OLD"]
 
 
-def test_disabled_cache_error_mentions_spin_offs_file_flag(
+def test_disabled_cache_error_asks_for_a_non_empty_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """With cache disabled (--spin-offs-file '') the error names the flag."""
+    """With the cache disabled the error asks for a path to put the row in."""
     handler = SpinOffHandler(spin_offs_file=None)
     monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
 
@@ -105,7 +91,7 @@ def test_disabled_cache_error_mentions_spin_offs_file_flag(
         handler.get_spin_off_source("NEW", SPIN_OFF_DATE, {})
 
     message = str(excinfo.value)
-    assert "--spin-offs-file" in message
-    assert "non-interactive" in message
-    # Must NOT point at a file that won't actually be read
-    assert "spin_offs.csv" not in message
+    assert "non-empty --spin-offs-file" in message
+    assert "'NEW,<source>' row" in message
+    # The disabled cache is never read, so its default path must not be named.
+    assert str(DEFAULT_SPIN_OFF_FILE) not in message


### PR DESCRIPTION
An empty `--spin-offs-file` disables the spin-offs cache, but a non-interactive run missing a mapping told the user to add a row to `out/spin_offs.csv` - a file the next run never reads, so it failed identically. Closes #1067.

- `SpinOffHandler` passes `self.spin_offs_file` to `InteractiveInputRequiredError` instead of falling back to `DEFAULT_SPIN_OFF_FILE`.
- With the cache disabled the error asks for a non-empty `--spin-offs-file` path containing the `dst,src` row, so one run's advice is enough.
- `docs/extra-data-and-options.md` and `docs/brokers/raw.md` no longer promise that the error always names a row to add.
