### PR TITLE
Name the first pass prepare_history

### DIFF
--- a/cgt_calc/ingestion.py
+++ b/cgt_calc/ingestion.py
@@ -1132,11 +1132,11 @@ class TransactionIngester:
             year_totals[transaction.broker, transaction.currency] += amount
         return amount
 
-    def convert_to_hmrc_transactions(
+    def prepare_history(
         self,
         transactions: list[BrokerTransaction],
     ) -> None:
-        """Convert broker transactions to HMRC transactions."""
+        """Run the first pass over the broker transactions."""
         # We keep a balance per broker,currency pair
         balance: dict[tuple[str, CurrencyCode], Decimal] = defaultdict(
             lambda: Decimal(0)

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -158,30 +158,30 @@ class CapitalGainsCalculator:
         """Check if symbol is exempt from Capital Gains Tax."""
         return symbol.upper() in self.cgt_exempt_tickers
 
-    def convert_to_hmrc_transactions(
+    def prepare_history(
         self,
         transactions: list[BrokerTransaction],
     ) -> None:
-        """Convert broker transactions to HMRC transactions.
+        """Run the first pass over the broker transactions.
 
         Runs once per calculator, whether or not it succeeds: a second run
         would accumulate into the history the first one recorded.
         """
         if self.run.ingestion_started:
             raise RuntimeError(
-                "convert_to_hmrc_transactions() runs once per calculator; build "
+                "prepare_history() runs once per calculator; build "
                 "a new one to ingest again"
             )
         self.run.ingestion_started = True
-        self.ingester.convert_to_hmrc_transactions(transactions)
+        self.ingester.prepare_history(transactions)
         self.run.ingested = True
 
     def calculate(
         self,
         transactions: list[BrokerTransaction],
     ) -> CapitalGainsReport:
-        """Convert broker transactions and calculate the capital gain."""
-        self.convert_to_hmrc_transactions(transactions)
+        """Run both passes and return the report."""
+        self.prepare_history(transactions)
         return self.calculate_capital_gain()
 
     def first_pass_report(self, totals: FirstPassTotals) -> None:
@@ -217,7 +217,7 @@ class CapitalGainsCalculator:
         """
         if not self.run.ingested:
             raise RuntimeError(
-                "convert_to_hmrc_transactions() must complete before "
+                "prepare_history() must complete before "
                 "calculate_capital_gain(); use calculate() to run both in order"
             )
         # The walk and the income processing accumulate into run state, so a

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -43,13 +43,15 @@ The calculation has two passes:
 - `cgt_calc/ingestion.py` validates transactions and runs the first pass. It records dividends and
     interest for `income.py` to process, and delegates share-reorganisation planning to
     `stock_split_planning.py`.
-- `cgt_calc/calculator_state.py` holds the mutable working state shared by both passes.
+- `cgt_calc/calculator_state.py` holds `PreparedHistory`, which the first pass fills and the second
+    pass only reads, and `RunState`, which the second pass builds and which is reset at the start of
+    every calculation.
 - `cgt_calc/matching.py` runs the second pass, applying the same-day, bed-and-breakfast and Section
     104 matching rules.
 - `cgt_calc/model.py` defines shared values and the report model. `render_text.py` and
     `render_latex.py` format that report without calculating it.
-- `cgt_calc/main.py` connects the stages behind `CapitalGainsCalculator`. `cgt_calc/cli.py` handles
-    command-line input and output.
+- `cgt_calc/main.py` connects the stages behind `CapitalGainsCalculator`, whose `calculate()` runs
+    the two passes in order. `cgt_calc/cli.py` handles command-line input and output.
 
 Put a change in the module that owns its behaviour. Extract a new module only when one complete
 concern can move behind explicit inputs; do not split a file only to reduce its line count.

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -90,7 +90,7 @@ def get_report(
                 index=index,
                 rows_in_time_order=True,
             )
-    calculator.convert_to_hmrc_transactions(broker_transactions)
+    calculator.prepare_history(broker_transactions)
     prepared = copy.deepcopy(calculator.state.history)
     report = calculator.calculate_capital_gain()
     assert calculator.state.history == prepared, (
@@ -287,7 +287,7 @@ def test_eri_duplicate_report_within_tolerance_is_skipped(
         ),
     ]
 
-    calculator.convert_to_hmrc_transactions(transactions)
+    calculator.prepare_history(transactions)
 
     assert "Skipping duplicated ERI transaction" in caplog.text
     assert calculator.eris[date]["VWRL"].price == Decimal("1.00000")
@@ -326,7 +326,7 @@ def test_eri_conflicting_report_raises_invalid_transaction_error() -> None:
     ]
 
     with pytest.raises(InvalidTransactionError, match="conflicting ERI report"):
-        calculator.convert_to_hmrc_transactions(transactions)
+        calculator.prepare_history(transactions)
 
 
 @pytest.mark.parametrize(
@@ -359,9 +359,9 @@ def test_eri_missing_required_data_has_a_transaction_error(
     )
 
     with pytest.raises(error):
-        create_calculator(
-            tax_year=2024, balance_check=False
-        ).convert_to_hmrc_transactions([transaction])
+        create_calculator(tax_year=2024, balance_check=False).prepare_history(
+            [transaction]
+        )
 
 
 def test_dividend_and_tax_currency_mismatch_has_a_calculation_error() -> None:
@@ -386,7 +386,7 @@ def test_dividend_and_tax_currency_mismatch_has_a_calculation_error() -> None:
         ]
     ]
     calculator = create_calculator(tax_year=2024, balance_check=False)
-    calculator.convert_to_hmrc_transactions(transactions)
+    calculator.prepare_history(transactions)
 
     with pytest.raises(CalculationError, match="currencies do not match"):
         calculator.calculate_capital_gain()
@@ -419,9 +419,7 @@ def test_invalid_management_fee_has_a_transaction_error(
     )
 
     with pytest.raises(InvalidTransactionError, match=error_match):
-        create_calculator(
-            tax_year=2024, balance_check=False
-        ).convert_to_hmrc_transactions([fee])
+        create_calculator(tax_year=2024, balance_check=False).prepare_history([fee])
 
 
 def test_zero_management_fee_is_accepted() -> None:
@@ -439,9 +437,7 @@ def test_zero_management_fee_is_accepted() -> None:
         broker="Test",
     )
 
