### PR TITLE
Put the documentation link on the first README screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 [![PyPI version](https://img.shields.io/pypi/v/cgt-calc?style=flat-square)](https://pypi.org/project/cgt-calc/)
 [![CI](https://img.shields.io/github/actions/workflow/status/cgt-calc/capital-gains-calculator/ci.yml?style=flat-square&label=CI)](https://github.com/cgt-calc/capital-gains-calculator/actions)
 [![codecov](https://img.shields.io/codecov/c/github/cgt-calc/capital-gains-calculator?style=flat-square)](https://app.codecov.io/gh/cgt-calc/capital-gains-calculator)
-[![Documentation](https://img.shields.io/badge/docs-cgt--calc.uk-blue?style=flat-square)](https://cgt-calc.uk/)
 
 # <img src="https://cgt-calc.uk/assets/logo.svg" alt="" width="34" valign="middle"> UK Capital Gains Calculator
 
 Use cgt-calc to calculate **UK capital gains** from your investment transaction history and generate
-a detailed report from a supported broker export. Full documentation lives at
-**[cgt-calc.uk](https://cgt-calc.uk/)**, covering installation, per-broker export guides, offshore
-funds (ERI), extra data and options, and Docker usage.
+a detailed report from a supported broker export.
+
+See the [full documentation](https://cgt-calc.uk/) for installation, broker export guides, offshore
+funds (ERI), extra data and options, and Docker.
 
 Supported sources include **Charles Schwab**, **Freetrade**, **Hargreaves Lansdown**, **Interactive
 Brokers**, **Morgan Stanley**, **Revolut**, **Sharesight**, **Trading 212**, **Vanguard**, or a

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 # <img src="https://cgt-calc.uk/assets/logo.svg" alt="" width="34" valign="middle"> UK Capital Gains Calculator
 
 Use cgt-calc to calculate **UK capital gains** from your investment transaction history and generate
-a detailed report from a supported broker export. Full documentation — installation, per-broker
-export guides, offshore funds (ERI), extra data and options, and Docker usage — lives at
-**[cgt-calc.uk](https://cgt-calc.uk/)**.
+a detailed report from a supported broker export. Full documentation lives at
+**[cgt-calc.uk](https://cgt-calc.uk/)**, covering installation, per-broker export guides, offshore
+funds (ERI), extra data and options, and Docker usage.
 
 Supported sources include **Charles Schwab**, **Freetrade**, **Hargreaves Lansdown**, **Interactive
 Brokers**, **Morgan Stanley**, **Revolut**, **Sharesight**, **Trading 212**, **Vanguard**, or a

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 Use cgt-calc to calculate **UK capital gains** from your investment transaction history and generate
 a detailed report from a supported broker export.
 
-See the [full documentation](https://cgt-calc.uk/) for installation, broker export guides, offshore
-funds (ERI), extra data and options, and Docker.
-
 Supported sources include **Charles Schwab**, **Freetrade**, **Hargreaves Lansdown**, **Interactive
 Brokers**, **Morgan Stanley**, **Revolut**, **Sharesight**, **Trading 212**, **Vanguard**, or a
 custom **RAW** format. Check your broker's guide before starting, especially for employer shares,
 because not every award export or transaction type is supported.
+
+See the [full documentation](https://cgt-calc.uk/) for installation, broker export guides, offshore
+funds (ERI), extra data and options, and Docker.
 
 ## 🚀 Quick Start
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 [![PyPI version](https://img.shields.io/pypi/v/cgt-calc?style=flat-square)](https://pypi.org/project/cgt-calc/)
 [![CI](https://img.shields.io/github/actions/workflow/status/cgt-calc/capital-gains-calculator/ci.yml?style=flat-square&label=CI)](https://github.com/cgt-calc/capital-gains-calculator/actions)
 [![codecov](https://img.shields.io/codecov/c/github/cgt-calc/capital-gains-calculator?style=flat-square)](https://app.codecov.io/gh/cgt-calc/capital-gains-calculator)
+[![Documentation](https://img.shields.io/badge/docs-cgt--calc.uk-blue?style=flat-square)](https://cgt-calc.uk/)
 
 # <img src="https://cgt-calc.uk/assets/logo.svg" alt="" width="34" valign="middle"> UK Capital Gains Calculator
 
 Use cgt-calc to calculate **UK capital gains** from your investment transaction history and generate
-a detailed report from a supported broker export.
+a detailed report from a supported broker export. Full documentation — installation, per-broker
+export guides, offshore funds (ERI), extra data and options, and Docker usage — lives at
+**[cgt-calc.uk](https://cgt-calc.uk/)**.
 
 Supported sources include **Charles Schwab**, **Freetrade**, **Hargreaves Lansdown**, **Interactive
 Brokers**, **Morgan Stanley**, **Revolut**, **Sharesight**, **Trading 212**, **Vanguard**, or a
@@ -51,11 +54,6 @@ acquired at different times, gains and losses, a dividend with overseas tax, and
 <a href="https://cgt-calc.uk/assets/example_report.pdf">
   <img src="https://cgt-calc.uk/assets/example_report_preview.webp" alt="Preview of the 2025/26 example report" width="600">
 </a>
-
-## 📚 Documentation
-
-Full documentation — installation, per-broker export guides, offshore funds (ERI), extra data and
-options, and Docker usage — lives at **[cgt-calc.uk](https://cgt-calc.uk/)**.
 
 ## 🤝 Contributing
 


### PR DESCRIPTION
The documentation homepage was first linked in a section below the example report and Quick Start, roughly two screens down the GitHub page, although Quick Start already linked individual pages of the site.

- Move the pointer to the full documentation into its own paragraph directly after the supported sources, listing the main docs pages.

Removed the separate Documentation section, as Quick Start already links the Installation, Usage and Brokers pages individually.