### PR TITLE
Split `CalculatorState` by lifetime

### DIFF
--- a/cgt_calc/calculator_state.py
+++ b/cgt_calc/calculator_state.py
@@ -27,16 +27,14 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class CalculatorState:
-    """What the calculator builds up as it walks the transactions.
+class PreparedHistory:
+    """What the first pass records for the second pass to replay.
 
-    Everything here is written during a run. Configuration and the injected
-    converters and fetchers stay on the calculator itself.
+    Everything here is written while transactions are being read, and read
+    again while they are matched. The three scratch fields
+    (split_day_capacity, holding_sources, gift_prices) are the first pass's
+    own working notes: nothing in the second pass looks at them.
     """
-
-    total_uk_interest: Decimal = Decimal(0)
-    total_foreign_interest: Decimal = Decimal(0)
-    total_interest_tax: Decimal = Decimal(0)
 
     acquisition_list: HmrcTransactionLog = field(default_factory=dict)
     disposal_list: HmrcTransactionLog = field(default_factory=dict)
@@ -49,7 +47,6 @@ class CalculatorState:
     # No gain/no loss transfers to a spouse/civil partner. Kept separate from
     # disposal_list so they never enter the taxable disposal totals.
     transfer_to_spouse_list: HmrcTransactionLog = field(default_factory=dict)
-    bnb_list: HmrcTransactionLog = field(default_factory=dict)
     # What each share reorganisation does to a holding, by date and
     # symbol. Decided once from the chronological source view and
     # replayed by both passes: deciding again in the second pass is how
@@ -104,14 +101,6 @@ class CalculatorState:
         tuple[str, CurrencyCode, datetime.date], ForeignCurrencyAmount
     ] = field(default_factory=lambda: defaultdict(ForeignCurrencyAmount))
 
-    # Log for the report section related only to interests and dividends
-    calculation_log_yields: CalculationLog = field(
-        default_factory=lambda: defaultdict(dict)
-    )
-
-    portfolio: dict[str, Position] = field(
-        default_factory=lambda: defaultdict(Position)
-    )
     spin_offs: dict[datetime.date, list[SpinOff]] = field(
         default_factory=lambda: defaultdict(list)
     )
@@ -121,13 +110,6 @@ class CalculatorState:
     spin_off_estimates: dict[tuple[datetime.date, str], Decimal] = field(
         default_factory=lambda: defaultdict(Decimal)
     )
-    # Whether the first pass has begun, and whether it finished. Ingestion
-    # accumulates into the lists above, so it may only fill this state once,
-    # and a run that failed part way leaves a partial history that must not
-    # be calculated on.
-    ingestion_started: bool = False
-    ingested: bool = False
-    calculated: bool = False
     # Disposals that are gifts at market value rather than sales, and
     # whether the recipient is a connected person. A loss on a gift to a
     # connected person is clogged (TCGA 1992 s18(3)) and reported on its own.
@@ -143,14 +125,61 @@ class CalculatorState:
     # the pool's cost with no shares, so it cannot be told from the pool
     # itself once it is in.
     fee_days: set[tuple[datetime.date, str]] = field(default_factory=set)
+    eris: ExcessReportedIncomeLog = field(default_factory=lambda: defaultdict(dict))
+
+
+@dataclass
+class RunState:
+    """What the second pass builds, and how far the run has got.
+
+    The walk owns everything here. `portfolio` is the exception the split
+    makes visible: the first pass fills it with provisional holdings to
+    check its own rows against, and the walk clears it and rebuilds it.
+    """
+
+    total_uk_interest: Decimal = Decimal(0)
+    total_foreign_interest: Decimal = Decimal(0)
+    total_interest_tax: Decimal = Decimal(0)
+
+    bnb_list: HmrcTransactionLog = field(default_factory=dict)
+
+    # Log for the report section related only to interests and dividends
+    calculation_log_yields: CalculationLog = field(
+        default_factory=lambda: defaultdict(dict)
+    )
+
+    portfolio: dict[str, Position] = field(
+        default_factory=lambda: defaultdict(Position)
+    )
+    # Whether the first pass has begun, and whether it finished. Ingestion
+    # accumulates into the prepared history, so it may only fill this state
+    # once, and a run that failed part way leaves a partial history that must
+    # not be calculated on.
+    ingestion_started: bool = False
+    ingested: bool = False
+    calculated: bool = False
     # The source side of each spin-off, recorded when it is applied and
     # collected into the calculation log by date.
     spin_off_entries: dict[datetime.date, dict[str, list[CalculationEntry]]] = field(
         default_factory=lambda: defaultdict(lambda: defaultdict(list))
     )
-    eris: ExcessReportedIncomeLog = field(default_factory=lambda: defaultdict(dict))
     eris_distribution: ExcessReportedIncomeDistributionLog = field(
         default_factory=lambda: defaultdict(
             lambda: defaultdict(ExcessReportedIncomeDistribution)
         )
     )
+
+
+@dataclass
+class CalculatorState:
+    """What the calculator builds up as it walks the transactions.
+
+    Everything here is written during a run, split by how long each part
+    lives: the first pass fills `history`, the second fills `run`. Keeping
+    them apart is what makes a write that crosses between the passes
+    something you can grep for. Configuration and the injected converters
+    and fetchers stay on the calculator itself.
+    """
+
+    history: PreparedHistory = field(default_factory=PreparedHistory)
+    run: RunState = field(default_factory=RunState)

--- a/cgt_calc/income.py
+++ b/cgt_calc/income.py
@@ -51,7 +51,8 @@ class IncomeProcessor:
         autoconvert_currency: bool = False,
     ):
         """Create income processor object."""
-        self.state = state
+        self.history = state.history
+        self.run = state.run
         self.currency_converter = currency_converter
         self.isin_converter = isin_converter
         self.interest_fund_tickers = interest_fund_tickers
@@ -94,20 +95,20 @@ class IncomeProcessor:
         It groups them by month, using the last date on each month for the report
         and updates the interest totals for the year.
         """
-        monthly_interests = self._group_by_month(self.state.interest_list)
+        monthly_interests = self._group_by_month(self.history.interest_list)
 
         for (broker, currency, date), foreign_amount in monthly_interests.items():
             gbp_amount = self.currency_converter.to_gbp(
                 foreign_amount.amount, currency, date
             )
             if currency == UK_CURRENCY:
-                self.state.total_uk_interest += gbp_amount
+                self.run.total_uk_interest += gbp_amount
                 rule_prefix = "interestUK"
             else:
-                self.state.total_foreign_interest += gbp_amount
+                self.run.total_foreign_interest += gbp_amount
                 rule_prefix = f"interest{currency}"
 
