### PR TITLE
Keep assigned option settlement cash on its settlement date

### DIFF
--- a/.harper-ignore.txt
+++ b/.harper-ignore.txt
@@ -40,3 +40,6 @@
 # The ISIN in the comment on the exchange-alias table, naming the security
 # whose ticker code the sentence is about.
 ^const\.py:.*`US67066G1040`
+# "True on every one of them" counts the rows one at a time; Harper reads it
+# as the closed compound "everyone".
+^model\.py:.*Everyone

--- a/cgt_calc/ingestion.py
+++ b/cgt_calc/ingestion.py
@@ -1164,7 +1164,8 @@ class TransactionIngester:
                     Decimal(0)
                 )  # dummy value, this will get filtered out
                 continue
-            new_balance = balance[transaction.broker, transaction.currency]
+            opening_balance = balance[transaction.broker, transaction.currency]
+            new_balance = opening_balance
             if transaction.action in {
                 ActionType.BUY,
                 ActionType.REINVEST_SHARES,
@@ -1266,6 +1267,10 @@ class TransactionIngester:
                 raise InvalidTransactionError(
                     transaction, f"Action not processed({transaction.action})"
                 )
+            if not transaction.affects_cash_balance:
+                # The shares are pooled here, but the money moves on a row of
+                # its own, at the date it really left or reached the account.
+                new_balance = opening_balance
             balance_history.append(new_balance)
             if self.balance_check and new_balance < 0:
                 entries = [
@@ -1275,10 +1280,12 @@ class TransactionIngester:
                     )
                     # Only same-pool transactions that moved the cash balance
                     # are relevant (skips other currencies, ERI entries,
-                    # renames, splits, etc.)
+                    # renames, splits, and rows whose cash is carried by
+                    # another row)
                     if trx.broker == transaction.broker
                     and trx.currency == transaction.currency
                     and trx.amount
+                    and trx.affects_cash_balance
                 ]
                 omitted = len(entries) - BALANCE_CHECK_CONTEXT_ROWS
                 if omitted > 0:

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -443,6 +443,13 @@ class BrokerTransaction:
     # Premiums from assigned options are converted on their original dates and
     # folded into the tax basis/proceeds of the underlying share transaction.
     capital_adjustments: list[CapitalAdjustment] = field(default_factory=list)
+    # False on a row whose tax event is dated apart from the cash it involves,
+    # which another row carries on the date the money really moved. The row
+    # still acquires or disposes of the shares; it leaves the cash balance,
+    # and the balance check, to that other row. Out of the repr the errors
+    # print: the balance error lists only rows that did move cash, so the
+    # flag reads True on every one of them.
+    affects_cash_balance: bool = field(default=True, repr=False)
 
     @property
     def pool_quantity(self) -> Decimal | None:

