### PR TITLE
Enforce the calculator's two-step lifecycle

### DIFF
--- a/cgt_calc/calculator_state.py
+++ b/cgt_calc/calculator_state.py
@@ -121,6 +121,12 @@ class CalculatorState:
     spin_off_estimates: dict[tuple[datetime.date, str], Decimal] = field(
         default_factory=lambda: defaultdict(Decimal)
     )
+    # Whether the first pass has begun, and whether it finished. Ingestion
+    # accumulates into the lists above, so it may only fill this state once,
+    # and a run that failed part way leaves a partial history that must not
+    # be calculated on.
+    ingestion_started: bool = False
+    ingested: bool = False
     calculated: bool = False
     # Disposals that are gifts at market value rather than sales, and
     # whether the recipient is a connected person. A loss on a gift to a

--- a/cgt_calc/cli.py
+++ b/cgt_calc/cli.py
@@ -63,14 +63,13 @@ def calculate_cgt(args: argparse.Namespace) -> None:
         period_start=args.period_from,
         period_end=args.period_to,
     )
-    # First pass converts broker transactions to HMRC transactions.
-    # This means applying same day rule and collapsing all transactions with
-    # same type within the same day.
-    # It also converts prices to GBP, validates data and calculates dividends,
-    # taxes on dividends and interest.
-    calculator.convert_to_hmrc_transactions(broker_transactions)
+    # First pass converts broker transactions to HMRC transactions,
+    # collapsing all transactions with the same type within the same day.
+    # It also converts prices to GBP, validates the data, plans share
+    # reorganisations, and records dividends, taxes on dividends and interest
+    # for the second pass to process.
     # Second pass calculates capital gain tax for the given tax year.
-    report = calculator.calculate_capital_gain()
+    report = calculator.calculate(broker_transactions)
     # The report string is newline-terminated already; avoid a trailing
     # blank line so piped output stays stable under newline normalisation.
     print(report, end="")

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -160,8 +160,27 @@ class CapitalGainsCalculator:
         self,
         transactions: list[BrokerTransaction],
     ) -> None:
-        """Convert broker transactions to HMRC transactions."""
+        """Convert broker transactions to HMRC transactions.
+
+        Runs once per calculator, whether or not it succeeds: a second run
+        would accumulate into the history the first one recorded.
+        """
+        if self.state.ingestion_started:
+            raise RuntimeError(
+                "convert_to_hmrc_transactions() runs once per calculator; build "
+                "a new one to ingest again"
+            )
+        self.state.ingestion_started = True
         self.ingester.convert_to_hmrc_transactions(transactions)
+        self.state.ingested = True
+
+    def calculate(
+        self,
+        transactions: list[BrokerTransaction],
+    ) -> CapitalGainsReport:
+        """Convert broker transactions and calculate the capital gain."""
+        self.convert_to_hmrc_transactions(transactions)
+        return self.calculate_capital_gain()
 
     def first_pass_report(self, totals: FirstPassTotals) -> None:
         """Print the results of the first pass."""