-    create_calculator(tax_year=2024, balance_check=False).convert_to_hmrc_transactions(
-        [fee]
-    )
+    create_calculator(tax_year=2024, balance_check=False).prepare_history([fee])
 
 
 @pytest.mark.parametrize(
@@ -1051,7 +1047,7 @@ def test_transaction_ticker_cannot_reassign_a_reference_owned_isin() -> None:
     ]
 
     with pytest.raises(InvalidTransactionError, match="already used for"):
-        calculator.convert_to_hmrc_transactions(transactions)
+        calculator.prepare_history(transactions)
 
 
 def test_rename_transfers_pool_to_new_ticker() -> None:
@@ -1099,9 +1095,9 @@ def test_rename_without_old_symbol_has_a_transaction_error(description: str) -> 
     transaction.description = description
 
     with pytest.raises(InvalidTransactionError, match="old symbol"):
-        create_calculator(
-            tax_year=2024, balance_check=False
-        ).convert_to_hmrc_transactions([transaction])
+        create_calculator(tax_year=2024, balance_check=False).prepare_history(
+            [transaction]
+        )
 
 
 def test_section_104_disposal_uses_renamed_pool_cost() -> None:
@@ -1434,7 +1430,7 @@ def test_negative_balance_error_trims_long_history() -> None:
     calculator = create_calculator(tax_year=2024)
 
     with pytest.raises(CalculationError) as excinfo:
-        calculator.convert_to_hmrc_transactions(transactions)
+        calculator.prepare_history(transactions)
 
     message = str(excinfo.value)
     assert "... 5 earlier transaction(s) omitted ..." in message
