### PR TITLE
Shorten the package summary to one sentence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "uv_build"
 [project]
 name = "cgt-calc"
 version = "0.0.0"
-description = "Calculate UK capital gains from broker exports — supports Charles Schwab, Freetrade, Hargreaves Lansdown, Interactive Brokers, Morgan Stanley, Sharesight, Trading 212, Vanguard and a custom RAW format."
+description = "Calculate UK capital gains tax from broker exports for your HMRC Self Assessment"
 authors = [{ name = "Ruslan Sayfutdinov", email = "ruslan@sayfutdinov.com" }]
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Replace the broker list in the `pyproject.toml` summary with the same one-sentence description now used in the GitHub About section. Broker names remain discoverable through the repo topics and the README.