--- a/cgt_calc/parsers/schwab_options.py
+++ b/cgt_calc/parsers/schwab_options.py
@@ -31,6 +31,7 @@ from cgt_calc.model import (
 from cgt_calc.util import approx_equal, strip_zeros
 
 if TYPE_CHECKING:
+    from collections.abc import Container
     from pathlib import Path
 
     from cgt_calc.model import TransactionSource
@@ -346,7 +347,7 @@ def _find_assignment_share_transaction(
     transactions: list[SchwabTransaction],
     assignment: SchwabTransaction,
     assigned_shares: Decimal,
-    used: set[SchwabRowKey],
+    used: Container[SchwabRowKey],
     file: Path,
 ) -> SchwabTransaction:
     """Find Schwab's separate stock row created by an option assignment."""
@@ -415,7 +416,7 @@ def _find_assignment_share_transaction(
 def _apply_option_assignment(
     transactions: list[SchwabTransaction],
     assignment: _OptionAssignment,
-    used_share_transactions: set[SchwabRowKey],
+    settled_share_rows: dict[SchwabRowKey, BrokerTransaction],
     file: Path,
 ) -> BrokerTransaction:
     """Return the assigned shares, dated on the assignment itself.
@@ -424,6 +425,11 @@ def _apply_option_assignment(
     several days later and can fall in the next tax year. The disposal or
     acquisition happens when the option is assigned, so the exported row
     supplies the money and this supplies the date.
+
+    The money itself keeps that later date: the account is funded when it
+    settles, not when the option is assigned, and moving the cash early
+    rejects a funded account. `settled_share_rows` collects the cash-only
+    row each exported settlement becomes, keyed by the row it replaces.
     """
     transaction = assignment.transaction
     contract = transaction.option_contract
@@ -434,14 +440,30 @@ def _apply_option_assignment(
         transactions,
         transaction,
         assigned_shares,
-        used_share_transactions,
+        settled_share_rows,
         file,
     )
-    used_share_transactions.add(_row_key(share_transaction))
     amount = share_transaction.amount
     assert amount is not None
     price = share_transaction.price
     assert price is not None
+    settled_share_rows[_row_key(share_transaction)] = BrokerTransaction(
+        date=share_transaction.date,
+        action=ActionType.TRANSFER,
+        symbol=None,
+        # This row is synthetic, and the negative-balance error prints it
+        # verbatim to someone who never wrote it, so it has to say what it is.
+        description=f"Settlement of the {contract} assigned on {transaction.date}",
+        quantity=None,
+        price=None,
+        # The fee is already deducted from the settlement amount, and the tax
+        # row is what claims it as a cost.
+        fees=Decimal(0),
+        amount=amount,
+        currency=share_transaction.currency,
+        broker=share_transaction.broker,
+        source=share_transaction.source,
+    )
     return BrokerTransaction(
         date=transaction.date,
         action=share_transaction.action,
@@ -455,6 +477,7 @@ def _apply_option_assignment(
         broker=share_transaction.broker,
         source=share_transaction.source,
         capital_adjustments=_assignment_adjustments(assignment.allocations),
+        affects_cash_balance=False,
     )
 
 
@@ -546,12 +569,12 @@ def _emit_option_transactions(
     activity: _OptionActivity,
 ) -> list[BrokerTransaction]:
     """Replace every terminal option row with what it really was."""
-    used_share_transactions: set[SchwabRowKey] = set()
+    settled_share_rows: dict[SchwabRowKey, BrokerTransaction] = {}
     settlements = {
         _row_key(assignment.transaction): _apply_option_assignment(
             transactions,
             assignment,
-            used_share_transactions,
+            settled_share_rows,
             _row_file(assignment.transaction),
         )
         for assignment in activity.assignments.values()
@@ -563,7 +586,10 @@ def _emit_option_transactions(
     reconciled: list[BrokerTransaction] = []
     for transaction in transactions:
         row_key = _row_key(transaction)
-        if row_key in used_share_transactions:
+        settled = settled_share_rows.get(row_key)
+        if settled is not None:
+            # The shares moved to the assignment date; the cash stays here.
+            reconciled.append(settled)
             continue
         if transaction.action is ActionType.OPTION_EXPIRY:
             # An expiry ends the option and moves no cash: the premium is

--- a/docs/brokers/schwab.md
+++ b/docs/brokers/schwab.md
@@ -225,6 +225,16 @@ transaction it looked for, when it is missing, when more than one exported row c
 only candidate does not reconcile with the strike, quantity and fees, or when one contract is
 assigned more than once on a day, which the export gives no way to pair up with its share rows.
 
+The money keeps the settlement date. During import, cgt-calc represents the exported share row as a
+cash movement on the date Schwab paid or collected the money. This prevents the assignment from
+showing a shortfall before settlement.
+
+Same-day ordering is unchanged. Schwab rows are read from the bottom up, so a funding deposit listed
+above the share row is processed after it and the balance check can still fail.
+
+If a balance-check error includes the generated cash movement, its description is
+`Settlement of the META put option expiring 2024-05-17 at a strike of 50 assigned on 2024-05-17`.
+
 Purchased options (`Buy to Open`, `Sell to Close`, `Exercised`) are not supported. Neither are
 cash-settled index options, nor adjusted contracts, whose root carries a numeric suffix such as
 `AAPL1` and which no longer deliver 100 shares. The parser stops with an explicit error for those

--- a/tests/schwab/test_schwab_options.py
+++ b/tests/schwab/test_schwab_options.py
@@ -15,7 +15,7 @@ import pytest
 from cgt_calc import render_latex
 from cgt_calc.currency_converter import CurrencyConverter
 from cgt_calc.current_price_fetcher import CurrentPriceFetcher
-from cgt_calc.exceptions import ParsingError
+from cgt_calc.exceptions import CalculationError, ParsingError
 from cgt_calc.initial_prices import InitialPrices
 from cgt_calc.isin_converter import IsinConverter
 from cgt_calc.main import CapitalGainsCalculator
@@ -49,7 +49,7 @@ def _read(*rows: str) -> list[BrokerTransaction]:
         return SchwabParser.load_from_file(path)
 
 
-def _report(rows: list[str]) -> CapitalGainsReport:
+def _report(rows: list[str], *, balance_check: bool = False) -> CapitalGainsReport:
     """Calculate a report with one USD equal to one GBP."""
     transactions = _read(*rows)
     dates = {transaction.date for transaction in transactions}
@@ -62,7 +62,7 @@ def _report(rows: list[str]) -> CapitalGainsReport:
         SpinOffHandler(),
         InitialPrices(),
         interest_fund_tickers=[],
-        balance_check=False,
+        balance_check=balance_check,
     )
     calculator.convert_to_hmrc_transactions(transactions)
     return calculator.calculate_capital_gain()
@@ -222,6 +222,113 @@ def test_assigned_written_put_reduces_share_acquisition_cost() -> None:
     assert report.portfolio[0].symbol == "META"
     assert report.portfolio[0].quantity == Decimal(100)
     assert report.portfolio[0].amount == Decimal("4900.65")
+
+
+# Newest first, the way Schwab exports: the put is written on 2 May, assigned
+# on 17 May, and its shares settle on 21 May, the day the account is funded.
+_FUNDED_ASSIGNED_PUT = [
+    "05/21/2024,Buy,META,META PLATFORMS INC,$50.00,100,,-$5000.00",
+    "05/21/2024,MoneyLink Deposit,,,,,,$5000.00",
+    "05/17/2024,Assigned,META 05/17/2024 50.00 P,Assignment,,1,,",
+    "05/02/2024,Sell to Open,META 05/17/2024 50.00 P,Open,$1.00,1,$0.65,$99.35",
+]
+
+_PLAIN_FUNDED_PURCHASE = [
+    "05/21/2024,Buy,META,META PLATFORMS INC,$50.00,100,,-$5000.00",
+    "05/21/2024,MoneyLink Deposit,,,,,,$5000.00",
+]
+
+
+def _passes_balance_check(rows: list[str]) -> bool:
+    """Whether the balance check accepts this history."""
+    try:
+        _report(rows, balance_check=True)
+    except CalculationError:
+        return False
+    return True
+
+
+def test_assignment_leaves_its_settlement_cash_on_the_settlement_date() -> None:
+    """The taxable purchase moves to the assignment date; its cash does not."""
+    transactions = _read(*_FUNDED_ASSIGNED_PUT)
+    purchase = next(row for row in transactions if row.action is ActionType.BUY)
+    settlement = next(
+        row
+        for row in transactions
+        if row.action is ActionType.TRANSFER and row.amount == Decimal("-5000.00")
+    )
+
+    assert purchase.date == datetime.date(2024, 5, 17)
+    assert purchase.affects_cash_balance is False
+    assert settlement.date == datetime.date(2024, 5, 21)
+    assert settlement.affects_cash_balance is True
+    # Quoted verbatim in docs/brokers/schwab.md, so pin the whole string.
+    assert settlement.description == (
+        "Settlement of the META put option expiring 2024-05-17 "
+        "at a strike of 50 assigned on 2024-05-17"
+    )
+
+
+def test_funded_assigned_put_passes_the_balance_check() -> None:
+    """Cash leaves on 21 May, and the account is funded on 21 May."""
+    report = _report(_FUNDED_ASSIGNED_PUT, balance_check=True)
+
+    assert len(report.portfolio) == 1
+    assert report.portfolio[0].quantity == Decimal(100)
+    assert report.portfolio[0].amount == Decimal("4900.65")
+
+
+def test_assigned_put_without_its_funding_deposit_still_errors() -> None:
+    """An account that really cannot pay is still reported, on the pay date."""
+    rows = [row for row in _FUNDED_ASSIGNED_PUT if "MoneyLink" not in row]
+
+    with pytest.raises(
+        CalculationError, match=r"negative balance\(-4900.65\)"
+    ) as error:
+        _report(rows, balance_check=True)
+
+    message = str(error.value)
+    assert "datetime.date(2024, 5, 21)" in message
+    # The taxable purchase moves no cash, so listing it under a running
+    # balance it did not change would only mislead.
+    assert "ActionType.BUY" not in message
+
+
+@pytest.mark.parametrize("deposit_first", [True, False])
+def test_assigned_put_and_plain_purchase_agree_on_the_balance_check(
+    deposit_first: bool,
+) -> None:
+    """An assignment must not be judged more harshly than an ordinary buy.
+
+    The parser reads an export from the bottom up, so the deposit listed
+    below the purchase is the one read first, and only that order is funded
+    in time. The other order fails for both histories alike: that is a
+    same-day ordering limitation of the balance check itself, not something
+    assignment adds.
+    """
+
+    def ordered(rows: list[str]) -> list[str]:
+        return rows if deposit_first else [rows[1], rows[0], *rows[2:]]
+
+    assert _passes_balance_check(ordered(_FUNDED_ASSIGNED_PUT)) is deposit_first
+    assert _passes_balance_check(ordered(_PLAIN_FUNDED_PURCHASE)) is deposit_first
+
+
+def test_assigned_call_leaves_its_proceeds_on_the_settlement_date() -> None:
+    """Proceeds of an assigned call arrive when Schwab actually paid them."""
+    transactions = _read(
+        "05/21/2024,Sell,META,META PLATFORMS INC,$350.00,100,,$35000.00",
+        "05/17/2024,Assigned,META 05/17/2024 350.00 C,Assignment,,1,,",
+        "05/02/2024,Sell to Open,META 05/17/2024 350.00 C,Open,$2.00,1,$0.65,$199.35",
+        "05/01/2024,Buy,META,META PLATFORMS INC,$300.00,100,,-$30000.00",
+    )
+    sale = next(row for row in transactions if row.action is ActionType.SELL)
+    settlement = next(row for row in transactions if row.action is ActionType.TRANSFER)
+
+    assert sale.date == datetime.date(2024, 5, 17)
+    assert sale.affects_cash_balance is False
+    assert settlement.date == datetime.date(2024, 5, 21)
+    assert settlement.amount == Decimal("35000.00")
 
 
 def test_partial_close_and_assignment_split_the_opening_premium() -> None:


### PR DESCRIPTION
An option assignment moved the exported share row's cash onto the assignment date along with the tax event, so #1012 rejected a funded account with a negative balance several days before the money actually left it.

- Add `affects_cash_balance` to `BrokerTransaction`, false on a row whose tax event is dated apart from the cash it involves.
- Emit an assignment's taxable `BUY` or `SELL` on the assignment date without moving the cash balance, and an `ActionType.TRANSFER` carrying the settlement amount at the exported row's own date and position.
- Leave rows that moved no cash out of the negative-balance diagnostic, so it never lists one under a balance it did not change.
- Say in the Schwab guide that the money keeps the settlement date, and quote the description of the cash movement the import generates.

Same-day ordering is unchanged: a purchase read before the same-day deposit that funds it still fails, now for an assignment and an ordinary share purchase alike.