@@ -1448,7 +1444,7 @@ def test_negative_balance_error_shows_short_history_in_full() -> None:
     calculator = create_calculator(tax_year=2024)
 
     with pytest.raises(CalculationError) as excinfo:
-        calculator.convert_to_hmrc_transactions(transactions)
+        calculator.prepare_history(transactions)
 
     message = str(excinfo.value)
     assert "Reached a negative balance(-1.000000)" in message
@@ -1482,7 +1478,7 @@ def test_negative_balance_error_shows_only_relevant_transactions() -> None:
     calculator = create_calculator(tax_year=2024)
 
     with pytest.raises(CalculationError) as excinfo:
-        calculator.convert_to_hmrc_transactions(transactions)
+        calculator.prepare_history(transactions)
 
     message = str(excinfo.value)
     assert message.count("Balance after transaction=") == 3
@@ -1615,7 +1611,7 @@ def test_foreign_fees_folded_into_gbp_transaction() -> None:
         foreign_fees={CurrencyCode("USD"): Decimal("1.25")},
     )
 
-    calculator.convert_to_hmrc_transactions([buy])
+    calculator.prepare_history([buy])
 
     assert buy.foreign_fees == {}
     assert buy.fees == Decimal(1)
@@ -1652,7 +1648,7 @@ def test_foreign_fees_folded_into_non_gbp_transaction() -> None:
         foreign_fees={CurrencyCode("GBP"): Decimal(1)},
     )
 
-    calculator.convert_to_hmrc_transactions([buy])
+    calculator.prepare_history([buy])
 
     assert buy.foreign_fees == {}
     assert buy.fees == Decimal("1.25")
@@ -1710,7 +1706,7 @@ def test_multiple_foreign_fee_currencies_on_sell() -> None:
         },
     )
 
-    calculator.convert_to_hmrc_transactions([buy, sell])
+    calculator.prepare_history([buy, sell])
 
     assert sell.foreign_fees == {}
     assert sell.fees == Decimal("0.70")
@@ -1743,7 +1739,7 @@ def report_values(obj: object) -> object:
 def test_calculate_capital_gain_is_repeatable() -> None:
     """A second run rebuilds the same report from the same prepared history."""
     calculator = create_calculator(tax_year=2024, balance_check=False)
