### PR TITLE
Make the matching replay read-only over prepared history

### DIFF
--- a/cgt_calc/calculator_state.py
+++ b/cgt_calc/calculator_state.py
@@ -168,6 +168,13 @@ class RunState:
             lambda: defaultdict(ExcessReportedIncomeDistribution)
         )
     )
+    # Acquisition cost of a spun-off holding once the source pool is known,
+    # by day and symbol. The first pass could only estimate it; the walk
+    # works out the real figure when it reaches the day and keeps it here
+    # rather than rewriting the recorded acquisition.
+    spin_off_corrected_amounts: dict[tuple[datetime.date, str], Decimal] = field(
+        default_factory=dict
+    )
 
 
 @dataclass

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -212,9 +212,8 @@ class CapitalGainsCalculator:
     ) -> CapitalGainsReport:
         """Calculate capital gain and return generated report.
 
-        Runs once per calculator. The walk consumes the first pass's
-        estimates as it replaces them and accumulates bed and breakfast
-        claims as it makes them, so a second run would count both twice.
+        Runs once per calculator. The walk accumulates bed and breakfast
+        claims as it makes them, so a second run would count them twice.
         """
         if not self.run.ingested:
             raise RuntimeError(

--- a/cgt_calc/matching.py
+++ b/cgt_calc/matching.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import datetime
 from decimal import Decimal
 from fractions import Fraction
@@ -127,6 +127,7 @@ class Matcher:
     ) -> list[CalculationEntry]:
         """Process single acquisition."""
         acquisition = self.history.acquisition_list[date_index][symbol]
+        acquisition_amount = acquisition.amount
         spin_offs_here = [
             spin_off
             for spin_off in self.history.spin_offs.get(date_index, [])
@@ -138,11 +139,12 @@ class Matcher:
             # original cost is apportioned between the two holdings at the
             # reorganisation itself (CG51976). The first pass could only
             # estimate the source pool, so it recorded an estimate for this
-            # holding; here the pool is authoritative and in GBP. Swap exactly
-            # the estimate out of the day's acquisitions, which may also hold
-            # ordinary purchases of the same symbol, and take the source's
-            # side at the same moment so that what one gives up is what the
-            # other receives.
+            # holding; here the pool is authoritative and in GBP. Record the
+            # corrected figure on the run, exactly the estimate apart, and take
+            # the source's side at the same moment so that what one gives up is
+            # what the other receives. The recorded acquisition is left alone:
+            # it may also hold ordinary purchases of the same symbol, and the
+            # first pass's history stays as written.
             carried = Decimal(0)
             # Several rows for one spin-off, as when the holding is split
             # across brokers, are one reorganisation: the split of value is by
@@ -181,16 +183,17 @@ class Matcher:
                     )
                 )
                 source.amount -= share
-            acquisition.amount += carried - self.history.spin_off_estimates.pop(
+            acquisition_amount += carried - self.history.spin_off_estimates.get(
                 (date_index, symbol), Decimal(0)
             )
-        modified_amount = acquisition.amount
+            self.run.spin_off_corrected_amounts[date_index, symbol] = acquisition_amount
+        modified_amount = acquisition_amount
         position = self.run.portfolio[symbol]
         calculation_entries = []
         # Management fee transaction can have 0 quantity
         assert acquisition.quantity >= 0
         # Stock split can have 0 amount
-        assert acquisition.amount >= 0
+        assert acquisition_amount >= 0
 
         bnb_acquisition = HmrcTransactionData()
         bed_and_breakfast_fees = Decimal(0)
@@ -200,7 +203,7 @@ class Matcher:
             assert bnb_acquisition.quantity <= acquisition.quantity
             # Multiply by the B&B quantity before dividing to avoid rounding errors from division
             bnb_cost_basis = normalize_amount(
-                (bnb_acquisition.quantity * acquisition.amount) / acquisition.quantity
+                (bnb_acquisition.quantity * acquisition_amount) / acquisition.quantity
             )
             modified_amount -= bnb_cost_basis
             modified_amount += bnb_acquisition.amount
@@ -216,7 +219,7 @@ class Matcher:
                     new_quantity=position.quantity + bnb_acquisition.quantity,
                     new_pool_cost=position.amount + bnb_acquisition.amount,
                     fees=bed_and_breakfast_fees,
-                    allowable_cost=acquisition.amount,
+                    allowable_cost=acquisition_amount,
                     eris=bnb_acquisition.eris,
                 )
             )
@@ -236,7 +239,7 @@ class Matcher:
                     new_quantity=position.quantity + acquisition.quantity,
                     new_pool_cost=position.amount + modified_amount,
                     fees=acquisition.fees - bed_and_breakfast_fees,
-                    allowable_cost=acquisition.amount,
+                    allowable_cost=acquisition_amount,
                     spin_off=spin_off,
                 )
             )
@@ -1160,11 +1163,17 @@ class Matcher:
 
         Units a reorganisation restated are not here to be taken out: they
         were never acquired (TCGA 1992 s127, CG51805), so they never enter
