### PR TITLE
Post the docs preview status as the cgtbot App

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -60,9 +60,9 @@ jobs:
       - name: Set status pending
         if: steps.pr.outputs.number
         env:
-          STATUS_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          GH_TOKEN="${STATUS_TOKEN}" gh api --method POST "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
+          gh api --method POST "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
             -f state=pending -f context="${STATUS_CONTEXT}" -f description="Deploying preview"
 
       - name: Download PR site
@@ -120,14 +120,20 @@ jobs:
       - name: Report no change
         if: steps.pr.outputs.number && steps.compare.outputs.unchanged == 'true'
         env:
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-          STATUS_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          GH_TOKEN="${STATUS_TOKEN}" gh api --method POST "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
+          gh api --method POST "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
             -f state=success -f context="${STATUS_CONTEXT}" \
             -f description="No rendered changes" \
             -f target_url="https://cgt-calc.uk/"
-          # An earlier preview comment would now link to stale content — refresh it.
+
+      - name: Refresh the stale preview comment
+        # Keeps GITHUB_TOKEN: an earlier preview comment would now link to stale
+        # content, and github-actions[bot] wrote it, so the same identity edits it.
+        if: steps.pr.outputs.number && steps.compare.outputs.unchanged == 'true'
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
           ID=$(gh api "repos/${GH_REPO}/issues/${PR_NUMBER}/comments" --paginate \
             --jq ".[] | select(.body | startswith(\"${COMMENT_MARKER}\")) | .id" | head -1)
           if [ -n "${ID}" ]; then
@@ -164,9 +170,9 @@ jobs:
       - name: Report preview ready
         if: steps.pr.outputs.number && steps.compare.outputs.unchanged != 'true'
         env:
-          STATUS_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          GH_TOKEN="${STATUS_TOKEN}" gh api --method POST "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
+          gh api --method POST "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
             -f state=success -f context="${STATUS_CONTEXT}" \
             -f description="Preview ready" \
             -f target_url="${{ steps.facts.outputs.url }}"
@@ -197,9 +203,9 @@ jobs:
       - name: Report failure
         if: failure() && steps.pr.outputs.number
         env:
-          STATUS_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          GH_TOKEN="${STATUS_TOKEN}" gh api --method POST "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
+          gh api --method POST "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
             -f state=failure -f context="${STATUS_CONTEXT}" \
             -f description="Preview failed" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -30,8 +30,15 @@ jobs:
     permissions:
       actions: read
       pull-requests: write
-      statuses: write
     steps:
+      - name: Create status token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.MERGE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.MERGE_BOT_PRIVATE_KEY }}
+          permission-statuses: write
+
       - name: Resolve PR
         id: pr
         env:
@@ -52,8 +59,10 @@ jobs:
 
       - name: Set status pending
         if: steps.pr.outputs.number
+        env:
+          STATUS_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh api --method POST "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
+          GH_TOKEN="${STATUS_TOKEN}" gh api --method POST "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
             -f state=pending -f context="${STATUS_CONTEXT}" -f description="Deploying preview"
 
       - name: Download PR site
@@ -112,8 +121,9 @@ jobs:
         if: steps.pr.outputs.number && steps.compare.outputs.unchanged == 'true'
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
+          STATUS_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh api --method POST "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
+          GH_TOKEN="${STATUS_TOKEN}" gh api --method POST "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
             -f state=success -f context="${STATUS_CONTEXT}" \
             -f description="No rendered changes" \
             -f target_url="https://cgt-calc.uk/"
@@ -153,8 +163,10 @@ jobs:
 
       - name: Report preview ready
         if: steps.pr.outputs.number && steps.compare.outputs.unchanged != 'true'
+        env:
+          STATUS_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh api --method POST "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
+          GH_TOKEN="${STATUS_TOKEN}" gh api --method POST "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
             -f state=success -f context="${STATUS_CONTEXT}" \
             -f description="Preview ready" \
             -f target_url="${{ steps.facts.outputs.url }}"
@@ -184,8 +196,10 @@ jobs:
 
       - name: Report failure
         if: failure() && steps.pr.outputs.number
+        env:
+          STATUS_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh api --method POST "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
+          GH_TOKEN="${STATUS_TOKEN}" gh api --method POST "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
             -f state=failure -f context="${STATUS_CONTEXT}" \
             -f description="Preview failed" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
The `Docs preview` status came from `github-actions`. It now comes from the project's own `cgtbot` App, so the check is attributed to the bot that produces it.

- `preview-docs.yml` mints a token scoped to `statuses: write` and uses it for the four status posts: pending, `No rendered changes`, `Preview ready` and `Preview failed`.
- Dropped `statuses: write` from the job's `GITHUB_TOKEN` permissions, which no longer writes any status.
- Artifact downloads, PR resolution, the base-digest lookup and the preview comments keep `GITHUB_TOKEN`. The App has no `actions: read` and does not need to touch comments.

The `Docs preview` context string is unchanged, so the required-check list is unaffected.