-    calculator.convert_to_hmrc_transactions(
+    calculator.prepare_history(
         [
             transaction(
                 datetime.date(2024, 6, 1), ActionType.BUY, "FOO", 10, 10, 0, -100, GBP
@@ -1787,7 +1783,7 @@ def test_calculate_capital_gain_is_repeatable() -> None:
     assert calculator.state.history == prepared
 
 
-def test_convert_to_hmrc_transactions_runs_once() -> None:
+def test_prepare_history_runs_once() -> None:
     """A second ingestion would accumulate into the history already recorded."""
     calculator = create_calculator(tax_year=2024, balance_check=False)
     transactions = [
@@ -1795,10 +1791,10 @@ def test_convert_to_hmrc_transactions_runs_once() -> None:
             datetime.date(2024, 6, 1), ActionType.BUY, "FOO", 1, 10, 0, -10, GBP
         )
     ]
-    calculator.convert_to_hmrc_transactions(transactions)
+    calculator.prepare_history(transactions)
 
     with pytest.raises(RuntimeError, match="runs once per calculator"):
-        calculator.convert_to_hmrc_transactions(transactions)
+        calculator.prepare_history(transactions)
 
 
 def test_calculate_capital_gain_requires_ingestion() -> None:
@@ -1818,10 +1814,10 @@ def test_failed_ingestion_can_be_neither_retried_nor_calculated() -> None:
     ]
 
     with pytest.raises(AmountMissingError):
-        calculator.convert_to_hmrc_transactions(transactions)
+        calculator.prepare_history(transactions)
 
     with pytest.raises(RuntimeError, match="runs once per calculator"):
-        calculator.convert_to_hmrc_transactions(transactions)
+        calculator.prepare_history(transactions)
 
     with pytest.raises(RuntimeError, match="must complete before"):
         calculator.calculate_capital_gain()
@@ -1839,7 +1835,7 @@ def test_calculate_matches_the_two_step_sequence() -> None:
 
     combined = create_calculator(tax_year=2024, balance_check=False)
     two_step = create_calculator(tax_year=2024, balance_check=False)
-    two_step.convert_to_hmrc_transactions(transactions())
+    two_step.prepare_history(transactions())
 
     assert str(combined.calculate(transactions())) == str(
         two_step.calculate_capital_gain()

--- a/tests/general/test_dividend_source_country.py
+++ b/tests/general/test_dividend_source_country.py
@@ -70,7 +70,7 @@ def _treaty_country(transactions: list[BrokerTransaction]) -> str | None:
         interest_fund_tickers=[],
         balance_check=False,
     )
-    calculator.convert_to_hmrc_transactions(transactions)
+    calculator.prepare_history(transactions)
     report = calculator.calculate_capital_gain()
 
     entries = [

--- a/tests/general/test_dividend_tax_attribution.py
+++ b/tests/general/test_dividend_tax_attribution.py
@@ -78,7 +78,7 @@ def _reported(
         autoconvert_currency=autoconvert_currency,
         gbp_prices=gbp_prices,
     )
-    calculator.convert_to_hmrc_transactions(transactions)
+    calculator.prepare_history(transactions)
     calculator.process_dividends()
     rows = []
     for entries in calculator.calculation_log_yields.values():
@@ -110,7 +110,7 @@ def _unattributed_warnings(
     caplog.clear()
     calculator = _calculator(transactions, tax_year)
     with caplog.at_level(logging.WARNING, logger="cgt_calc.income"):
-        calculator.convert_to_hmrc_transactions(transactions)
+        calculator.prepare_history(transactions)
         calculator.process_dividends()
     return [
         record.message
@@ -128,7 +128,7 @@ def _summary_dividend_lines(
     # Discard whatever an earlier run in the same test printed.
     capsys.readouterr()
     calculator = _calculator(transactions, tax_year)
-    calculator.convert_to_hmrc_transactions(transactions)
+    calculator.prepare_history(transactions)
     lines = capsys.readouterr().out.splitlines()
     header = next((i for i, line in enumerate(lines) if "Dividends" in line), None)
     if header is None:
@@ -281,7 +281,7 @@ def test_tax_in_another_currency_than_its_dividend_is_refused(
         interest_fund_tickers=tickers,
         balance_check=False,
     )
-    calculator.convert_to_hmrc_transactions(transactions)
+    calculator.prepare_history(transactions)
 
     with pytest.raises(CalculationError, match="currencies do not match"):
         calculator.process_dividends()

--- a/tests/general/test_warning_scope.py
+++ b/tests/general/test_warning_scope.py
@@ -79,7 +79,7 @@ def test_treaty_mismatch_warning_scoped_to_tax_year(
     calculator = _calculator(transactions)
 
     with caplog.at_level(logging.WARNING, logger="cgt_calc.income"):
-        calculator.convert_to_hmrc_transactions(transactions)
+        calculator.prepare_history(transactions)
         calculator.calculate_capital_gain()
 
     warnings = [
@@ -102,7 +102,7 @@ def test_bed_and_breakfast_in_tax_year_is_logged_at_info(
     calculator = _calculator(transactions)
 
     with caplog.at_level(logging.INFO, logger="cgt_calc.matching"):
-        calculator.convert_to_hmrc_transactions(transactions)
+        calculator.prepare_history(transactions)
         calculator.calculate_capital_gain()
 
     bed_and_breakfast = [
@@ -127,7 +127,7 @@ def test_bed_and_breakfast_outside_tax_year_is_logged_at_debug(
     calculator = _calculator(transactions)
 
     with caplog.at_level(logging.DEBUG, logger="cgt_calc.matching"):
-        calculator.convert_to_hmrc_transactions(transactions)
+        calculator.prepare_history(transactions)
         calculator.calculate_capital_gain()
 
     bed_and_breakfast = [

--- a/tests/schwab/test_schwab_interest_tax.py
+++ b/tests/schwab/test_schwab_interest_tax.py
@@ -38,7 +38,7 @@ def test_schwab_interest_tax_without_symbol_is_account_level() -> None:
         interest_fund_tickers=[],
         balance_check=False,
     )
-    calculator.convert_to_hmrc_transactions(list(transactions))
+    calculator.prepare_history(list(transactions))
     report = calculator.calculate_capital_gain()
 
     assert report.total_foreign_interest == Decimal("2.94")

--- a/tests/schwab/test_schwab_options.py
+++ b/tests/schwab/test_schwab_options.py
@@ -64,7 +64,7 @@ def _report(rows: list[str], *, balance_check: bool = False) -> CapitalGainsRepo
         interest_fund_tickers=[],
         balance_check=balance_check,
     )
-    calculator.convert_to_hmrc_transactions(transactions)
+    calculator.prepare_history(transactions)
     return calculator.calculate_capital_gain()
 
 
@@ -165,7 +165,7 @@ def test_closing_cost_uses_the_close_date_exchange_rate() -> None:
         balance_check=False,
     )
 
-    calculator.convert_to_hmrc_transactions(transactions)
+    calculator.prepare_history(transactions)
     report = calculator.calculate_capital_gain()
 
     assert report.disposal_proceeds == Decimal("15.00")

--- a/tests/trading212/test_trading212.py
+++ b/tests/trading212/test_trading212.py
@@ -1544,7 +1544,7 @@ def test_the_legacy_single_row_stock_split_still_reaches_the_calculator(
     assert split.quantity == Decimal(10)
 
     calculator = create_calculator(tax_year=2025, balance_check=False)
-    calculator.convert_to_hmrc_transactions([buy, split])
+    calculator.prepare_history([buy, split])
     # A reorganisation, so the pool doubles in units and keeps its cost.
     assert calculator.portfolio["FOO"].quantity == Decimal(20)
     assert calculator.portfolio["FOO"].amount == Decimal(100)

--- a/tests/trading212/test_trading212_splits.py
+++ b/tests/trading212/test_trading212_splits.py
@@ -1253,7 +1253,7 @@ def test_reorganisations_hours_apart_are_separate_events(tmp_path: Path) -> None
     ]
     calculator = create_calculator(tax_year=2025, balance_check=False)
     with pytest.raises(CalculationError) as error:
-        calculator.convert_to_hmrc_transactions(transactions)
+        calculator.prepare_history(transactions)
     message = str(error.value)
     assert "different or unknown times" in message
     assert "Add a single RAW STOCK_SPLIT row" not in message


### PR DESCRIPTION
`convert_to_hmrc_transactions` did more than convert to HMRC transactions: it also validates, converts currency, plans share reorganisations, records income, and builds provisional holdings, and its output is `PreparedHistory`. Renamed it to `prepare_history`, and fixed `docs/development/contributing.md`'s code-layout section, which still described `calculator_state.py` as state shared by both passes after it split into `PreparedHistory` and `RunState`.

- Renamed `convert_to_hmrc_transactions` to `prepare_history` on `CapitalGainsCalculator` (`cgt_calc/main.py`) and `TransactionIngester` (`cgt_calc/ingestion.py`), including call sites, `RuntimeError` messages, and docstrings.
- Updated all 35 test call sites and the one test name that used the old method name.
- Rewrote the `calculator_state.py` and `main.py` bullets in `docs/development/contributing.md`'s "Code layout" section for `PreparedHistory` and `RunState` and the two-pass flow behind `calculate()`.
- No delegate under the old name: the package exposes only the CLI, and every caller is in this repo.

No behaviour change: stdout and stderr are byte-identical to `main`, including the "First pass complete" / "Second pass complete" lines, which stay untouched along with `first_pass_report`, `FirstPassTotals`, and the flag names - out of scope here.