### PR TITLE
Update `shtab` to 1.12.1 and drop the argument-group type ignore

### DIFF
--- a/cgt_calc/args_parser.py
+++ b/cgt_calc/args_parser.py
@@ -229,8 +229,7 @@ Environment variables:
         help="show version and exit",
     )
     shtab.add_argument_to(
-        # Argument groups support the same operation as parsers.
-        general_group,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        general_group,
         "--print-completion",
         help="print shell tab completion script and exit",
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "yfinance>=1.7.0",
   "openpyxl>=3.1.5",
   "xlrd>=2.0.2",
-  "shtab>=1.12.0",
+  "shtab>=1.12.1",
   # zoneinfo needs a tz database where the OS does not ship one.
   "tzdata>=2026.3; sys_platform == 'win32' or sys_platform == 'emscripten'",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -214,7 +214,7 @@ requires-dist = [
     { name = "pdfplumber", specifier = ">=0.11.9" },
     { name = "pyrate-limiter", specifier = ">=4.0.0" },
     { name = "requests", specifier = ">=2.27.1" },
-    { name = "shtab", specifier = ">=1.12.0" },
+    { name = "shtab", specifier = ">=1.12.1" },
     { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'", specifier = ">=2026.3" },
     { name = "xlrd", specifier = ">=2.0.2" },
     { name = "yfinance", specifier = ">=1.7.0" },
@@ -1533,11 +1533,11 @@ wheels = [
 
 [[package]]
 name = "shtab"
-version = "1.12.0"
+version = "1.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/3e/68e4adc2af22d3ff0c4967d52aaac825d33c20467bfd20348526f925e868/shtab-1.12.0.tar.gz", hash = "sha256:46d0b07e6820e3eaaaf95e437a6e89f66a6141dd8bd92da15321939ac692d44d", size = 65967, upload-time = "2026-08-24T16:39:25.477Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/71/ddb3c0a7a86db44d2fb3f9cbac162f7ddbcbf563b4a174963ba2b3d4d819/shtab-1.12.1.tar.gz", hash = "sha256:0637338723a8fc08ed1c2fd826d8432229924649c26e3247bb48c53d60ca3bf9", size = 66195, upload-time = "2026-09-01T22:12:47.999Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/eb/f45d7689298eaf2a49488cf3135464cb6b30e179e9637f99429cd61db7a0/shtab-1.12.0-py3-none-any.whl", hash = "sha256:e377c1451b68ce40abe63b378a389002f0befb2113796a80b047a2bfba0cfb68", size = 22669, upload-time = "2026-08-24T16:39:24.222Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/3f/8bf03f51e920585e207157cb49c5bf8e65a9229297c9ec347a6014eb3d61/shtab-1.12.1-py3-none-any.whl", hash = "sha256:31d07db9c958fbe15edd1d0f3c966a7085766374a11ccc5861b810fcd4ada123", size = 22763, upload-time = "2026-09-01T22:12:46.384Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`shtab` 1.12.1 makes `add_argument_to` generic over `_ActionsContainer`, so passing an argument group is now correctly typed.

- Bump `shtab` to `>=1.12.1`.
- Drop the `arg-type` / `invalid-argument-type` ignore on the `general_group` argument to `shtab.add_argument_to`.

The `action.complete` ignore in `args_validators.py` stays: `shtab` still does not declare `complete` on `argparse.Action`.

No behavior change: `--print-completion` output is unchanged.
