### PR TITLE
Judge the cash balance at each day's close

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -105,6 +105,7 @@ IBKR
 IBKR's
 idx
 ingester
+intraday
 InvalidOperation
 InvalidTransactionError
 Invesco

--- a/cgt_calc/ingestion.py
+++ b/cgt_calc/ingestion.py
@@ -1152,9 +1152,11 @@ class TransactionIngester:
 
         transactions = self._resolve_gifts(transactions)
         # The cash balance is judged once a day is complete rather than after
-        # every row. Within one day the row order is not a record of what
-        # happened first, so a purchase read before the same-day deposit that
-        # funds it is not an overdraft. Cash is still posted after every row;
+        # every row. Within one day the row order is not consistently reliable
+        # for sequencing cash: a RAW file records it deliberately, a broker
+        # export often does not, and several write the newest row first. So a
+        # purchase read before the same-day deposit that funds it is not
+        # evidence of an overdraft. Cash is still posted after every row;
         # each pool keeps the index of its own last row of the day, a later
         # row simply overwriting the earlier one. Excess reported income never
         # reaches the check, so an ERI row landing last would silence the

--- a/cgt_calc/ingestion.py
+++ b/cgt_calc/ingestion.py
@@ -1151,6 +1151,17 @@ class TransactionIngester:
             self.isin_converter.add_from_transaction(transaction)
 
         transactions = self._resolve_gifts(transactions)
+        # Broker exports carry dates but no reliable execution times, so the
+        # order of same-day rows is arbitrary: a purchase listed before the
+        # deposit that funded it is not an overdraft. Cash is still posted
+        # after every row, but each pool is only judged after its last row of
+        # the day. Excess reported income never reaches the check, so an ERI
+        # row landing last would silence the whole day for that pool.
+        day_close = {
+            (transaction.broker, transaction.currency, transaction.date): index
+            for index, transaction in enumerate(transactions)
+            if transaction.action is not ActionType.EXCESS_REPORTED_INCOME
+        }
         # Reorganisations are planned a day at a time, before any of that
         # day's rows is processed: what a row's count means depends on
         # whether a reorganisation followed it that day, and the pool has to
@@ -1275,7 +1286,8 @@ class TransactionIngester:
                 # its own, at the date it really left or reached the account.
                 new_balance = opening_balance
             balance_history.append(new_balance)