@@ -195,6 +214,11 @@ class CapitalGainsCalculator:
         estimates as it replaces them and accumulates bed and breakfast
         claims as it makes them, so a second run would count both twice.
         """
+        if not self.state.ingested:
+            raise RuntimeError(
+                "convert_to_hmrc_transactions() must complete before "
+                "calculate_capital_gain(); use calculate() to run both in order"
+            )
         if self.state.calculated:
             raise RuntimeError(
                 "calculate_capital_gain() runs once per calculator; build a "

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -16,6 +16,7 @@ from cgt_calc.const import BALANCE_CHECK_CONTEXT_ROWS, RENAME_DESCRIPTION_PREFIX
 from cgt_calc.currency_converter import CurrencyConverter
 from cgt_calc.current_price_fetcher import CurrentPriceFetcher
 from cgt_calc.exceptions import (
+    AmountMissingError,
     CalculationError,
     InvalidTransactionError,
     IsinMissingError,
@@ -43,6 +44,7 @@ from .calc_test_data import (
     GBP,
     buy_transaction,
     calc_basic_data,
+    sell_transaction,
     split_transaction,
     transaction,
     transfer_transaction,
@@ -1722,3 +1724,62 @@ def test_calculate_capital_gain_runs_once() -> None:
 
     with pytest.raises(RuntimeError, match="runs once per calculator"):
         calculator.calculate_capital_gain()
+
+
+def test_convert_to_hmrc_transactions_runs_once() -> None:
+    """A second ingestion would accumulate into the history already recorded."""
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    transactions = [
+        transaction(
+            datetime.date(2024, 6, 1), ActionType.BUY, "FOO", 1, 10, 0, -10, GBP
+        )
+    ]
+    calculator.convert_to_hmrc_transactions(transactions)
+
+    with pytest.raises(RuntimeError, match="runs once per calculator"):
+        calculator.convert_to_hmrc_transactions(transactions)
+
+
+def test_calculate_capital_gain_requires_ingestion() -> None:
+    """Calculating before ingesting used to return an empty report."""
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+
+    with pytest.raises(RuntimeError, match="must complete before"):
+        calculator.calculate_capital_gain()
+
+
+def test_failed_ingestion_can_be_neither_retried_nor_calculated() -> None:
+    """A history that stopped part way through is not a history to report on."""
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    transactions = [
+        buy_transaction(datetime.date(2024, 5, 1), "FOO", 10, 10, 0, -100),
+        transaction(datetime.date(2024, 5, 2), ActionType.BUY, "BAR", 10, 10, 0, None),
+    ]
+
+    with pytest.raises(AmountMissingError):
+        calculator.convert_to_hmrc_transactions(transactions)
+
+    with pytest.raises(RuntimeError, match="runs once per calculator"):
+        calculator.convert_to_hmrc_transactions(transactions)
+
+    with pytest.raises(RuntimeError, match="must complete before"):
+        calculator.calculate_capital_gain()
+
+
+def test_calculate_matches_the_two_step_sequence() -> None:
+    """calculate() is the two steps in the only order that works."""
+
+    def transactions() -> list[BrokerTransaction]:
+        return [
+            buy_transaction(datetime.date(2024, 5, 1), "FOO", 10, 10, 0, -100),
+            sell_transaction(datetime.date(2024, 6, 3), "FOO", 10, 12, 0, 120),
+            buy_transaction(datetime.date(2024, 6, 10), "FOO", 10, 11, 0, -110),
+        ]
+
+    combined = create_calculator(tax_year=2024, balance_check=False)
+    two_step = create_calculator(tax_year=2024, balance_check=False)
+    two_step.convert_to_hmrc_transactions(transactions())
+
+    assert str(combined.calculate(transactions())) == str(
+        two_step.calculate_capital_gain()
+    )


### PR DESCRIPTION
The calculator's two-step lifecycle was unenforced: a second `convert_to_hmrc_transactions()` call silently accumulated into existing state, and `calculate_capital_gain()` on a fresh calculator silently returned an empty report. This adds one public `calculate()` operation that runs both steps in order, and makes every misuse mode raise instead of producing silent garbage.

- Add `ingestion_started` and `ingested` flags to `CalculatorState`, beside the existing `calculated` flag: `ingestion_started` is set before the first pass runs, `ingested` only once it returns successfully.
- `convert_to_hmrc_transactions()` raises `RuntimeError` on a second call, including after a call that failed part way through - the partial history it left must not be added to.
- `calculate_capital_gain()` raises `RuntimeError` unless ingestion completed, so a history that stopped part way through is never reported on.
- Add `CapitalGainsCalculator.calculate(transactions)`, composing the two existing methods; both stay public for existing direct callers.
- `cli.py` switches to `calculate()` and corrects a comment that claimed the first pass applies the same-day rule (statutory same-day matching happens in the second pass) and calculates dividends (the first pass records them; the second pass processes them).
- Add tests pinning both guards, the failed-ingestion case, and `calculate()` producing the same report as the two-step sequence.

Valid runs are byte-identical (including the byte-pinned example-files fixture); the only new behaviour is a clear error on out-of-order, repeated, or post-failure calls.
