### PR TITLE
Document the code layout for contributors

### DIFF
--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -32,6 +32,28 @@ uv sync
 This command creates a virtual environment and installs all project and development dependencies
 into it. Run it again after pulling new changes to update dependencies.
 
+## Code layout
+
+The calculation has two passes:
+
+`broker files → parsers → BrokerTransaction → ingestion → matching → CapitalGainsReport → renderers`
+
+- `cgt_calc/parsers/` reads broker exports and converts their rows into `BrokerTransaction` values.
+    Keep broker-specific columns and normalisation here, and keep tax matching outside the parsers.
+- `cgt_calc/ingestion.py` validates transactions and runs the first pass. It records dividends and
+    interest for `income.py` to process, and delegates share-reorganisation planning to
+    `stock_split_planning.py`.
+- `cgt_calc/calculator_state.py` holds the mutable working state shared by both passes.
+- `cgt_calc/matching.py` runs the second pass, applying the same-day, bed-and-breakfast and Section
+    104 matching rules.
+- `cgt_calc/model.py` defines shared values and the report model. `render_text.py` and
+    `render_latex.py` format that report without calculating it.
+- `cgt_calc/main.py` connects the stages behind `CapitalGainsCalculator`. `cgt_calc/cli.py` handles
+    command-line input and output.
+
+Put a change in the module that owns its behaviour. Extract a new module only when one complete
+concern can move behind explicit inputs; do not split a file only to reduce its line count.
+
 ## Code style
 
 All checks in CI must pass before merging changes.

--- a/docs/development/eri-data.md
+++ b/docs/development/eri-data.md
@@ -9,7 +9,7 @@ is described in [Providing custom ERI data](../custom-eri-data.md#where-provider
 For most providers you can import reports automatically. Run the
 [`import_eri_reports.py`](https://github.com/cgt-calc/capital-gains-calculator/blob/main/scripts/import_eri_reports.py)
 script pointing to either the file or the folder containing the downloaded ERI reports. The tool
-recognizes the funds provider from the filename and imports the data into the matching resource CSV
+recognises the funds provider from the filename and imports the data into the matching resource CSV
 under
 [`cgt_calc/resources/eri/`](https://github.com/cgt-calc/capital-gains-calculator/tree/main/cgt_calc/resources/eri).
 Vanguard, BlackRock, iShares, Xtrackers and Invesco reports are all supported this way. The script


### PR DESCRIPTION
Adds a "Code layout" section to docs/development/contributing.md: the two-pass pipeline, a bullet per module saying what it owns, and the placement rule for changes - put them in the module that owns the behaviour, and never split a file just to reduce its line count.

Also fixes a stray US spelling in eri-data.md (recognizes -> recognises).

Docs-only change.