-            if self.balance_check and new_balance < 0:
+            key = (transaction.broker, transaction.currency, transaction.date)
+            if self.balance_check and new_balance < 0 and day_close[key] == i:
                 entries = [
                     f"{trx}\nBalance after transaction={balance_after}"
                     for trx, balance_after in zip(
@@ -1298,6 +1310,7 @@ class TransactionIngester:
                     ]
                 msg = f"Reached a negative balance({new_balance})"
                 msg += f" for broker {transaction.broker} ({transaction.currency})"
+                msg += f" at the end of {transaction.date}"
                 msg += " after processing the following transactions:\n"
                 msg += "\n".join(entries) + "\n"
                 msg += "Tip: If your input file is missing deposits/withdrawals use --no-balance-check."

--- a/cgt_calc/ingestion.py
+++ b/cgt_calc/ingestion.py
@@ -1151,12 +1151,14 @@ class TransactionIngester:
             self.isin_converter.add_from_transaction(transaction)
 
         transactions = self._resolve_gifts(transactions)
-        # Broker exports carry dates but no reliable execution times, so the
-        # order of same-day rows is arbitrary: a purchase listed before the
-        # deposit that funded it is not an overdraft. Cash is still posted
-        # after every row, but each pool is only judged after its last row of
-        # the day. Excess reported income never reaches the check, so an ERI
-        # row landing last would silence the whole day for that pool.
+        # The cash balance is judged once a day is complete rather than after
+        # every row. Within one day the row order is not a record of what
+        # happened first, so a purchase read before the same-day deposit that
+        # funds it is not an overdraft. Cash is still posted after every row;
+        # each pool keeps the index of its own last row of the day, a later
+        # row simply overwriting the earlier one. Excess reported income never
+        # reaches the check, so an ERI row landing last would silence the
+        # whole day for that pool.
         day_close = {
             (transaction.broker, transaction.currency, transaction.date): index
             for index, transaction in enumerate(transactions)
@@ -1310,6 +1312,8 @@ class TransactionIngester:
                     ]
                 msg = f"Reached a negative balance({new_balance})"
                 msg += f" for broker {transaction.broker} ({transaction.currency})"
+                # The row that raises is the day's last, which is often not the
+                # row that spent the money, so the day is what to name here.
                 msg += f" at the end of {transaction.date}"
                 msg += " after processing the following transactions:\n"
                 msg += "\n".join(entries) + "\n"

--- a/docs/brokers/schwab.md
+++ b/docs/brokers/schwab.md
@@ -229,9 +229,6 @@ The money keeps the settlement date. During import, cgt-calc represents the expo
 cash movement on the date Schwab paid or collected the money. This prevents the assignment from
 showing a shortfall before settlement.
 
-Same-day ordering is unchanged. Schwab rows are read from the bottom up, so a funding deposit listed
-above the share row is processed after it and the balance check can still fail.
-
 If a balance-check error includes the generated cash movement, its description is
 `Settlement of the META put option expiring 2024-05-17 at a strike of 50 assigned on 2024-05-17`.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -101,11 +101,15 @@ Avoid `--no-balance-check` unless the relevant broker guide recommends it or you
 check cannot succeed. Disabling it removes one of the checks that can reveal incomplete transaction
 history.
 
-The balance check compares each account's cash balance against zero at the end of every day it has
-rows for, once, rather than after each row. Exports disagree about the order of a day's rows, and
-several write the newest first, so a purchase can appear before the deposit that funded it. Because
-the day is judged as a whole, an account that dips below zero during a day and recovers before the
-day ends is not reported.
+For each broker and currency, the balance check compares the cash balance with zero after that day's
+last row, rather than after every row. Exports disagree about the order of a day's rows, and several
+write the newest first, so a purchase can appear before the deposit that funded it. Balances are
+kept per broker and currency rather than per account, so everything you export from one broker in
+one currency shares a single balance.
+
+cgt-calc cannot detect a balance that falls below zero within a day and recovers by the end of it.
+If you need to verify intraday funding, check the cash history in your broker's own records for that
+day.
 
 A successful run means cgt-calc could parse and calculate the supplied transactions. It does not
 prove that the supplied history was complete or that every part of your tax position is supported.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -101,11 +101,11 @@ Avoid `--no-balance-check` unless the relevant broker guide recommends it or you
 check cannot succeed. Disabling it removes one of the checks that can reveal incomplete transaction
 history.
 
-For each broker and currency, the balance check compares the cash balance with zero after that day's
-last row, rather than after every row. Exports disagree about the order of a day's rows, and several
-write the newest first, so a purchase can appear before the deposit that funded it. Balances are
-kept per broker and currency rather than per account, so everything you export from one broker in
-one currency shares a single balance.
+For each broker and currency, the balance check compares the cash balance with zero after the last
+row of each day, rather than after every row. Exports disagree about the order of a day's rows, and
+several write the newest first, so a purchase can appear before the deposit that funded it. Balances
+are kept per broker and currency rather than per account, so everything you export from one broker
+in one currency shares a single balance.
 
 cgt-calc cannot detect a balance that falls below zero within a day and recovers by the end of it.
 If you need to verify intraday funding, check the cash history in your broker's own records for that

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -101,6 +101,12 @@ Avoid `--no-balance-check` unless the relevant broker guide recommends it or you
 check cannot succeed. Disabling it removes one of the checks that can reveal incomplete transaction
 history.
 
+The balance check compares each account's cash balance against zero at the end of every day it has
+rows for, once, rather than after each row. Exports disagree about the order of a day's rows, and
+several write the newest first, so a purchase can appear before the deposit that funded it. Because
+the day is judged as a whole, an account that dips below zero during a day and recovers before the
+day ends is not reported.
+
 A successful run means cgt-calc could parse and calculate the supplied transactions. It does not
 prove that the supplied history was complete or that every part of your tax position is supported.
 

--- a/tests/general/calc_test_data.py
+++ b/tests/general/calc_test_data.py
@@ -157,6 +157,7 @@ def transaction(
     amount: float | None = None,
     currency: CurrencyCode = USD,
     isin: Isin | None = None,
+    broker: str = "Testing",
 ) -> BrokerTransaction:
     """Create transaction."""
     return BrokerTransaction(
@@ -169,7 +170,7 @@ def transaction(
         fees=round_decimal(Decimal(fees), 6),
         amount=round_decimal(Decimal(amount), 6) if amount else None,
         currency=currency,
-        broker="Testing",
+        broker=broker,
         isin=isin,
     )
 

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -1950,7 +1950,7 @@ def test_balance_check_accepts_same_day_funding_in_either_order(
     ]
     calculator = create_calculator(tax_year=2024)
 
-    calculator.convert_to_hmrc_transactions(rows if deposit_first else rows[::-1])
+    calculator.prepare_history(rows if deposit_first else rows[::-1])
 
 
 def test_balance_check_reports_an_overdraft_left_at_the_end_of_the_day() -> None:
@@ -1963,7 +1963,7 @@ def test_balance_check_reports_an_overdraft_left_at_the_end_of_the_day() -> None
     calculator = create_calculator(tax_year=2024)
 
     with pytest.raises(CalculationError) as excinfo:
-        calculator.convert_to_hmrc_transactions(transactions)
+        calculator.prepare_history(transactions)
 
     message = str(excinfo.value)
     assert "Reached a negative balance(-1000.000000)" in message
@@ -1982,11 +1982,11 @@ def test_balance_check_reports_an_overdraft_left_at_the_end_of_the_day() -> None
 def test_balance_check_is_not_funded_by_a_later_day_or_another_pool(
     date: datetime.date, broker: str, currency: CurrencyCode
 ) -> None:
-    """Money has to be there already, in the same broker and currency.
+    """Funding must be in the same broker and currency by the purchase date.
 
-    An earlier day's deposit funds later activity, as it always has. A
-    deposit made after the purchase does not, and neither does money at
-    another broker or in another currency.
+    A deposit dated on or before the purchase funds it, wherever it sits
+    in the export. A deposit dated after the purchase does not, and
+    neither does money at another broker or in another currency.
     """
     purchase = buy_transaction(
         datetime.date(2024, 5, 1),
@@ -2002,7 +2002,7 @@ def test_balance_check_is_not_funded_by_a_later_day_or_another_pool(
     calculator = create_calculator(tax_year=2024)
 
     with pytest.raises(CalculationError, match=r"negative balance\(-5000"):
-        calculator.convert_to_hmrc_transactions(
+        calculator.prepare_history(
             sorted([deposit, purchase], key=lambda row: row.date)
         )
 
@@ -2021,7 +2021,7 @@ def test_balance_check_is_not_silenced_by_a_trailing_eri_row() -> None:
     calculator = create_calculator(tax_year=2024)
 
     with pytest.raises(CalculationError, match=r"negative balance\(-1"):
-        calculator.convert_to_hmrc_transactions(transactions)
+        calculator.prepare_history(transactions)
 
 
 def test_custom_period_narrows_reporting_window() -> None:

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -47,6 +47,7 @@ from .calc_test_data import (
     GBP,
     buy_transaction,
     calc_basic_data,
+    eri_transaction,
     sell_transaction,
     split_transaction,
     transaction,
@@ -1935,6 +1936,87 @@ def test_negative_balance_error_shows_only_relevant_transactions() -> None:
     assert message.count("Balance after transaction=") == 3
     assert "currency='EUR'" not in message
     assert "Split of FOO" not in message
+
+
+@pytest.mark.parametrize("deposit_first", [True, False])
+def test_balance_check_accepts_same_day_funding_in_either_order(
+    deposit_first: bool,
+) -> None:
+    """A purchase funded on the day it is made passes whichever row is first."""
+    day = datetime.date(2024, 5, 1)
+    rows = [
+        transfer_transaction(day, 5000.0),
+        buy_transaction(day, "FOO", quantity=100, price=50.0, fees=0.0, amount=-5000.0),
+    ]
+    calculator = create_calculator(tax_year=2024)
+
+    calculator.convert_to_hmrc_transactions(rows if deposit_first else rows[::-1])
+
+
+def test_balance_check_reports_an_overdraft_left_at_the_end_of_the_day() -> None:
+    """A day that ends short is still reported, and the message names the day."""
+    day = datetime.date(2024, 5, 1)
+    transactions = [
+        transfer_transaction(day, 4000.0),
+        buy_transaction(day, "FOO", quantity=100, price=50.0, fees=0.0, amount=-5000.0),
+    ]
+    calculator = create_calculator(tax_year=2024)
+
+    with pytest.raises(CalculationError) as excinfo:
+        calculator.convert_to_hmrc_transactions(transactions)
+
+    message = str(excinfo.value)
+    assert "Reached a negative balance(-1000.000000)" in message
+    assert "at the end of 2024-05-01 after processing" in message
+
+
+@pytest.mark.parametrize(
+    ("date", "broker", "currency"),
+    [
+        (datetime.date(2024, 5, 2), "Testing", CurrencyCode("USD")),
+        (datetime.date(2024, 5, 1), "Another broker", CurrencyCode("USD")),
+        (datetime.date(2024, 5, 1), "Testing", CurrencyCode("EUR")),
+    ],
+    ids=["later date", "other broker", "other currency"],
+)
+def test_balance_check_is_not_funded_from_another_pool_day(
+    date: datetime.date, broker: str, currency: CurrencyCode
+) -> None:
+    """Only cash in the same broker, currency and day counts as funding."""
+    purchase = buy_transaction(
+        datetime.date(2024, 5, 1),
+        "FOO",
+        quantity=100,
+        price=50.0,
+        fees=0.0,
+        amount=-5000.0,
+    )
+    deposit = transaction(
+        date, ActionType.TRANSFER, amount=5000.0, currency=currency, broker=broker
+    )
+    calculator = create_calculator(tax_year=2024)
+
+    with pytest.raises(CalculationError, match=r"negative balance\(-5000"):
+        calculator.convert_to_hmrc_transactions(
+            sorted([deposit, purchase], key=lambda row: row.date)
+        )
+
+
+def test_balance_check_is_not_silenced_by_a_trailing_eri_row() -> None:
+    """Excess reported income skips the check, so it cannot stand in for day close."""
+    day = datetime.date(2024, 5, 1)
+    isin = Isin("USFOO0000006")
+    transactions = [
+        transfer_transaction(day, 100.0),
+        buy_transaction(
+            day, "FOO", quantity=1, price=101.0, fees=0.0, amount=-101.0, isin=isin
+        ),
+        eri_transaction(day, isin, 2.1),
+    ]
+    calculator = create_calculator(tax_year=2024)
+
+    with pytest.raises(CalculationError, match=r"negative balance\(-1"):
+        calculator.convert_to_hmrc_transactions(transactions)
 
 
 def test_custom_period_narrows_reporting_window() -> None:

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -1979,10 +1979,15 @@ def test_balance_check_reports_an_overdraft_left_at_the_end_of_the_day() -> None
     ],
     ids=["later date", "other broker", "other currency"],
 )
-def test_balance_check_is_not_funded_from_another_pool_day(
+def test_balance_check_is_not_funded_by_a_later_day_or_another_pool(
     date: datetime.date, broker: str, currency: CurrencyCode
 ) -> None:
-    """Only cash in the same broker, currency and day counts as funding."""
+    """Money has to be there already, in the same broker and currency.
+
+    An earlier day's deposit funds later activity, as it always has. A
+    deposit made after the purchase does not, and neither does money at
+    another broker or in another currency.
+    """
     purchase = buy_transaction(
         datetime.date(2024, 5, 1),
         "FOO",

--- a/tests/schwab/test_schwab_options.py
+++ b/tests/schwab/test_schwab_options.py
@@ -300,18 +300,16 @@ def test_assigned_put_and_plain_purchase_agree_on_the_balance_check(
 ) -> None:
     """An assignment must not be judged more harshly than an ordinary buy.
 
-    The parser reads an export from the bottom up, so the deposit listed
-    below the purchase is the one read first, and only that order is funded
-    in time. The other order fails for both histories alike: that is a
-    same-day ordering limitation of the balance check itself, not something
-    assignment adds.
+    Each pool is judged after its last row of the day, so where the funding
+    deposit sits in the export no longer decides the outcome. Both orders
+    pass, for the assignment and the plain purchase alike.
     """
 
     def ordered(rows: list[str]) -> list[str]:
         return rows if deposit_first else [rows[1], rows[0], *rows[2:]]
 
-    assert _passes_balance_check(ordered(_FUNDED_ASSIGNED_PUT)) is deposit_first
-    assert _passes_balance_check(ordered(_PLAIN_FUNDED_PURCHASE)) is deposit_first
+    assert _passes_balance_check(ordered(_FUNDED_ASSIGNED_PUT))
+    assert _passes_balance_check(ordered(_PLAIN_FUNDED_PURCHASE))
 
 
 def test_assigned_call_leaves_its_proceeds_on_the_settlement_date() -> None:

--- a/tests/schwab/test_schwab_options.py
+++ b/tests/schwab/test_schwab_options.py
@@ -295,7 +295,7 @@ def test_assigned_put_without_its_funding_deposit_still_errors() -> None:
 
 
 @pytest.mark.parametrize("deposit_first", [True, False])
-def test_assigned_put_and_plain_purchase_agree_on_the_balance_check(
+def test_assigned_put_passes_the_balance_check_in_either_export_order(
     deposit_first: bool,
 ) -> None:
     """An assignment must not be judged more harshly than an ordinary buy.


### PR DESCRIPTION
The balance check ran after every row, so a same-day purchase listed before the deposit that funded it was reported as an overdraft even though the account was funded that day. Within one day, row order is not consistently reliable for sequencing cash: a RAW file records it deliberately, a broker export often does not, and several write the newest row first.

- Judge each `(broker, currency, date)` pool once, at its last row of the day, instead of after every row. Cash still posts after every row and no tax event moves.
- Leave `ActionType.EXCESS_REPORTED_INCOME` rows out of that reckoning: they `continue` before the balance code, so one landing last would silence a real shortfall for the whole day.
- Name the day in the negative-balance error, since the row that raises it is no longer necessarily the row that caused it.
- Say in `docs/usage.md` that the balance is pooled per broker and currency rather than per account and judged at each day's close, that a dip which recovers within the day is not reported, and to check the broker's own cash history to verify intraday funding.
- Drop the paragraph in `docs/brokers/schwab.md` describing the ordering limitation this removes.

An account left overdrawn when a day ends is still reported. A deposit dated on or before the purchase funds it, wherever it sits in the export; one dated after it does not, and neither does money at another broker or in another currency.
