### PR TITLE
Reset run state so a calculation can be repeated

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -175,6 +175,7 @@ Revolut
 RKT
 roundings
 RowIterator
+RunState
 RuntimeError
 RuntimeMode
 s105

--- a/cgt_calc/calculator_state.py
+++ b/cgt_calc/calculator_state.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
@@ -157,7 +157,6 @@ class RunState:
     # not be calculated on.
     ingestion_started: bool = False
     ingested: bool = False
-    calculated: bool = False
     # The source side of each spin-off, recorded when it is applied and
     # collected into the calculation log by date.
     spin_off_entries: dict[datetime.date, dict[str, list[CalculationEntry]]] = field(
@@ -175,6 +174,16 @@ class RunState:
     spin_off_corrected_amounts: dict[tuple[datetime.date, str], Decimal] = field(
         default_factory=dict
     )
+
+    def reset(self) -> None:
+        """Forget what the last calculation built, keeping how far ingestion got.
+
+        In place, because the collaborators hold this object, not its fields.
+        """
+        fresh = RunState()
+        for spec in fields(self):
+            if spec.name not in {"ingestion_started", "ingested"}:
+                setattr(self, spec.name, getattr(fresh, spec.name))
 
 
 @dataclass

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -212,20 +212,17 @@ class CapitalGainsCalculator:
     ) -> CapitalGainsReport:
         """Calculate capital gain and return generated report.
 
-        Runs once per calculator. The walk accumulates bed and breakfast
-        claims as it makes them, so a second run would count them twice.
+        It may be run again, and each run starts from a fresh `RunState` over
+        the same prepared history.
         """
         if not self.run.ingested:
             raise RuntimeError(
                 "convert_to_hmrc_transactions() must complete before "
                 "calculate_capital_gain(); use calculate() to run both in order"
             )
-        if self.run.calculated:
-            raise RuntimeError(
-                "calculate_capital_gain() runs once per calculator; build a "
-                "new one to calculate again"
-            )
-        self.run.calculated = True
+        # The walk and the income processing accumulate into run state, so a
+        # rerun starts from nothing rather than adding to the last run.
+        self.run.reset()
         self._warn_unmatched_cgt_exempt_tickers()
         walked = self.matcher.walk()
 

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import datetime
 from decimal import Decimal, localcontext
+from enum import Enum
 import logging
 from pathlib import Path
 import subprocess
@@ -1716,20 +1717,74 @@ def test_multiple_foreign_fee_currencies_on_sell() -> None:
     assert sell.price == Decimal(10)
 
 
-def test_calculate_capital_gain_runs_once() -> None:
-    """A second run would count the first pass's estimates and B&B claims twice."""
+def report_values(obj: object) -> object:
+    """Rebuild a report out of things that compare by value.
+
+    Two reports built by separate runs cannot be compared with ==:
+    `PortfolioEntry` and `CalculationEntry` define no `__eq__`, so the
+    generated comparison falls back to identity on the portfolio and both
+    calculation logs. Rendering to text is not the comparison either -- it
+    leaves out most calculation log entries, drops empty positions and
+    rounds. This walks the whole structure into dicts and lists, so every
+    field of every entry is compared, including the ones only the PDF reads.
+    """
+    if isinstance(obj, Enum):
+        return obj
+    if isinstance(obj, dict):
+        return {key: report_values(value) for key, value in obj.items()}
+    if isinstance(obj, list | tuple):
+        return [report_values(item) for item in obj]
+    attributes = getattr(obj, "__dict__", None)
+    if attributes is None:
+        return obj
+    return {name: report_values(value) for name, value in attributes.items()}
+
+
+def test_calculate_capital_gain_is_repeatable() -> None:
+    """A second run rebuilds the same report from the same prepared history."""
     calculator = create_calculator(tax_year=2024, balance_check=False)
-    get_report(
-        calculator,
+    calculator.convert_to_hmrc_transactions(
         [
             transaction(
-                datetime.date(2024, 6, 1), ActionType.BUY, "FOO", 1, 10, 0, -10, GBP
-            )
-        ],
+                datetime.date(2024, 6, 1), ActionType.BUY, "FOO", 10, 10, 0, -100, GBP
+            ),
+            transaction(
+                datetime.date(2024, 6, 10), ActionType.SELL, "FOO", 10, 12, 0, 120, GBP
+            ),
+            # Within 30 days of the sale, so the walk records a bed and
+            # breakfast claim as it matches it.
+            transaction(
+                datetime.date(2024, 6, 20), ActionType.BUY, "FOO", 10, 11, 0, -110, GBP
+            ),
+            transaction(
+                datetime.date(2024, 7, 1),
+                ActionType.DIVIDEND,
+                "FOO",
+                None,
+                None,
+                0,
+                5,
+                GBP,
+            ),
+            transaction(
+                datetime.date(2024, 7, 2),
+                ActionType.INTEREST,
+                None,
+                None,
+                None,
+                0,
+                3,
+                GBP,
+            ),
+        ]
     )
+    prepared = copy.deepcopy(calculator.state.history)
 
-    with pytest.raises(RuntimeError, match="runs once per calculator"):
-        calculator.calculate_capital_gain()
+    first = calculator.calculate_capital_gain()
+    second = calculator.calculate_capital_gain()
+
+    assert report_values(second) == report_values(first)
+    assert calculator.state.history == prepared
 
 
 def test_convert_to_hmrc_transactions_runs_once() -> None:


### PR DESCRIPTION
`calculate_capital_gain()` no longer raises "runs once per calculator" - it resets accumulated run state (`bnb_list`, ERI/spin-off correction data, interest totals, `calculation_log_yields`) before each run, so a second call produces the same report.

- Add `RunState.reset()`: reinitialises every field except `ingestion_started`/`ingested`.
- Call it at the top of `calculate_capital_gain()`; remove the `calculated` flag and its `RuntimeError`.
- Replace `test_calculate_capital_gain_runs_once` with `test_calculate_capital_gain_is_repeatable`, which calculates twice over one prepared history and compares both reports field-by-field.

Ingestion is unchanged and still once-only. First run is byte-identical.