-        ``acquisition_list`` in the first place.
+        ``acquisition_list`` in the first place. A spun-off holding's cost is
+        the corrected figure once its day has been walked, in place of the
+        estimate the first pass recorded.
         """
         if not has_key(self.history.acquisition_list, date_index, symbol):
             return HmrcTransactionData()
-        return self.history.acquisition_list[date_index][symbol]
+        record = self.history.acquisition_list[date_index][symbol]
+        corrected = self.run.spin_off_corrected_amounts.get((date_index, symbol))
+        if corrected is not None:
+            return replace(record, amount=corrected)
+        return record
 
     def _contending_acquisitions(
         self,

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import datetime
 from decimal import Decimal, localcontext
 import logging
@@ -89,7 +90,12 @@ def get_report(
                 rows_in_time_order=True,
             )
     calculator.convert_to_hmrc_transactions(broker_transactions)
-    return calculator.calculate_capital_gain()
+    prepared = copy.deepcopy(calculator.state.history)
+    report = calculator.calculate_capital_gain()
+    assert calculator.state.history == prepared, (
+        "the matching replay wrote into the prepared history"
+    )
+    return report
 
 
 def create_calculator(

--- a/tests/general/test_spin_off_basis.py
+++ b/tests/general/test_spin_off_basis.py
@@ -48,8 +48,14 @@ def spin_off(
     foo_units: int,
     rates: dict[datetime.date, dict[CurrencyCode, Decimal]],
     currency: CurrencyCode = GBP,
+    after: list[BrokerTransaction] | None = None,
 ) -> tuple[CapitalGainsCalculator, CapitalGainsReport]:
-    """Run `transactions` then spin `foo_units` of BAR out of FOO."""
+    """Run `transactions` then spin `foo_units` of BAR out of FOO.
+
+    Rows in `after` are listed behind the spin-off, which is what a row on the
+    spin-off day itself needs: the sort keeps the order it is given, and a
+    disposal read before the shares arrive is refused.
+    """
     converter = CurrencyConverter(None, rates)
     handler = SpinOffHandler()
     handler.cache = {"BAR": "FOO"}
@@ -79,6 +85,7 @@ def spin_off(
                     0,
                     currency=currency,
                 ),
+                *(after or []),
             ],
             key=_transaction_sort_key,
         ),
@@ -246,6 +253,27 @@ def test_a_purchase_of_the_new_holding_on_the_day_keeps_its_cost() -> None:
 
     assert calculator.portfolio["BAR"].quantity == Decimal(15)
     assert calculator.portfolio["BAR"].amount == Decimal(60)
+
+
+def test_selling_the_new_holding_on_the_day_uses_the_corrected_cost() -> None:
+    """A same-day sale of BAR is identified against the corrected acquisition.
+
+    Half of FOO sold at a profit first, so the first pass estimated nothing
+    for BAR while the real share is 5. The day's acquisitions are walked
+    before its disposals, so the sale must see the 5, not the estimate.
+    """
+    _, report = spin_off(
+        [
+            transaction(BUY_DAY, ActionType.BUY, "FOO", 10, 10, 0, -100, GBP),
+            transaction(SALE_DAY, ActionType.SELL, "FOO", 5, 20, 0, 100, GBP),
+        ],
+        5,
+        {BUY_DAY: {GBP: FLAT}, SALE_DAY: {GBP: FLAT}, SPIN_OFF_DAY: {GBP: FLAT}},
+        after=[transaction(SPIN_OFF_DAY, ActionType.SELL, "BAR", 5, 10, 0, 50, GBP)],
+    )
+
+    same_day_sale = report.calculation_log[SPIN_OFF_DAY]["sell$BAR"]
+    assert sum((e.allowable_cost for e in same_day_sale), Decimal(0)) == Decimal(5)
 
 
 def test_selling_the_new_holding_just_before_the_spin_off_is_refused() -> None:


### PR DESCRIPTION
Replaces the second pass's one write into `PreparedHistory` (in-place rewrite of a spin-off acquisition's `amount`) with a read-only walk, byte-identical output.

- `RunState.spin_off_corrected_amounts` holds the walk's corrected spin-off cost per (day, symbol) instead of mutating the prepared record.
- `process_acquisition` uses a local `acquisition_amount`; `spin_off_estimates` is only ever `.get`, never popped.
- `_matchable_acquisition` returns `dataclasses.replace(record, amount=corrected)` when corrected, so same-day disposals see the fix while the B&B look-ahead still sees the raw record.
- `calculate_capital_gain` docstring no longer claims the walk consumes estimates; guard unchanged.
- `get_report` now deep-copies history before the walk and asserts equality after, as a permanent regression guard.
- Added a test for disposing a spun-off symbol on its own spin-off day (previously untested corrected-view branch).

Doesn't make the walk repeatable or lift the `calculated` guard - that's next in the series.

No behaviour change: `tests/general/data/test_run_with_example_files_output.txt` is byte-identical to base, and the stderr narrative assertion is unchanged.