-            self.state.calculation_log_yields[date][f"{rule_prefix}${broker}"] = [
+            self.run.calculation_log_yields[date][f"{rule_prefix}${broker}"] = [
                 CalculationEntry(
                     rule_type=RuleType.INTEREST,
                     quantity=Decimal(1),
@@ -118,7 +119,7 @@ class IncomeProcessor:
                 )
             ]
 
-        monthly_interest_taxes = self._group_by_month(self.state.interest_tax_list)
+        monthly_interest_taxes = self._group_by_month(self.history.interest_tax_list)
 
         for (broker, currency, date), foreign_amount in monthly_interest_taxes.items():
             gbp_amount = self.currency_converter.to_gbp(
@@ -128,9 +129,9 @@ class IncomeProcessor:
             # positive reversal rows then cancel out across months.
             tax_amount = -gbp_amount
             rule_prefix = f"interestTax{currency}"
-            self.state.total_interest_tax += tax_amount
+            self.run.total_interest_tax += tax_amount
 
-            self.state.calculation_log_yields[date][f"{rule_prefix}${broker}"] = [
+            self.run.calculation_log_yields[date][f"{rule_prefix}${broker}"] = [
                 CalculationEntry(
                     rule_type=RuleType.INTEREST_TAX,
                     quantity=Decimal(1),
@@ -251,11 +252,11 @@ class IncomeProcessor:
         """
         matched: ForeignAmountLog = defaultdict(ForeignCurrencyAmount)
         unmatched: ForeignAmountLog = defaultdict(ForeignCurrencyAmount)
-        for (broker, symbol, date, _), tax in self.state.dividend_tax_list.items():
+        for (broker, symbol, date, _), tax in self.history.dividend_tax_list.items():
             if not tax.amount:
                 continue
             candidates = self._dividends_for_tax(
-                date, self.state.dividend_dates.get((broker, symbol), set())
+                date, self.history.dividend_dates.get((broker, symbol), set())
             )
             if len(candidates) == 1:
                 # Dated on the dividend it belongs to, so that is the date
@@ -298,7 +299,7 @@ class IncomeProcessor:
         It updates the interest total for the year if needed.
         """
         attributed_tax = self.dividend_tax_attribution().matched
-        for (symbol, date), foreign_amount in self.state.dividend_list.items():
+        for (symbol, date), foreign_amount in self.history.dividend_list.items():
             # Dividends outside the computed tax year are not reported, so
             # neither are the warnings raised while resolving their treaty.
             if not self.date_in_tax_year(date):
@@ -400,7 +401,7 @@ class IncomeProcessor:
                 tax_treaty=treaty,
             )
 
-            self.state.calculation_log_yields[date][f"dividend${symbol}"] = [
+            self.run.calculation_log_yields[date][f"dividend${symbol}"] = [
                 CalculationEntry(
                     rule_type=RuleType.DIVIDEND,
                     quantity=Decimal(1),
@@ -413,4 +414,4 @@ class IncomeProcessor:
             ]
 
             if is_interest_fund:
-                self.state.total_foreign_interest += amount
+                self.run.total_foreign_interest += amount

--- a/cgt_calc/ingestion.py
+++ b/cgt_calc/ingestion.py
@@ -189,6 +189,9 @@ class TransactionIngester:
         date_in_tax_year: Callable[[datetime.date], bool],
     ):
         """Create transaction ingester object."""
+        self.history = state.history
+        self.run = state.run
+        # Kept whole only to hand on to plan_stock_splits().
         self.state = state
         self.income = income
         self.currency_converter = currency_converter
@@ -256,15 +259,15 @@ class TransactionIngester:
             transaction
         )
         quantity = self._pooled_quantity(transaction)
-        self.state.portfolio[symbol] += Position(quantity, amount - source_adjustment)
+        self.run.portfolio[symbol] += Position(quantity, amount - source_adjustment)
 
         gbp_amount = (
             self.currency_converter.to_gbp_for(amount, transaction) - capital_adjustment
         )
         if transaction.action is ActionType.SPIN_OFF:
-            self.state.spin_off_estimates[transaction.date, symbol] += gbp_amount
+            self.history.spin_off_estimates[transaction.date, symbol] += gbp_amount
         add_to_list(
-            self.state.acquisition_list,
+            self.history.acquisition_list,
             transaction.date,
             symbol,
             quantity,
@@ -288,12 +291,12 @@ class TransactionIngester:
         capacity answers instead, which its decreases cannot exceed because
         planning refused a day that closes below zero.
         """
-        capacity = self.state.split_day_capacity.get((symbol, date_index))
+        capacity = self.history.split_day_capacity.get((symbol, date_index))
         if capacity is not None:
             return capacity
-        if symbol not in self.state.portfolio:
+        if symbol not in self.run.portfolio:
             return None
-        return self.state.portfolio[symbol].quantity
+        return self.run.portfolio[symbol].quantity
 
     def _provisional_cost(self, symbol: str, quantity: Decimal) -> Decimal:
         """Cost to take out of the first-pass pool for shares leaving it.
@@ -303,7 +306,7 @@ class TransactionIngester:
         reorganisation day the running count can sit at or below zero here,
         and there is then nothing to apportion.
         """
-        position = self.state.portfolio[symbol]
+        position = self.run.portfolio[symbol]
         if position.quantity <= 0:
             return Decimal(0)
         return normalize_amount(position.amount * quantity / position.quantity)
@@ -320,8 +323,8 @@ class TransactionIngester:
         cleared when a day closes with nothing held, in
         ``_open_transaction_day``.
         """
-        if self.state.portfolio[symbol].quantity == 0:
-            del self.state.portfolio[symbol]
+        if self.run.portfolio[symbol].quantity == 0:
+            del self.run.portfolio[symbol]
 
     def _pooled_quantity(self, transaction: BrokerTransaction) -> Decimal:
         """Return the count to pool, in the units in force at the day's end."""
@@ -393,13 +396,13 @@ class TransactionIngester:
         quantity = self._pooled_quantity(transaction)
 
         ticker = self.spin_off_handler.get_spin_off_source(
-            symbol, transaction.date, self.state.portfolio
+            symbol, transaction.date, self.run.portfolio
         )
         # Nothing to apportion from an empty holding, and no proportion of
         # value to work out either. On a day the source is itself created by
         # a spin-off, this is the first sign the rows are out of order, and
         # it comes before any price is asked for.
-        if self.state.portfolio[ticker].quantity == 0:
+        if self.run.portfolio[ticker].quantity == 0:
             raise CalculationError(
                 f"{ticker} holds no shares on {transaction.date} when {symbol} "
                 f"is spun off from it. If {ticker} is itself spun off that day, "
@@ -414,7 +417,7 @@ class TransactionIngester:
         already_spun_from = next(
             (
                 spin_off
-                for spin_off in self.state.spin_offs[transaction.date]
+                for spin_off in self.history.spin_offs[transaction.date]
                 if spin_off.source == symbol
             ),
             None,
@@ -432,11 +435,11 @@ class TransactionIngester:
         dst_price = self.price_fetcher.get_closing_price(symbol, transaction.date)
         src_price = self.price_fetcher.get_closing_price(ticker, transaction.date)
         dst_amount = quantity * dst_price
-        src_amount = self.state.portfolio[ticker].quantity * src_price
-        original_src_amount = self.state.portfolio[ticker].amount
+        src_amount = self.run.portfolio[ticker].quantity * src_price
+        original_src_amount = self.run.portfolio[ticker].amount
 
         share_of_original_cost = src_amount / (dst_amount + src_amount)
-        self.state.spin_offs[transaction.date].append(
+        self.history.spin_offs[transaction.date].append(
             SpinOff(
                 dest=symbol,
                 source=ticker,
@@ -483,7 +486,7 @@ class TransactionIngester:
         amount = get_amount_or_fail(transaction)
         price = transaction.price
 
-        self.state.portfolio[symbol] -= Position(pooled_quantity, amount)
+        self.run.portfolio[symbol] -= Position(pooled_quantity, amount)
 
         self._drop_empty_holding(symbol)
 
@@ -491,7 +494,7 @@ class TransactionIngester:
             raise PriceMissingError(transaction)
         # A gift to a connected person on the same day is refused (see
         # add_gift); a gift to anyone else folds into this ordinary disposal.
-        if self.state.gift_disposals.get((transaction.date, symbol)):
+        if self.history.gift_disposals.get((transaction.date, symbol)):
             raise CalculationError(
                 self._sale_and_gift_message(symbol, transaction.date)
             )
@@ -508,7 +511,7 @@ class TransactionIngester:
             transaction
         )
         add_to_list(
-            self.state.disposal_list,
+            self.history.disposal_list,
             transaction.date,
             symbol,
             pooled_quantity,
@@ -517,7 +520,7 @@ class TransactionIngester:
             self.currency_converter.to_gbp_for(transaction.fees, transaction)
             + capital_fee_adjustment,
         )
-        self.state.sale_days.add((transaction.date, symbol))
+        self.history.sale_days.add((transaction.date, symbol))
 
     def _capital_adjustments_gbp(
         self, transaction: BrokerTransaction
@@ -592,10 +595,10 @@ class TransactionIngester:
             Decimal(0),
         )
         option_name = str(contract)
-        current = self.state.option_disposal_list[transaction.date].setdefault(
+        current = self.history.option_disposal_list[transaction.date].setdefault(
             option_name, OptionDisposalData()
         )
-        self.state.option_disposal_list[transaction.date][option_name] = (
+        self.history.option_disposal_list[transaction.date][option_name] = (
             current
             + OptionDisposalData(
                 quantity=tax_data.taxable_quantity,
@@ -655,12 +658,12 @@ class TransactionIngester:
         # cost. Reduce the first-pass holding so later same-symbol transactions
         # validate correctly; the actual pool cost is recomputed in the second
         # pass.
-        self.state.portfolio[symbol] -= Position(
+        self.run.portfolio[symbol] -= Position(
             quantity, self._provisional_cost(symbol, quantity)
         )
         self._drop_empty_holding(symbol)
         add_to_list(
-            self.state.transfer_to_spouse_list,
+            self.history.transfer_to_spouse_list,
             transaction.date,
             symbol,
             quantity,
@@ -719,11 +722,11 @@ class TransactionIngester:
         # sale, or such a gift, alongside a gift to a connected person is
         # refused: a loss on the single disposal could not then be split for
         # the s18(3) restriction.
-        if connected and key in self.state.sale_days:
+        if connected and key in self.history.sale_days:
             raise CalculationError(
                 self._sale_and_gift_message(symbol, transaction.date)
             )
-        if self.state.gift_disposals.get(key, connected) != connected:
+        if self.history.gift_disposals.get(key, connected) != connected:
             raise CalculationError(self._mixed_gifts_message(symbol, transaction.date))
         # Connected gifts must also agree on the value per unit. One holding
         # of one class has one market value on a day, so a second value means
@@ -732,13 +735,13 @@ class TransactionIngester:
         # Everything at one value is treated as one gift to one person.
         if connected:
             value = (transaction.price, transaction.currency)
-            if self.state.gift_prices.setdefault(key, value) != value:
+            if self.history.gift_prices.setdefault(key, value) != value:
                 raise CalculationError(
                     self._gift_values_differ_message(symbol, transaction.date)
                 )
         # Reduce the first-pass holding so later same-symbol transactions
         # validate; the pool cost is recomputed in the second pass.
-        self.state.portfolio[symbol] -= Position(
+        self.run.portfolio[symbol] -= Position(
             quantity, self._provisional_cost(symbol, quantity)
         )
         self._drop_empty_holding(symbol)
@@ -746,7 +749,7 @@ class TransactionIngester:
         # that proceeds come to the market value and the fees are allowed as
         # a cost of the disposal.
         add_to_list(
-            self.state.disposal_list,
+            self.history.disposal_list,
             transaction.date,
             symbol,
             quantity,
@@ -755,7 +758,7 @@ class TransactionIngester:
             ),
             self.currency_converter.to_gbp_for(transaction.fees, transaction),
         )
-        self.state.gift_disposals[transaction.date, symbol] = connected
+        self.history.gift_disposals[transaction.date, symbol] = connected
 
     @staticmethod
     def _gift_values_differ_message(symbol: str, date_index: datetime.date) -> str:
@@ -956,7 +959,7 @@ class TransactionIngester:
             if not symbol:
                 continue
 
-            for report_date, report_by_symbol in self.state.eris.items():
+            for report_date, report_by_symbol in self.history.eris.items():
                 if symbol in report_by_symbol and report_date == transaction.date:
                     previous_price = report_by_symbol[symbol].price
                     if approx_equal(previous_price, price, Decimal("0.0001")):
@@ -971,7 +974,7 @@ class TransactionIngester:
                         f"{report_date} of £{previous_price}",
                     )
 
-            self.state.eris[transaction.date][symbol] = ExcessReportedIncome(
+            self.history.eris[transaction.date][symbol] = ExcessReportedIncome(
                 price=price,
                 symbol=symbol,
                 date=transaction.date,
@@ -991,16 +994,16 @@ class TransactionIngester:
                 transaction,
                 "Rename transaction does not identify the old symbol",
             )
-        existing = self.state.rename_list[transaction.date].get(old_symbol)
+        existing = self.history.rename_list[transaction.date].get(old_symbol)
         if existing is not None and existing != new_symbol:
             raise CalculationError(
                 self._two_renames_message(
                     old_symbol, transaction.date, existing, new_symbol
                 )
             )
-        self.state.rename_list[transaction.date][old_symbol] = new_symbol
-        position = self.state.portfolio.pop(old_symbol, Position())
-        self.state.portfolio[new_symbol] += position
+        self.history.rename_list[transaction.date][old_symbol] = new_symbol
+        position = self.run.portfolio.pop(old_symbol, Position())
+        self.run.portfolio[new_symbol] += position
         # The units keep the accounts that put them there; only the name
         # changes. Nothing is forgotten here, whatever the count says. The
         # merged stream's order within a day is not chronology, so a count of
@@ -1009,9 +1012,9 @@ class TransactionIngester:
         # question is settled where every earlier day has closed, in
         # ``_open_transaction_day``, which is the only place a holding's
         # accounts are dropped.
-        moved = self.state.holding_sources.pop(old_symbol, set())
+        moved = self.history.holding_sources.pop(old_symbol, set())
         if moved:
-            self.state.holding_sources[new_symbol] |= moved
+            self.history.holding_sources[new_symbol] |= moved
 
     def add_management_fee(self, transaction: BrokerTransaction) -> Decimal:
         """Record a fee that increases the holding's pooled cost."""
@@ -1031,9 +1034,9 @@ class TransactionIngester:
         transaction.quantity = Decimal(0)
         gbp_fees = self.currency_converter.to_gbp_for(transaction.fees, transaction)
         symbol = get_symbol_or_fail(transaction)
-        self.state.fee_days.add((transaction.date, symbol))
+        self.history.fee_days.add((transaction.date, symbol))
         add_to_list(
-            self.state.acquisition_list,
+            self.history.acquisition_list,
             transaction.date,
             symbol,
             transaction.quantity,
@@ -1100,14 +1103,14 @@ class TransactionIngester:
             # nothing in it, and its sources must not outlive the units either.
             for symbol in [
                 held
-                for held in self.state.holding_sources
-                if held not in self.state.portfolio
-                or self.state.portfolio[held].quantity == 0
+                for held in self.history.holding_sources
+                if held not in self.run.portfolio
+                or self.run.portfolio[held].quantity == 0
             ]:
-                del self.state.holding_sources[symbol]
+                del self.history.holding_sources[symbol]
             plan_stock_splits(self.state, transaction.date, days[transaction.date])
         if quantity_sign(transaction.action) > 0 and transaction.symbol:
-            self.state.holding_sources[transaction.symbol].add(
+            self.history.holding_sources[transaction.symbol].add(
                 source_account(transaction)
             )
 
@@ -1121,9 +1124,9 @@ class TransactionIngester:
         amount = get_amount_or_fail(transaction)
         key = (transaction.broker, transaction.currency, transaction.date)
         if transaction.action is ActionType.INTEREST:
-            log, year_totals = self.state.interest_list, interests
+            log, year_totals = self.history.interest_list, interests
         else:
-            log, year_totals = self.state.interest_tax_list, interest_taxes
+            log, year_totals = self.history.interest_tax_list, interest_taxes
         log[key] += ForeignCurrencyAmount(amount, transaction.currency)
         if self.date_in_tax_year(transaction.date):
             year_totals[transaction.broker, transaction.currency] += amount
@@ -1207,15 +1210,15 @@ class TransactionIngester:
                 symbol = get_symbol_or_fail(transaction)
                 currency = transaction.currency
                 new_balance += amount
-                self.state.dividend_list[symbol, transaction.date] = (
+                self.history.dividend_list[symbol, transaction.date] = (
                     self.currency_converter.combine_amounts(
-                        self.state.dividend_list[symbol, transaction.date],
+                        self.history.dividend_list[symbol, transaction.date],
                         ForeignCurrencyAmount(amount, currency),
                         transaction.date,
                         autoconvert=self.autoconvert_currency,
                     )
                 )
-                self.state.dividend_dates[transaction.broker, symbol].add(
+                self.history.dividend_dates[transaction.broker, symbol].add(
                     transaction.date
                 )
                 if self.date_in_tax_year(transaction.date):
@@ -1226,7 +1229,7 @@ class TransactionIngester:
                 currency = transaction.currency
                 new_balance += amount
                 tax_key = (transaction.broker, symbol, transaction.date, currency)
-                self.state.dividend_tax_list[tax_key] += ForeignCurrencyAmount(
+                self.history.dividend_tax_list[tax_key] += ForeignCurrencyAmount(
                     amount, currency
                 )
             # Cash moves and nothing else: a deposit or withdrawal, a
@@ -1335,9 +1338,9 @@ class TransactionIngester:
         )
         bul = bullet(sys.stdout)
         print(style_text("Final portfolio", colour=Style.BRIGHT, emoji="📊"))
-        if not self.state.portfolio:
+        if not self.run.portfolio:
             print(f"{bul}(none)")
-        for stock, position in sorted(self.state.portfolio.items()):
+        for stock, position in sorted(self.run.portfolio.items()):
             print(f"{bul}{stock}: {position}")
         print()
         print(style_text("Final balance", colour=Style.BRIGHT, emoji="💰"))

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -92,6 +92,8 @@ class CapitalGainsCalculator:
             ticker.upper() for ticker in cgt_exempt_tickers or []
         )
         self.state = CalculatorState()
+        self.history = self.state.history
+        self.run = self.state.run
         self.income = IncomeProcessor(
             self.state,
             currency_converter,
@@ -125,27 +127,27 @@ class CapitalGainsCalculator:
     @property
     def portfolio(self) -> dict[str, Position]:
         """Holdings built up so far, by symbol."""
-        return self.state.portfolio
+        return self.run.portfolio
 
     @property
     def bnb_list(self) -> HmrcTransactionLog:
         """Acquisitions reserved by the bed and breakfast rule."""
-        return self.state.bnb_list
+        return self.run.bnb_list
 
     @property
     def splits(self) -> dict[datetime.date, dict[str, SplitTransformation]]:
         """What each share reorganisation does to a holding."""
-        return self.state.splits
+        return self.history.splits
 
     @property
     def eris(self) -> ExcessReportedIncomeLog:
         """Excess Reported Income by date and symbol."""
-        return self.state.eris
+        return self.history.eris
 
     @property
     def calculation_log_yields(self) -> CalculationLog:
         """Calculation log for the interest and dividend report sections."""
-        return self.state.calculation_log_yields
+        return self.run.calculation_log_yields
 
     def date_in_tax_year(self, date: datetime.date) -> bool:
         """Check if date is within current tax year."""
@@ -165,14 +167,14 @@ class CapitalGainsCalculator:
         Runs once per calculator, whether or not it succeeds: a second run
         would accumulate into the history the first one recorded.
         """
-        if self.state.ingestion_started:
+        if self.run.ingestion_started:
             raise RuntimeError(
                 "convert_to_hmrc_transactions() runs once per calculator; build "
                 "a new one to ingest again"
             )
-        self.state.ingestion_started = True
+        self.run.ingestion_started = True
         self.ingester.convert_to_hmrc_transactions(transactions)
-        self.state.ingested = True
+        self.run.ingested = True
 
     def calculate(
         self,
@@ -194,7 +196,7 @@ class CapitalGainsCalculator:
         """Warn for any exempt ticker with no transactions."""
         logged_symbols = {
             sym.upper()
-            for log in (self.state.acquisition_list, self.state.disposal_list)
+            for log in (self.history.acquisition_list, self.history.disposal_list)
             for day in log.values()
             for sym in day
         }
@@ -214,17 +216,17 @@ class CapitalGainsCalculator:
         estimates as it replaces them and accumulates bed and breakfast
         claims as it makes them, so a second run would count both twice.
         """
-        if not self.state.ingested:
+        if not self.run.ingested:
             raise RuntimeError(
                 "convert_to_hmrc_transactions() must complete before "
                 "calculate_capital_gain(); use calculate() to run both in order"
             )
-        if self.state.calculated:
+        if self.run.calculated:
             raise RuntimeError(
                 "calculate_capital_gain() runs once per calculator; build a "
                 "new one to calculate again"
             )
-        self.state.calculated = True
+        self.run.calculated = True
         self._warn_unmatched_cgt_exempt_tickers()
         walked = self.matcher.walk()
 
@@ -244,7 +246,7 @@ class CapitalGainsCalculator:
             self.tax_year,
             [
                 self.make_portfolio_entry(symbol, position.quantity, position.amount)
-                for symbol, position in self.state.portfolio.items()
+                for symbol, position in self.run.portfolio.items()
             ],
             walked.disposal_count,
             round_decimal(walked.disposal_proceeds, 2),
@@ -254,10 +256,10 @@ class CapitalGainsCalculator:
             Decimal(allowance) if allowance is not None else None,
             Decimal(dividend_allowance) if dividend_allowance is not None else None,
             walked.calculation_log,
-            dict(sorted(self.state.calculation_log_yields.items())),
-            round_decimal(self.state.total_uk_interest, 2),
-            round_decimal(self.state.total_foreign_interest, 2),
-            round_decimal(self.state.total_interest_tax, 2),
+            dict(sorted(self.run.calculation_log_yields.items())),
+            round_decimal(self.run.total_uk_interest, 2),
+            round_decimal(self.run.total_foreign_interest, 2),
+            round_decimal(self.run.total_interest_tax, 2),
             show_unrealized_gains=self.calc_unrealized_gains,
             gift_loss=round_decimal(walked.gift_loss, 2),
             period_start=self.period_start,

--- a/cgt_calc/matching.py
+++ b/cgt_calc/matching.py
@@ -88,7 +88,8 @@ class Matcher:
         is_cgt_exempt: Callable[[str], bool],
     ):
         """Create matcher object."""
-        self.state = state
+        self.history = state.history
+        self.run = state.run
         self.tax_year_start_date = tax_year_start_date
         self.tax_year_end_date = tax_year_end_date
         self.interest_fund_tickers = interest_fund_tickers
@@ -97,7 +98,7 @@ class Matcher:
 
     def get_eri(self, symbol: str, date: datetime.date) -> ExcessReportedIncome | None:
         """Return Excess Reported Income at specific date for the input symbol."""
-        return self.state.eris.get(date, {}).get(symbol)
+        return self.history.eris.get(date, {}).get(symbol)
 
     def _disposal_log_prefix(self, date_index: datetime.date, symbol: str) -> str:
         """Name the kind of disposal recorded for a symbol on a day.
@@ -112,10 +113,10 @@ class Matcher:
         if self.is_cgt_exempt(symbol):
             return "exempt"
         key = (date_index, symbol)
-        connected = self.state.gift_disposals.get(key)
+        connected = self.history.gift_disposals.get(key)
         if connected:
             return "gift"
-        if connected is None or key in self.state.sale_days:
+        if connected is None or key in self.history.sale_days:
             return "sell"
         return "gift-unconnected"
 
@@ -125,10 +126,10 @@ class Matcher:
         date_index: datetime.date,
     ) -> list[CalculationEntry]:
         """Process single acquisition."""
-        acquisition = self.state.acquisition_list[date_index][symbol]
+        acquisition = self.history.acquisition_list[date_index][symbol]
         spin_offs_here = [
             spin_off
-            for spin_off in self.state.spin_offs.get(date_index, [])
+            for spin_off in self.history.spin_offs.get(date_index, [])
             if spin_off.dest == symbol
         ]
         spin_off = spin_offs_here[0] if spin_offs_here else None
@@ -153,7 +154,7 @@ class Matcher:
                 events.setdefault(row.source, []).append(row)
             for source_symbol, rows in events.items():
                 first = rows[0]
-                source = self.state.portfolio[
+                source = self.run.portfolio[
                     self._spin_off_pool(date_index, source_symbol, first.dest)
                 ]
                 assert first.source_price is not None
@@ -164,7 +165,7 @@ class Matcher:
                 proportion = source_value / total_value if total_value else Decimal(1)
                 share = round_decimal((1 - proportion) * source.amount, 2)
                 carried += share
-                self.state.spin_off_entries[date_index][source_symbol].append(
+                self.run.spin_off_entries[date_index][source_symbol].append(
                     CalculationEntry(
                         RuleType.SPIN_OFF,
                         quantity=source.quantity,
@@ -180,11 +181,11 @@ class Matcher:
                     )
                 )
                 source.amount -= share
-            acquisition.amount += carried - self.state.spin_off_estimates.pop(
+            acquisition.amount += carried - self.history.spin_off_estimates.pop(
                 (date_index, symbol), Decimal(0)
             )
         modified_amount = acquisition.amount
-        position = self.state.portfolio[symbol]
+        position = self.run.portfolio[symbol]
         calculation_entries = []
         # Management fee transaction can have 0 quantity
         assert acquisition.quantity >= 0
@@ -194,10 +195,8 @@ class Matcher:
         bnb_acquisition = HmrcTransactionData()
         bed_and_breakfast_fees = Decimal(0)
 
-        if acquisition.quantity > 0 and has_key(
-            self.state.bnb_list, date_index, symbol
-        ):
-            bnb_acquisition = self.state.bnb_list[date_index][symbol]
+        if acquisition.quantity > 0 and has_key(self.run.bnb_list, date_index, symbol):
+            bnb_acquisition = self.run.bnb_list[date_index][symbol]
             assert bnb_acquisition.quantity <= acquisition.quantity
             # Multiply by the B&B quantity before dividing to avoid rounding errors from division
             bnb_cost_basis = normalize_amount(
@@ -221,7 +220,7 @@ class Matcher:
                     eris=bnb_acquisition.eris,
                 )
             )
-        self.state.portfolio[symbol] += Position(
+        self.run.portfolio[symbol] += Position(
             acquisition.quantity,
             modified_amount,
         )
@@ -259,9 +258,9 @@ class Matcher:
         ``transfer_to_spouse_list`` (which carry no fees and no proceeds).
         """
         disposal = (
-            self.state.transfer_to_spouse_list
+            self.history.transfer_to_spouse_list
             if no_gain_no_loss
-            else self.state.disposal_list
+            else self.history.disposal_list
         )[date_index][symbol]
         ctx = DisposalContext(
             symbol=symbol,
@@ -270,8 +269,8 @@ class Matcher:
             disposal=disposal,
             disposal_quantity=disposal.quantity,
             disposal_price=disposal.amount / disposal.quantity,
-            current_quantity=self.state.portfolio[symbol].quantity,
-            current_amount=self.state.portfolio[symbol].amount,
+            current_quantity=self.run.portfolio[symbol].quantity,
+            current_amount=self.run.portfolio[symbol].amount,
             chargeable_gain=Decimal(0),
             calculation_entries=[],
         )
@@ -283,7 +282,7 @@ class Matcher:
         assert round_decimal(ctx.disposal_quantity, 23) == 0, (
             f"disposal quantity {ctx.disposal_quantity}"
         )
-        self.state.portfolio[ctx.symbol] = Position(
+        self.run.portfolio[ctx.symbol] = Position(
             ctx.current_quantity, normalize_amount(ctx.current_amount)
         )
         ctx.chargeable_gain = round_decimal(ctx.chargeable_gain, 2)
@@ -385,8 +384,8 @@ class Matcher:
                 # reorganisation of a holding renamed *into* this name is
                 # deliberately not picked up: the shares disposed of here left
                 # before that one arrived, so they were never its shares.
-                renames = self.state.rename_list.get(search_index, {})
-                day_splits = self.state.splits.get(search_index, {})
+                renames = self.history.rename_list.get(search_index, {})
+                day_splits = self.history.splits.get(search_index, {})
                 renamed_symbol = renames.get(effective_symbol, effective_symbol)
                 transformation = day_splits.get(effective_symbol) or day_splits.get(
                     renamed_symbol
@@ -417,29 +416,29 @@ class Matcher:
                 )
                 if acquisition.quantity > 0:
                     bnb_acquisition = (
-                        self.state.bnb_list[search_index][effective_symbol]
-                        if has_key(self.state.bnb_list, search_index, effective_symbol)
+                        self.run.bnb_list[search_index][effective_symbol]
+                        if has_key(self.run.bnb_list, search_index, effective_symbol)
                         else HmrcTransactionData()
                     )
                     assert bnb_acquisition.quantity <= acquisition.quantity
 
                     same_day_disposal = (
-                        self.state.disposal_list[search_index][effective_symbol]
+                        self.history.disposal_list[search_index][effective_symbol]
                         if has_key(
-                            self.state.disposal_list, search_index, effective_symbol
+                            self.history.disposal_list, search_index, effective_symbol
                         )
                         else HmrcTransactionData()
                     )
                     # A same-day transfer to spouse competes for the same-day
                     # acquisition like a same-day sale, so reserve its share too.
                     if has_key(
-                        self.state.transfer_to_spouse_list,
+                        self.history.transfer_to_spouse_list,
                         search_index,
                         effective_symbol,
                     ):
                         same_day_disposal = (
                             same_day_disposal
-                            + self.state.transfer_to_spouse_list[search_index][
+                            + self.history.transfer_to_spouse_list[search_index][
                                 effective_symbol
                             ]
                         )
@@ -460,7 +459,7 @@ class Matcher:
                         continue
                     if any(
                         spin_off.dest == effective_symbol
-                        for spin_off in self.state.spin_offs.get(search_index, [])
+                        for spin_off in self.history.spin_offs.get(search_index, [])
                     ):
                         # What those shares cost is a share of the source's pool
                         # on the day of the spin-off, and the walk has not
@@ -570,7 +569,7 @@ class Matcher:
                         )
                         total_dist_amount += eri_distribution.amount
                         if self.date_in_tax_year(eri.distribution_date):
-                            self.state.eris_distribution[eri.distribution_date][
+                            self.run.eris_distribution[eri.distribution_date][
                                 ctx.symbol
                             ] += eri_distribution
 
@@ -603,7 +602,7 @@ class Matcher:
                             f"current amount {ctx.current_amount}"
                         )
                     add_to_list(
-                        self.state.bnb_list,
+                        self.run.bnb_list,
                         search_index,
                         effective_symbol,
                         consumed_acquisition_units,
@@ -689,15 +688,15 @@ class Matcher:
 
     def process_rename(self, old: str, new: str) -> CalculationEntry:
         """Transfer pool from old ticker to new ticker (no disposal)."""
-        pos = self.state.portfolio.pop(old, Position())
-        self.state.portfolio[new] += pos
+        pos = self.run.portfolio.pop(old, Position())
+        self.run.portfolio[new] += pos
         return CalculationEntry(
             rule_type=RuleType.RENAME,
             quantity=pos.quantity,
             amount=Decimal(0),
             fees=Decimal(0),
-            new_quantity=self.state.portfolio[new].quantity,
-            new_pool_cost=self.state.portfolio[new].amount,
+            new_quantity=self.run.portfolio[new].quantity,
+            new_pool_cost=self.run.portfolio[new].amount,
             allowable_cost=pos.amount,
             renamed_to=new,
         )
@@ -715,9 +714,9 @@ class Matcher:
         exports this was built from, which is enough to leave a disposal of
         the whole holding short of zero.
         """
-        renames = self.state.rename_list.get(date_index, {})
+        renames = self.history.rename_list.get(date_index, {})
         for symbol, transformation in sorted(
-            self.state.splits.get(date_index, {}).items()
+            self.history.splits.get(date_index, {}).items()
         ):
             chained = self._rename_chain_at(symbol, renames)
             if chained is not None:
@@ -729,7 +728,7 @@ class Matcher:
                 raise CalculationError(
                     self._rename_and_split_message(symbol, date_index, *pooled)
                 )
-            position = self.state.portfolio[symbol]
+            position = self.run.portfolio[symbol]
             if position.quantity != transformation.day_open_quantity:
                 raise CalculationError(
                     f"Cannot apply the reorganisation of {symbol} on "
@@ -739,7 +738,7 @@ class Matcher:
                     "the reorganisation was worked out. Please report this: "
                     "the two passes over the history disagree."
                 )
-            self.state.portfolio[symbol] = Position(
+            self.run.portfolio[symbol] = Position(
                 transformation.scaled_day_open_quantity, position.amount
             )
 
@@ -750,12 +749,9 @@ class Matcher:
         the portfolio still holds the day-opening pool; an acquisition later
         today lands before the rename, which is applied at the end of the day.
         """
-        if (
-            symbol in self.state.portfolio
-            and self.state.portfolio[symbol].quantity != 0
-        ):
+        if symbol in self.run.portfolio and self.run.portfolio[symbol].quantity != 0:
             return True
-        return has_key(self.state.acquisition_list, date_index, symbol)
+        return has_key(self.history.acquisition_list, date_index, symbol)
 
     @staticmethod
     def _rename_chain_at(
@@ -837,9 +833,9 @@ class Matcher:
         takes no part in same-day or 30-day identification.
         """
         for symbol, transformation in sorted(
-            self.state.splits.get(date_index, {}).items()
+            self.history.splits.get(date_index, {}).items()
         ):
-            position = self.state.portfolio[symbol]
+            position = self.run.portfolio[symbol]
             quantity = position.quantity + transformation.reconciliation_delta
             if quantity < 0:
                 raise CalculationError(
@@ -847,7 +843,7 @@ class Matcher:
                     f"{date_index}: reconciling to the broker's count leaves "
                     f"{strip_zeros(quantity)} units."
                 )
-            self.state.portfolio[symbol] = Position(quantity, position.amount)
+            self.run.portfolio[symbol] = Position(quantity, position.amount)
             if date_index < tax_year_start_index:
                 continue
             event = transformation.event
@@ -888,11 +884,11 @@ class Matcher:
         holding onward again or pools it with a second one is refused before
         any of this (see ``apply_split_openings``).
         """
-        renames = self.state.rename_list.get(date_index, {})
+        renames = self.history.rename_list.get(date_index, {})
         for symbol, transformation in sorted(
-            self.state.splits.get(date_index, {}).items()
+            self.history.splits.get(date_index, {}).items()
         ):
-            closing = self.state.portfolio[renames.get(symbol, symbol)].quantity
+            closing = self.run.portfolio[renames.get(symbol, symbol)].quantity
             if closing != transformation.expected_day_close:
                 raise CalculationError(
                     f"Cannot apply the reorganisation of {symbol} on "
@@ -977,7 +973,7 @@ class Matcher:
         received by spin-off that day are not a trade; dependency order has
         already put them in its pool.
         """
-        renames = self.state.rename_list.get(date_index, {})
+        renames = self.history.rename_list.get(date_index, {})
         # Follow the day's renames back from the source, a holding renamed
         # twice in a morning being two hops from its pool. Only renames on
         # this chain matter; what happened to other symbols that day does not.
@@ -1007,10 +1003,10 @@ class Matcher:
         holding = sorted(
             name
             for name in names
-            if name in self.state.portfolio
+            if name in self.run.portfolio
             and (
-                self.state.portfolio[name].quantity > 0
-                or self.state.portfolio[name].amount != 0
+                self.run.portfolio[name].quantity > 0
+                or self.run.portfolio[name].amount != 0
             )
         )
         if len(holding) > 1:
@@ -1028,21 +1024,21 @@ class Matcher:
             spun_in = sum(
                 (
                     spin_off.quantity
-                    for spin_off in self.state.spin_offs.get(date_index, [])
+                    for spin_off in self.history.spin_offs.get(date_index, [])
                     if spin_off.dest == name
                 ),
                 Decimal(0),
             )
             if (
-                has_key(self.state.acquisition_list, date_index, name)
-                and self.state.acquisition_list[date_index][name].quantity > spun_in
+                has_key(self.history.acquisition_list, date_index, name)
+                and self.history.acquisition_list[date_index][name].quantity > spun_in
             ):
                 activity.append("bought")
-            if has_key(self.state.disposal_list, date_index, name):
+            if has_key(self.history.disposal_list, date_index, name):
                 activity.append("sold")
-            if has_key(self.state.transfer_to_spouse_list, date_index, name):
+            if has_key(self.history.transfer_to_spouse_list, date_index, name):
                 activity.append("transferred to a spouse")
-            if (date_index, name) in self.state.fee_days:
+            if (date_index, name) in self.history.fee_days:
                 activity.append("charged a fee")
         if activity:
             raise CalculationError(
@@ -1071,7 +1067,7 @@ class Matcher:
         """
         sources: dict[str, list[str]] = defaultdict(list)
         first_event: dict[str, int] = {}
-        for index, spin_off in enumerate(self.state.spin_offs.get(date_index, [])):
+        for index, spin_off in enumerate(self.history.spin_offs.get(date_index, [])):
             sources[spin_off.dest].append(spin_off.source)
             first_event.setdefault(spin_off.dest, index)
 
@@ -1081,7 +1077,7 @@ class Matcher:
             return 1 + max((depth(source) for source in sources[symbol]), default=-1)
 
         return sorted(
-            self.state.acquisition_list[date_index],
+            self.history.acquisition_list[date_index],
             key=lambda symbol: (depth(symbol), first_event.get(symbol, -1)),
         )
 
@@ -1166,9 +1162,9 @@ class Matcher:
         were never acquired (TCGA 1992 s127, CG51805), so they never enter
         ``acquisition_list`` in the first place.
         """
-        if not has_key(self.state.acquisition_list, date_index, symbol):
+        if not has_key(self.history.acquisition_list, date_index, symbol):
             return HmrcTransactionData()
-        return self.state.acquisition_list[date_index][symbol]
+        return self.history.acquisition_list[date_index][symbol]
 
     def _contending_acquisitions(
         self,
@@ -1208,8 +1204,8 @@ class Matcher:
                 # disposal day itself the sale and the transfer are the two
                 # laying claim, so subtracting them would hide the clash.
                 for log in (
-                    self.state.disposal_list,
-                    self.state.transfer_to_spouse_list,
+                    self.history.disposal_list,
+                    self.history.transfer_to_spouse_list,
                 ):
                     if has_key(log, day, ticker):
                         taken += log[day][ticker].quantity
@@ -1220,7 +1216,7 @@ class Matcher:
         for i in range(BED_AND_BREAKFAST_DAYS):
             search_index = date_index + datetime.timedelta(days=i + 1)
             # HMRC treats renames as the same security for B&B purposes.
-            effective_symbol = self.state.rename_list.get(search_index, {}).get(
+            effective_symbol = self.history.rename_list.get(search_index, {}).get(
                 effective_symbol, effective_symbol
             )
             if has_shares_going_spare(
@@ -1236,13 +1232,13 @@ class Matcher:
         contended: list[datetime.date],
     ) -> str:
         """Explain why a same-day sale and transfer cannot be calculated."""
-        sold = self.state.disposal_list[date_index][symbol].quantity
-        transferred = self.state.transfer_to_spouse_list[date_index][symbol].quantity
+        sold = self.history.disposal_list[date_index][symbol].quantity
+        transferred = self.history.transfer_to_spouse_list[date_index][symbol].quantity
         shown = ", ".join(str(date) for date in contended[:MAX_CONTENDED_DATES_SHOWN])
         if len(contended) > MAX_CONTENDED_DATES_SHOWN:
             shown += f" and {len(contended) - MAX_CONTENDED_DATES_SHOWN} more"
-        has_gift = (date_index, symbol) in self.state.gift_disposals
-        has_sale = (date_index, symbol) in self.state.sale_days
+        has_gift = (date_index, symbol) in self.history.gift_disposals
+        has_sale = (date_index, symbol) in self.history.sale_days
         if has_gift and has_sale:
             verb, noun = ("sold or gave away", "disposal")
         elif has_gift:
@@ -1281,13 +1277,13 @@ class Matcher:
         exactly like a disposal (see ``process_disposal``), but with a nil gain,
         so it is kept out of the taxable disposal totals.
         """
-        if date_index not in self.state.transfer_to_spouse_list:
+        if date_index not in self.history.transfer_to_spouse_list:
             return
-        for symbol in self.state.transfer_to_spouse_list[date_index]:
+        for symbol in self.history.transfer_to_spouse_list[date_index]:
             # HMRC does not define how to identify a taxable sale and a no gain/no
             # loss transfer of the same shares on the same day, so refuse the
             # cases where that identification actually changes the answer.
-            if has_key(self.state.disposal_list, date_index, symbol) and (
+            if has_key(self.history.disposal_list, date_index, symbol) and (
                 contended := self._contending_acquisitions(
                     symbol, date_index, bnb_claimed_before_today
                 )
@@ -1308,7 +1304,7 @@ class Matcher:
                 logging.INFO if self.date_in_tax_year(date_index) else logging.DEBUG,
                 "Transferred %s units of %s to spouse on %s "
                 "(no gain/no loss, base cost £%s)",
-                self.state.transfer_to_spouse_list[date_index][symbol].quantity,
+                self.history.transfer_to_spouse_list[date_index][symbol].quantity,
                 symbol,
                 date_index,
                 round_decimal(base_cost, 2),
@@ -1324,8 +1320,8 @@ class Matcher:
         """Process single excess reported income."""
         eri = self.get_eri(symbol, date_index)
         assert eri is not None
-        amount = self.state.portfolio[eri.symbol].amount
-        quantity = self.state.portfolio[eri.symbol].quantity
+        amount = self.run.portfolio[eri.symbol].amount
+        quantity = self.run.portfolio[eri.symbol].quantity
 
         if quantity == 0:
             return None
@@ -1344,10 +1340,10 @@ class Matcher:
             amount,
             new_amount,
         )
-        self.state.portfolio[eri.symbol].amount = new_amount
+        self.run.portfolio[eri.symbol].amount = new_amount
 
         if self.date_in_tax_year(eri.distribution_date):
-            self.state.eris_distribution[eri.distribution_date][symbol] += (
+            self.run.eris_distribution[eri.distribution_date][symbol] += (
                 ExcessReportedIncomeDistribution(
                     price=eri.price,
                     amount=allowable_cost,
@@ -1378,7 +1374,7 @@ class Matcher:
         costs = Decimal(0)
         gains = Decimal(0)
         losses = Decimal(0)
-        for option_name, option in self.state.option_disposal_list.get(
+        for option_name, option in self.history.option_disposal_list.get(
             date_index, {}
         ).items():
             raw_gain = option.proceeds - option.allowable_cost
@@ -1420,8 +1416,8 @@ class Matcher:
 
         # The first pass left its estimates in the portfolio; the walk rebuilds
         # it from nothing.
-        self.state.portfolio.clear()
-        self.state.spin_off_entries.clear()
+        self.run.portfolio.clear()
+        self.run.spin_off_entries.clear()
         calculation_log: CalculationLog = defaultdict(dict)
 
         for date_index in (
@@ -1434,14 +1430,14 @@ class Matcher:
             bnb_claimed_before_today = (
                 {
                     (day, ticker): data.quantity
-                    for day, tickers in self.state.bnb_list.items()
+                    for day, tickers in self.run.bnb_list.items()
                     for ticker, data in tickers.items()
                 }
-                if date_index in self.state.transfer_to_spouse_list
+                if date_index in self.history.transfer_to_spouse_list
                 else {}
             )
             self.apply_split_openings(date_index)
-            if date_index in self.state.acquisition_list:
+            if date_index in self.history.acquisition_list:
                 for symbol in self._acquisition_order(date_index):
                     calculation_entries = self.process_acquisition(
                         symbol,
@@ -1451,7 +1447,7 @@ class Matcher:
                         calculation_log[date_index][f"buy${symbol}"] = (
                             calculation_entries
                         )
-            for source, entries in self.state.spin_off_entries.pop(
+            for source, entries in self.run.spin_off_entries.pop(
                 date_index, {}
             ).items():
                 if date_index >= tax_year_start_index:
@@ -1459,22 +1455,22 @@ class Matcher:
             self.record_split_reconciliations(
                 date_index, tax_year_start_index, calculation_log
             )
-            if date_index in self.state.disposal_list:
-                for symbol in self.state.disposal_list[date_index]:
+            if date_index in self.history.disposal_list:
+                for symbol in self.history.disposal_list[date_index]:
                     transaction_capital_gain, calculation_entries = (
                         self.process_disposal(symbol, date_index)
                     )
                     if date_index >= tax_year_start_index:
-                        transaction_amount = self.state.disposal_list[date_index][
+                        transaction_amount = self.history.disposal_list[date_index][
                             symbol
                         ].amount
-                        transaction_fees = self.state.disposal_list[date_index][
+                        transaction_fees = self.history.disposal_list[date_index][
                             symbol
                         ].fees
                         transaction_disposal_proceeds = (
                             transaction_amount + transaction_fees
                         )
-                        transaction_quantity = self.state.disposal_list[date_index][
+                        transaction_quantity = self.history.disposal_list[date_index][
                             symbol
                         ].quantity
                         calculated_quantity = Decimal(0)
@@ -1545,8 +1541,8 @@ class Matcher:
                 capital_gain += option_gains
                 capital_loss += option_losses
 
-            if date_index in self.state.rename_list:
-                for old, new in self.state.rename_list[date_index].items():
+            if date_index in self.history.rename_list:
+                for old, new in self.history.rename_list[date_index].items():
                     entry = self.process_rename(old, new)
                     if date_index >= tax_year_start_index:
                         calculation_log[date_index][f"rename${old}"] = [entry]
@@ -1561,8 +1557,8 @@ class Matcher:
             self.verify_split_day_closes(date_index)
 
             # Excess Reported incomes should be reported at the end of the day
-            if date_index in self.state.eris:
-                for symbol in self.state.eris[date_index]:
+            if date_index in self.history.eris:
+                for symbol in self.history.eris[date_index]:
                     maybe_entry = self.process_eri(symbol, date_index)
                     if not maybe_entry:
                         continue
@@ -1575,13 +1571,13 @@ class Matcher:
                         ] = [maybe_entry]
 
             # Lastly all the ERI distribution events
-            if date_index in self.state.eris_distribution:
-                for symbol in self.state.eris_distribution[date_index]:
-                    data = self.state.eris_distribution[date_index][symbol]
+            if date_index in self.run.eris_distribution:
+                for symbol in self.run.eris_distribution[date_index]:
+                    data = self.run.eris_distribution[date_index][symbol]
                     is_interest = symbol in self.interest_fund_tickers
                     if is_interest:
-                        self.state.total_foreign_interest += data.amount
-                    self.state.calculation_log_yields[date_index][
+                        self.run.total_foreign_interest += data.amount
+                    self.run.calculation_log_yields[date_index][
                         f"excess-reported-income-distribution${symbol}"
                     ] = [
                         CalculationEntry(

--- a/cgt_calc/stock_split_planning.py
+++ b/cgt_calc/stock_split_planning.py
@@ -331,7 +331,7 @@ def _plan_stock_split(
             )
         (before_rows if placement == "before" else after_rows).append(other)
 
-    day_open_quantity = state.portfolio[symbol].quantity
+    day_open_quantity = state.run.portfolio[symbol].quantity
     holding_at_event = day_open_quantity + sum(
         (
             quantity_sign(other.action) * _get_quantity_or_fail(other)
@@ -411,7 +411,7 @@ def _plan_stock_split(
             "units."
         )
 
-    state.splits[date_index][symbol] = SplitTransformation(
+    state.history.splits[date_index][symbol] = SplitTransformation(
         event=event,
         mode=mode,
         ratio=exact_ratio,
@@ -436,14 +436,14 @@ def _plan_stock_split(
     # its own last disposal. A negative reconciliation can leave the count
     # briefly below zero here, ahead of the day's acquisitions, which
     # nothing reads.
-    position = state.portfolio[symbol]
-    state.portfolio[symbol] = Position(
+    position = state.run.portfolio[symbol]
+    state.run.portfolio[symbol] = Position(
         scaled_day_open_quantity + reconciliation_delta, position.amount
     )
     # Everything the day can give up, in the order the replay puts it:
     # the restated opening, then every increase, then the reconciliation.
     # Decreases draw on this rather than on the running count.
-    state.split_day_capacity[symbol, date_index] = (
+    state.history.split_day_capacity[symbol, date_index] = (
         scaled_day_open_quantity
         + _signed_quantity(
             [
@@ -513,7 +513,7 @@ def _stock_split_event(
             f"{strip_zeros(holding_at_event)}."
         )
     if not isinstance(row, RawTransaction):
-        contributors = state.holding_sources.get(symbol, set()) | {
+        contributors = state.history.holding_sources.get(symbol, set()) | {
             source_account(other)
             for other in before_rows
             if quantity_sign(other.action) > 0


### PR DESCRIPTION
`CalculatorState` was one 31-field dataclass mixing four different lifetimes with no boundary between them. Splits it into two dataclasses so the crossings become greppable for the next PR.

- Add `PreparedHistory`: fields written during preparation and read by the replay, plus preparation-internal scratch and prepared income events.
- Add `RunState`: fields the replay builds, plus the lifecycle flags.
- `CalculatorState` becomes a thin composite holding `history: PreparedHistory` and `run: RunState`.
- Rewrite every `self.state.<field>` reference across `ingestion.py`, `matching.py`, `income.py`, `stock_split_planning.py`, and `main.py` to the field's new home. The facade properties (`portfolio`, `bnb_list`, `splits`, `eris`, `calculation_log_yields`) keep their names and signatures.

No behaviour change: this moves fields between objects and rewrites the paths that reach them, nothing else.