### PR TITLE
Pin the LaTeX source of the report

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,9 @@ repos:
       - id: check-toml
       - id: check-yaml
       - id: end-of-file-fixer
+        exclude: ^tests/general/data/(latex/.*|test_run_with_example_files_report)\.tex$
       - id: trailing-whitespace
+        exclude: ^tests/general/data/(latex/.*|test_run_with_example_files_report)\.tex$
   - repo: https://github.com/scop/pre-commit-shfmt
     rev: v3.13.1-1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,9 +8,9 @@ repos:
       - id: check-toml
       - id: check-yaml
       - id: end-of-file-fixer
-        exclude: ^tests/general/data/(latex/.*|test_run_with_example_files_report)\.tex$
+        exclude: ^tests/.*\.tex$
       - id: trailing-whitespace
-        exclude: ^tests/general/data/(latex/.*|test_run_with_example_files_report)\.tex$
+        exclude: ^tests/.*\.tex$
   - repo: https://github.com/scop/pre-commit-shfmt
     rev: v3.13.1-1
     hooks:

--- a/tests/general/data/latex/exempt.tex
+++ b/tests/general/data/latex/exempt.tex
@@ -1,0 +1,145 @@
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage[a4paper, margin=3cm]{geometry}
+\setlength{\parindent}{0pt} %--don't indent paragraphs
+\begin{document}
+\centerline{\Large\bfseries Capital Gains Tax Calculations for 2024-25}
+
+
+\section*{Capital Gains Events}
+
+
+\subsection*{01 May 2024}
+         % if is_aquisition
+                        \subsubsection*{
+            Acquisition 1: 100 units of T26 for £10,000.00
+            (£100.00/unit)%
+                    }
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 100,
+ % if is_aquisition
+    actual cost: £10,000.00.
+
+    Number of units in the pool:
+100%
+,
+    new pool cost: £10,000.00
+    (£100.00/unit)%
+                    .
+
+\end{enumerate}
+
+
+
+\subsection*{01 September 2024}
+         % if is_exempt
+            \subsubsection*{
+        Exempt disposal: 50 units of T26 valued at £6,000.00
+        (£120.00/unit)%
+            }
+    The cost and disposal expenses shown below are used for this illustrative calculation only;
+    they are not allowable deductions against other gains.
+
+    Gain is £1,000.00; the gain or loss is disregarded (exempt asset).
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 50,
+        cost used for this illustrative
+            calculation:
+        £5,000.00,
+            \mbox{disregarded gain: £1,000.00.}
+    
+    Number of units left in the pool:
+50%
+,
+    new pool cost: £5,000.00
+    (£100.00/unit)%
+        .
+
+\end{enumerate}
+
+
+
+\subsection*{02 September 2024}
+         % if is_exempt
+            \subsubsection*{
+        Exempt disposal: 25 units of T26 valued at £2,500.00
+        (£100.00/unit)%
+            }
+    The cost and disposal expenses shown below are used for this illustrative calculation only;
+    they are not allowable deductions against other gains.
+
+            Neither a gain nor a loss; the gain or loss is disregarded (exempt asset).
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 25,
+        cost used for this illustrative
+            calculation:
+        £2,500.00,
+            \mbox{disregarded loss: £0.00.}
+    
+    Number of units left in the pool:
+25%
+,
+    new pool cost: £2,500.00
+    (£100.00/unit)%
+        .
+
+\end{enumerate}
+
+
+
+\subsection*{03 September 2024}
+         % if is_exempt
+            \subsubsection*{
+        Exempt disposal: 25 units of T26 valued at £2,000.00
+        (£80.00/unit)%
+            }
+    The cost and disposal expenses shown below are used for this illustrative calculation only;
+    they are not allowable deductions against other gains.
+
+            Loss is £500.00; the gain or loss is disregarded (exempt asset).
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 25,
+        cost used for this illustrative
+            calculation:
+        £2,500.00,
+            \mbox{disregarded loss: £500.00.}
+    
+    Number of units left in the pool:
+0%
+.
+
+\end{enumerate}
+
+
+
+
+\clearpage
+\section*{Overall - Capital Gains}
+\subsection*{Number of acquisitions: 1}
+\subsection*{Number of disposals: 0}
+\subsection*{Total disposal proceeds: £0.00}
+\subsection*{Total capital gain before loss: £0}
+\subsection*{Total capital loss: £0}
+\subsection*{Number of exempt disposals: 3}
+\subsection*{Total exempt disposal proceeds: £10,500.00}
+\subsection*{Total capital gain after loss: £0}
+\vspace{1em}
+Amounts are rounded to the nearest penny individually, so a line may differ from its components by a penny.
+\vspace{2em}
+\section*{Overall - Dividends and Interests}
+\subsection*{Number of dividend distributions: 0}
+\subsection*{Number of interest transactions: 0}
+\subsection*{Number of interest tax transactions: 0}
+\subsection*{Number of excess reported income distributions: 0}
+\subsection*{Total amount of dividends proceeds: £0.00}
+\subsection*{Total amount of dividends tax allowance due to double taxation treaties: £0.00}
+\subsection*{Total amount of dividends tax yearly allowance: £500.00}
+\subsection*{Total amount of taxable dividends proceeds: £0.00}
+\subsection*{Total amount of UK interests proceeds: £0.00}
+\subsection*{Total amount of foreign interests proceeds: £0.00}
+\subsection*{Total amount of interest tax paid: £0.00}
+\end{document}

--- a/tests/general/data/latex/fee_and_income.tex
+++ b/tests/general/data/latex/fee_and_income.tex
@@ -1,0 +1,101 @@
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage[a4paper, margin=3cm]{geometry}
+\setlength{\parindent}{0pt} %--don't indent paragraphs
+\begin{document}
+\centerline{\Large\bfseries Capital Gains Tax Calculations for 2024-25}
+
+
+\section*{Capital Gains Events}
+
+
+\subsection*{01 June 2024}
+         % if is_aquisition
+                        \subsubsection*{
+            Acquisition 1: 10 units of FOO for £100.00
+            (£10.00/unit)%
+                    }
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 10,
+ % if is_aquisition
+    actual cost: £100.00.
+
+    Number of units in the pool:
+10%
+,
+    new pool cost: £100.00
+    (£10.00/unit)%
+                    .
+
+\end{enumerate}
+
+
+
+\subsection*{03 June 2024}
+         % if is_aquisition
+                \subsubsection*{Management fee for FOO of £5.00}
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 0,
+ % if is_aquisition
+    actual cost: £5.00.
+
+    Number of units in the pool:
+10%
+,
+    new pool cost: £105.00
+    (£10.50/unit)%
+                    .
+
+\end{enumerate}
+
+
+
+    \clearpage
+    \section*{Interest and Dividends Events}
+
+    
+    \subsection*{03 June 2024}
+                                                                \textbf{Dividend 1:} BAR for £100.00
+                    (tax paid at source: £15.00)
+                            , tax treaty amount: £15.00 (treaty rate for USA: 15.00\%)
+            
+    
+    
+    \subsection*{02 July 2024}
+                                         % if is_interest
+                \textbf{Interest UK 1:} Testing for £3.00
+    
+    
+    
+    \subsection*{03 July 2024}
+                                                             % if is_interest_tax
+                \textbf{Interest tax UK 1:} GBP for £2.00
+    
+    
+    
+\clearpage
+\section*{Overall - Capital Gains}
+\subsection*{Number of acquisitions: 1}
+\subsection*{Number of disposals: 0}
+\subsection*{Total disposal proceeds: £0.00}
+\subsection*{Total capital gain before loss: £0}
+\subsection*{Total capital loss: £0}
+\subsection*{Total capital gain after loss: £0}
+\vspace{1em}
+Amounts are rounded to the nearest penny individually, so a line may differ from its components by a penny.
+\vspace{2em}
+\section*{Overall - Dividends and Interests}
+\subsection*{Number of dividend distributions: 1}
+\subsection*{Number of interest transactions: 1}
+\subsection*{Number of interest tax transactions: 1}
+\subsection*{Number of excess reported income distributions: 0}
+\subsection*{Total amount of dividends proceeds: £100.00}
+\subsection*{Total amount of dividends tax allowance due to double taxation treaties: £15.00}
+\subsection*{Total amount of dividends tax yearly allowance: £500.00}
+\subsection*{Total amount of taxable dividends proceeds: £0.00}
+\subsection*{Total amount of UK interests proceeds: £3.00}
+\subsection*{Total amount of foreign interests proceeds: £0.00}
+\subsection*{Total amount of interest tax paid: £2.00}
+\end{document}

--- a/tests/general/data/latex/gifts.tex
+++ b/tests/general/data/latex/gifts.tex
@@ -1,0 +1,171 @@
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage[a4paper, margin=3cm]{geometry}
+\setlength{\parindent}{0pt} %--don't indent paragraphs
+\begin{document}
+\centerline{\Large\bfseries Capital Gains Tax Calculations for 2024-25}
+
+
+\section*{Capital Gains Events}
+
+
+\subsection*{01 June 2024}
+         % if is_aquisition
+                        \subsubsection*{
+            Acquisition 1: 10 units of FOO for £100.00
+            (£10.00/unit)%
+                    }
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 10,
+ % if is_aquisition
+    actual cost: £100.00.
+
+    Number of units in the pool:
+10%
+,
+    new pool cost: £100.00
+    (£10.00/unit)%
+                    .
+
+\end{enumerate}
+
+
+
+\subsection*{10 June 2024}
+                                        \subsubsection*{
+            Disposal 1: 2 units of FOO
+            given away at a market value of £60.00
+            (£30.00/unit)%
+                    }
+        Chargeable \textbf{gain} is £40.00, before any relief:
+        a gift of shares that qualify for Gift Hold-over Relief has the gain deferred by a joint claim on your returns
+                Capital gain to date is £40.00
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 2,
+        allowable
+            cost:
+        £20.00,
+            \mbox{gain: £40.00.}
+    
+    Number of units left in the pool:
+8%
+,
+    new pool cost: £80.00
+    (£10.00/unit)%
+        .
+
+\end{enumerate}
+
+
+
+\subsection*{11 June 2024}
+                                        \subsubsection*{
+            Disposal 2: 2 units of FOO
+            given away at a market value of £10.00
+            (£5.00/unit)%
+                    }
+                \textbf{Clogged loss} of £10.00 on a gift, kept out of the loss total:
+        a loss on a gift to a connected person can only be set against gains on disposals to the same person while still connected (TCGA 1992 s18(3)).
+
+                Losses on gifts to date are £10.00
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 2,
+        allowable
+            cost:
+        £20.00,
+            \mbox{loss: £10.00.}
+    
+    Number of units left in the pool:
+6%
+,
+    new pool cost: £60.00
+    (£10.00/unit)%
+        .
+
+\end{enumerate}
+
+
+
+\subsection*{12 June 2024}
+                                    \subsubsection*{
+            Disposal 3: 2 units of FOO
+            given away at a market value of £10.00
+            (£5.00/unit)%
+                    }
+                Chargeable \textbf{loss} is £10.00
+
+                Capital loss to date is £10.00
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 2,
+        allowable
+            cost:
+        £20.00,
+            \mbox{loss: £10.00.}
+    
+    Number of units left in the pool:
+4%
+,
+    new pool cost: £40.00
+    (£10.00/unit)%
+        .
+
+\end{enumerate}
+
+
+
+\subsection*{13 June 2024}
+                                        \subsubsection*{
+            Disposal 4: 2 units of FOO
+            given away at a market value of £20.00
+            (£10.00/unit)%
+                    }
+                Neither a gain nor a loss.
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 2,
+        allowable
+            cost:
+        £20.00,
+            \mbox{loss: £0.00.}
+    
+    Number of units left in the pool:
+2%
+,
+    new pool cost: £20.00
+    (£10.00/unit)%
+        .
+
+\end{enumerate}
+
+
+
+
+\clearpage
+\section*{Overall - Capital Gains}
+\subsection*{Number of acquisitions: 1}
+\subsection*{Number of disposals: 4}
+\subsection*{Total disposal proceeds: £100.00}
+\subsection*{Total capital gain before loss: £40.00}
+\subsection*{Total capital loss: £10.00}
+\subsection*{Losses on gifts, kept separate: £10.00}
+\subsection*{Total capital gain after loss: £30.00}
+\vspace{1em}
+Amounts are rounded to the nearest penny individually, so a line may differ from its components by a penny.
+\vspace{2em}
+\section*{Overall - Dividends and Interests}
+\subsection*{Number of dividend distributions: 0}
+\subsection*{Number of interest transactions: 0}
+\subsection*{Number of interest tax transactions: 0}
+\subsection*{Number of excess reported income distributions: 0}
+\subsection*{Total amount of dividends proceeds: £0.00}
+\subsection*{Total amount of dividends tax allowance due to double taxation treaties: £0.00}
+\subsection*{Total amount of dividends tax yearly allowance: £500.00}
+\subsection*{Total amount of taxable dividends proceeds: £0.00}
+\subsection*{Total amount of UK interests proceeds: £0.00}
+\subsection*{Total amount of foreign interests proceeds: £0.00}
+\subsection*{Total amount of interest tax paid: £0.00}
+\end{document}

--- a/tests/general/data/latex/option_grant.tex
+++ b/tests/general/data/latex/option_grant.tex
@@ -1,0 +1,58 @@
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage[a4paper, margin=3cm]{geometry}
+\setlength{\parindent}{0pt} %--don't indent paragraphs
+\begin{document}
+\centerline{\Large\bfseries Capital Gains Tax Calculations for 2024-25}
+
+
+\section*{Capital Gains Events}
+
+
+\subsection*{01 May 2024}
+                                    \subsubsection*{
+            Disposal 1: grant of 2
+            contracts of the META call option expiring 2024-05-17 at a strike of 500
+            for £200.00
+        }
+        Chargeable \textbf{gain} is £198.70
+                Capital gain to date is £198.70
+    
+\begin{enumerate}
+\item \textbf{OPTION}. Quantity: 2,
+        allowable
+            cost:
+        £1.30,
+            \mbox{gain: £198.70.}
+    
+    The option grant does not change the Section 104 holding of the underlying shares.
+
+\end{enumerate}
+
+
+
+
+\clearpage
+\section*{Overall - Capital Gains}
+\subsection*{Number of acquisitions: 0}
+\subsection*{Number of disposals: 1}
+\subsection*{Total disposal proceeds: £200.00}
+\subsection*{Total capital gain before loss: £198.70}
+\subsection*{Total capital loss: £0}
+\subsection*{Total capital gain after loss: £198.70}
+\vspace{1em}
+Amounts are rounded to the nearest penny individually, so a line may differ from its components by a penny.
+\vspace{2em}
+\section*{Overall - Dividends and Interests}
+\subsection*{Number of dividend distributions: 0}
+\subsection*{Number of interest transactions: 0}
+\subsection*{Number of interest tax transactions: 0}
+\subsection*{Number of excess reported income distributions: 0}
+\subsection*{Total amount of dividends proceeds: £0.00}
+\subsection*{Total amount of dividends tax allowance due to double taxation treaties: £0.00}
+\subsection*{Total amount of dividends tax yearly allowance: £500.00}
+\subsection*{Total amount of taxable dividends proceeds: £0.00}
+\subsection*{Total amount of UK interests proceeds: £0.00}
+\subsection*{Total amount of foreign interests proceeds: £0.00}
+\subsection*{Total amount of interest tax paid: £0.00}
+\end{document}

--- a/tests/general/data/latex/rename.tex
+++ b/tests/general/data/latex/rename.tex
@@ -1,0 +1,113 @@
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage[a4paper, margin=3cm]{geometry}
+\setlength{\parindent}{0pt} %--don't indent paragraphs
+\begin{document}
+\centerline{\Large\bfseries Capital Gains Tax Calculations for 2024-25}
+
+
+\section*{Capital Gains Events}
+
+
+\subsection*{01 May 2024}
+         % if is_aquisition
+                        \subsubsection*{
+            Acquisition 1: 100 units of OLD for £1,000.00
+            (£10.00/unit)%
+                    }
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 100,
+ % if is_aquisition
+    actual cost: £1,000.00.
+
+    Number of units in the pool:
+100%
+,
+    new pool cost: £1,000.00
+    (£10.00/unit)%
+                    .
+
+\end{enumerate}
+
+
+
+\subsection*{10 May 2024}
+                                \subsubsection*{
+            Disposal 1: 100 units of OLD
+            for £800.00
+            (£8.00/unit)%
+                    }
+                Chargeable \textbf{loss} is £100.00
+
+                Capital loss to date is £100.00
+    
+\begin{enumerate}
+\item \textbf{BED AND BREAKFAST}. Quantity: 100,
+        allowable
+            cost on \mbox{20 May 2024:}
+        £900.00,
+            \mbox{loss: £100.00.}
+    
+    Number of units left in the pool:
+0%
+.
+
+\end{enumerate}
+
+         % if is_rename
+    \subsubsection*{
+        OLD was renamed to NEW%
+            }
+
+
+
+
+\subsection*{20 May 2024}
+         % if is_aquisition
+                        \subsubsection*{
+            Acquisition 2: 100 units of NEW for £900.00
+            (£9.00/unit)%
+                    }
+    
+\begin{enumerate}
+\item \textbf{BED AND BREAKFAST}. Quantity: 100,
+ % if is_aquisition
+    actual cost: £1,000.00.
+
+    Number of units in the pool:
+100%
+,
+    new pool cost: £1,000.00
+    (£10.00/unit)%
+                    .
+
+\end{enumerate}
+
+
+
+
+\clearpage
+\section*{Overall - Capital Gains}
+\subsection*{Number of acquisitions: 2}
+\subsection*{Number of disposals: 1}
+\subsection*{Total disposal proceeds: £800.00}
+\subsection*{Total capital gain before loss: £0}
+\subsection*{Total capital loss: £100.00}
+\subsection*{Total capital gain after loss: £-100.00}
+\vspace{1em}
+Amounts are rounded to the nearest penny individually, so a line may differ from its components by a penny.
+\vspace{2em}
+\section*{Overall - Dividends and Interests}
+\subsection*{Number of dividend distributions: 0}
+\subsection*{Number of interest transactions: 0}
+\subsection*{Number of interest tax transactions: 0}
+\subsection*{Number of excess reported income distributions: 0}
+\subsection*{Total amount of dividends proceeds: £0.00}
+\subsection*{Total amount of dividends tax allowance due to double taxation treaties: £0.00}
+\subsection*{Total amount of dividends tax yearly allowance: £500.00}
+\subsection*{Total amount of taxable dividends proceeds: £0.00}
+\subsection*{Total amount of UK interests proceeds: £0.00}
+\subsection*{Total amount of foreign interests proceeds: £0.00}
+\subsection*{Total amount of interest tax paid: £0.00}
+\end{document}

--- a/tests/general/data/latex/spin_off.tex
+++ b/tests/general/data/latex/spin_off.tex
@@ -1,0 +1,102 @@
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage[a4paper, margin=3cm]{geometry}
+\setlength{\parindent}{0pt} %--don't indent paragraphs
+\begin{document}
+\centerline{\Large\bfseries Capital Gains Tax Calculations for 2024-25}
+
+
+\section*{Capital Gains Events}
+
+
+\subsection*{01 June 2024}
+         % if is_aquisition
+                        \subsubsection*{
+            Acquisition 1: 10 units of FOO for £100.00
+            (£10.00/unit)%
+                    }
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 10,
+ % if is_aquisition
+    actual cost: £100.00.
+
+    Number of units in the pool:
+10%
+,
+    new pool cost: £100.00
+    (£10.00/unit)%
+                    .
+
+\end{enumerate}
+
+
+
+\subsection*{05 July 2024}
+         % if is_aquisition
+                        \subsubsection*{
+            Acquisition 2: 10 units of BAR for £10.00
+            (£1.00/unit)%
+                    }
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 10,
+ % if is_aquisition
+    actual cost: £10.00.
+
+    Number of units in the pool:
+10%
+,
+    new pool cost: £10.00
+    (£1.00/unit)%
+    
+    Cost basis calculated based on cost of FOO share pool from which BAR shares were spinned off%
+                    .
+
+\end{enumerate}
+
+         % if is_spin_off
+                        \subsubsection*{
+            Spin-off adjustment 3: FOO cost adjusted because of BAR shares spinned off
+        }
+    
+\begin{enumerate}
+\item \textbf{SPIN OFF}. Quantity: 10,
+    original cost of FOO: £100.00, after spin-off: £90.00
+
+    Number of units in the pool:
+10%
+,
+    new pool cost: £90.00
+    (£9.00/unit)%
+        .
+
+\end{enumerate}
+
+
+
+
+\clearpage
+\section*{Overall - Capital Gains}
+\subsection*{Number of acquisitions: 3}
+\subsection*{Number of disposals: 0}
+\subsection*{Total disposal proceeds: £0.00}
+\subsection*{Total capital gain before loss: £0}
+\subsection*{Total capital loss: £0}
+\subsection*{Total capital gain after loss: £0}
+\vspace{1em}
+Amounts are rounded to the nearest penny individually, so a line may differ from its components by a penny.
+\vspace{2em}
+\section*{Overall - Dividends and Interests}
+\subsection*{Number of dividend distributions: 0}
+\subsection*{Number of interest transactions: 0}
+\subsection*{Number of interest tax transactions: 0}
+\subsection*{Number of excess reported income distributions: 0}
+\subsection*{Total amount of dividends proceeds: £0.00}
+\subsection*{Total amount of dividends tax allowance due to double taxation treaties: £0.00}
+\subsection*{Total amount of dividends tax yearly allowance: £500.00}
+\subsection*{Total amount of taxable dividends proceeds: £0.00}
+\subsection*{Total amount of UK interests proceeds: £0.00}
+\subsection*{Total amount of foreign interests proceeds: £0.00}
+\subsection*{Total amount of interest tax paid: £0.00}
+\end{document}

--- a/tests/general/data/latex/split.tex
+++ b/tests/general/data/latex/split.tex
@@ -1,0 +1,99 @@
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage[a4paper, margin=3cm]{geometry}
+\setlength{\parindent}{0pt} %--don't indent paragraphs
+\begin{document}
+\centerline{\Large\bfseries Capital Gains Tax Calculations for 2023-24}
+
+
+\section*{Capital Gains Events}
+
+
+\subsection*{02 May 2023}
+         % if is_aquisition
+                        \subsubsection*{
+            Acquisition 1: 0.9 units of FOO for £90.00
+            (£100.00/unit)%
+                    }
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 0.9,
+ % if is_aquisition
+    actual cost: £90.00.
+
+    Number of units in the pool:
+0.9%
+,
+    new pool cost: £90.00
+    (£100.00/unit)%
+                    .
+
+\end{enumerate}
+
+
+
+\subsection*{15 May 2023}
+         % if is_aquisition
+                        \subsubsection*{
+            Acquisition 2: 0.0111111111 units of FOO for £10.00
+            (£900.00/unit)%
+                    }
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 0.0111111111,
+ % if is_aquisition
+    actual cost: £10.00.
+
+    Number of units in the pool:
+0.1111111111%
+,
+    new pool cost: £100.00
+    (£900.00/unit)%
+                    .
+
+\end{enumerate}
+
+         % if is_split
+        \subsubsection*{
+        Share reorganisation: 0.9 units of FOO restated as 0.1 (ratio 1/9)
+    }
+    Neither a disposal nor an acquisition: the new holding is the same asset, held from the same dates, with the same pooled cost (TCGA 1992 s127).
+
+    Stated as 1 units before the event and 0.11111111 after.
+    
+        Reconciled to that count by -0.0000000011 units, from 0.1111111111 to 0.11111111.
+    
+    Units in the pool at this point in the day: 0.11111111%
+    ,
+        pool cost: £100.00
+        (£900.00/unit)%
+    .
+
+
+
+
+
+\clearpage
+\section*{Overall - Capital Gains}
+\subsection*{Number of acquisitions: 2}
+\subsection*{Number of disposals: 0}
+\subsection*{Total disposal proceeds: £0.00}
+\subsection*{Total capital gain before loss: £0}
+\subsection*{Total capital loss: £0}
+\subsection*{Total capital gain after loss: £0}
+\vspace{1em}
+Amounts are rounded to the nearest penny individually, so a line may differ from its components by a penny.
+\vspace{2em}
+\section*{Overall - Dividends and Interests}
+\subsection*{Number of dividend distributions: 0}
+\subsection*{Number of interest transactions: 0}
+\subsection*{Number of interest tax transactions: 0}
+\subsection*{Number of excess reported income distributions: 0}
+\subsection*{Total amount of dividends proceeds: £0.00}
+\subsection*{Total amount of dividends tax allowance due to double taxation treaties: £0.00}
+\subsection*{Total amount of dividends tax yearly allowance: £1,000.00}
+\subsection*{Total amount of taxable dividends proceeds: £0.00}
+\subsection*{Total amount of UK interests proceeds: £0.00}
+\subsection*{Total amount of foreign interests proceeds: £0.00}
+\subsection*{Total amount of interest tax paid: £0.00}
+\end{document}

--- a/tests/general/data/latex/spouse_transfer.tex
+++ b/tests/general/data/latex/spouse_transfer.tex
@@ -1,0 +1,75 @@
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage[a4paper, margin=3cm]{geometry}
+\setlength{\parindent}{0pt} %--don't indent paragraphs
+\begin{document}
+\centerline{\Large\bfseries Capital Gains Tax Calculations for 2024-25}
+
+
+\section*{Capital Gains Events}
+
+
+\subsection*{01 June 2024}
+         % if is_aquisition
+                        \subsubsection*{
+            Acquisition 1: 10 units of FOO for £100.00
+            (£10.00/unit)%
+                    }
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 10,
+ % if is_aquisition
+    actual cost: £100.00.
+
+    Number of units in the pool:
+10%
+,
+    new pool cost: £100.00
+    (£10.00/unit)%
+                    .
+
+\end{enumerate}
+
+
+
+\subsection*{10 June 2024}
+         % if is_transfer_to_spouse
+    \subsubsection*{
+        Transferred to spouse: 4 units of FOO (no gain/no loss)
+    }
+    Base cost of £40.00 passes to the recipient.
+
+        Number of units left in the pool: 6%
+    ,
+        new pool cost: £60.00
+        (£10.00/unit)%
+    .
+
+
+
+
+
+\clearpage
+\section*{Overall - Capital Gains}
+\subsection*{Number of acquisitions: 1}
+\subsection*{Number of disposals: 0}
+\subsection*{Total disposal proceeds: £0.00}
+\subsection*{Total capital gain before loss: £0}
+\subsection*{Total capital loss: £0}
+\subsection*{Total capital gain after loss: £0}
+\vspace{1em}
+Amounts are rounded to the nearest penny individually, so a line may differ from its components by a penny.
+\vspace{2em}
+\section*{Overall - Dividends and Interests}
+\subsection*{Number of dividend distributions: 0}
+\subsection*{Number of interest transactions: 0}
+\subsection*{Number of interest tax transactions: 0}
+\subsection*{Number of excess reported income distributions: 0}
+\subsection*{Total amount of dividends proceeds: £0.00}
+\subsection*{Total amount of dividends tax allowance due to double taxation treaties: £0.00}
+\subsection*{Total amount of dividends tax yearly allowance: £500.00}
+\subsection*{Total amount of taxable dividends proceeds: £0.00}
+\subsection*{Total amount of UK interests proceeds: £0.00}
+\subsection*{Total amount of foreign interests proceeds: £0.00}
+\subsection*{Total amount of interest tax paid: £0.00}
+\end{document}

--- a/tests/general/data/test_run_with_example_files_report.tex
+++ b/tests/general/data/test_run_with_example_files_report.tex
@@ -1,0 +1,425 @@
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage[a4paper, margin=3cm]{geometry}
+\setlength{\parindent}{0pt} %--don't indent paragraphs
+\begin{document}
+\centerline{\Large\bfseries Capital Gains Tax Calculations for 2020-21}
+
+
+\section*{Capital Gains Events}
+
+
+\subsection*{02 June 2020}
+         % if is_aquisition
+                        \subsubsection*{
+            Acquisition 1: 100 units of VUAG for £2,042.38
+            (£20.42/unit)%
+                            , including £4.89 fees
+                    }
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 100,
+ % if is_aquisition
+    actual cost: £2,042.38.
+
+    Number of units in the pool:
+100%
+,
+    new pool cost: £2,042.38
+    (£20.42/unit)%
+                    .
+
+\end{enumerate}
+
+
+
+\subsection*{03 June 2020}
+         % if is_aquisition
+                        \subsubsection*{
+            Acquisition 2: 154 units of VUAG for £3,569.68
+            (£23.18/unit)%
+                            , including £8.15 fees
+                    }
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 154,
+ % if is_aquisition
+    actual cost: £3,569.68.
+
+    Number of units in the pool:
+254%
+,
+    new pool cost: £5,612.06
+    (£22.09/unit)%
+                    .
+
+\end{enumerate}
+
+                                \subsubsection*{
+            Disposal 1: 254 units of VUAG
+            for £5,887.53
+            (£23.18/unit)%
+                            , £12.22 fees allowed as cost
+                    }
+        Chargeable \textbf{gain} is £148.45
+                Capital gain to date is £148.45
+    
+\begin{enumerate}
+\item \textbf{SAME DAY}. Quantity: 154,
+            disposal proceeds: £3,569.61,
+        allowable
+            cost:
+        £3,577.09,
+            \mbox{loss: £7.49.}
+    
+    Number of units left in the pool:
+100%
+,
+    new pool cost: £2,042.38
+    (£20.42/unit)%
+        .
+
+\item \textbf{BED AND BREAKFAST}. Quantity: 30.5,
+            disposal proceeds: £706.97,
+        allowable
+            cost on \mbox{02 Jul 2020:}
+        £739.19,
+            \mbox{loss: £32.22.}
+    
+    Number of units left in the pool:
+69.5%
+,
+    new pool cost: £1,419.45
+    (£20.42/unit)%
+        .
+
+\item \textbf{SECTION 104}. Quantity: 69.5,
+            disposal proceeds: £1,610.96,
+        allowable
+            cost:
+        £1,422.80,
+            \mbox{gain: £188.16.}
+    
+    Number of units left in the pool:
+0%
+.
+
+\end{enumerate}
+
+
+
+\subsection*{06 June 2020}
+         % if is_aquisition
+                        \subsubsection*{
+            Acquisition 3: 90 units of VUAG for £2,351.26
+            (£26.13/unit)%
+                            , including £4.07 fees
+                    }
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 90,
+ % if is_aquisition
+    actual cost: £2,351.26.
+
+    Number of units in the pool:
+90%
+,
+    new pool cost: £2,351.26
+    (£26.13/unit)%
+                    .
+
+\end{enumerate}
+
+                                \subsubsection*{
+            Disposal 2: 90 units of VUAG
+            for £2,420.54
+            (£26.89/unit)%
+                            , £4.07 fees allowed as cost
+                    }
+        Chargeable \textbf{gain} is £65.20
+                Capital gain to date is £213.65
+    
+\begin{enumerate}
+\item \textbf{SAME DAY}. Quantity: 90,
+        allowable
+            cost:
+        £2,355.34,
+            \mbox{gain: £65.20.}
+    
+    Number of units left in the pool:
+0%
+.
+
+\end{enumerate}
+
+
+
+\subsection*{24 June 2020}
+         % if is_aquisition
+                        \subsubsection*{
+            Acquisition 4: 1 units of VNRG for £8.07
+            (£8.07/unit)%
+                    }
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 1,
+ % if is_aquisition
+    actual cost: £8.07.
+
+    Number of units in the pool:
+1%
+,
+    new pool cost: £8.07
+    (£8.07/unit)%
+                    .
+
+\end{enumerate}
+
+
+
+\subsection*{30 June 2020}
+         % if is_eri
+                \subsubsection*{
+            Excess Reported Income: VNRG cost increased by £0.91
+            (£0.9061/unit)%
+        }
+    
+\begin{enumerate}
+\item \textbf{EXCESS REPORTED INCOME}. Quantity: 1,
+    original cost of VNRG: £8.07, after income distribution: £8.98%
+
+    Number of units in the pool:
+1%
+,
+    new pool cost: £8.98
+    (£8.98/unit)%
+        .
+
+\end{enumerate}
+
+
+
+\subsection*{02 July 2020}
+         % if is_aquisition
+                        \subsubsection*{
+            Acquisition 5: 30.5 units of VUAG for £737.72
+            (£24.19/unit)%
+                            , including £3.19 fees
+                    }
+    
+\begin{enumerate}
+\item \textbf{BED AND BREAKFAST}. Quantity: 30.5,
+ % if is_aquisition
+    actual cost: £645.19.
+
+    Number of units in the pool:
+30.5%
+,
+    new pool cost: £645.19
+    (£21.15/unit)%
+                                        
+    Cost basis increased by £22.26
+    (£0.7300/unit)%
+    , due to exccess reported income on \mbox{30 Jun 2020}%
+            .
+
+\end{enumerate}
+
+
+
+\subsection*{25 November 2020}
+         % if is_aquisition
+                        \subsubsection*{
+            Acquisition 6: 100 units of GME for £1,106.25
+            (£11.06/unit)%
+                    }
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 100,
+ % if is_aquisition
+    actual cost: £1,106.25.
+
+    Number of units in the pool:
+100%
+,
+    new pool cost: £1,106.25
+    (£11.06/unit)%
+                    .
+
+\end{enumerate}
+
+
+
+\subsection*{27 November 2020}
+         % if is_aquisition
+                        \subsubsection*{
+            Acquisition 7: 1 units of NVDA for £401.01
+            (£401.01/unit)%
+                    }
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 1,
+ % if is_aquisition
+    actual cost: £401.01.
+
+    Number of units in the pool:
+1%
+,
+    new pool cost: £401.01
+    (£401.01/unit)%
+                    .
+
+\end{enumerate}
+
+
+
+\subsection*{26 January 2021}
+         % if is_aquisition
+                        \subsubsection*{
+            Acquisition 8: 100 units of GME for £6,554.80
+            (£65.55/unit)%
+                    }
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 100,
+ % if is_aquisition
+    actual cost: £6,554.80.
+
+    Number of units in the pool:
+200%
+,
+    new pool cost: £7,661.05
+    (£38.31/unit)%
+                    .
+
+\end{enumerate}
+
+
+
+\subsection*{01 February 2021}
+                                \subsubsection*{
+            Disposal 3: 200 units of GME
+            for £32,453.25
+            (£162.27/unit)%
+                    }
+        Chargeable \textbf{gain} is £24,792.20
+                Capital gain to date is £25,005.85
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 200,
+        allowable
+            cost:
+        £7,661.05,
+            \mbox{gain: £24,792.20.}
+    
+    Number of units left in the pool:
+0%
+.
+
+\end{enumerate}
+
+
+
+\subsection*{25 March 2021}
+         % if is_aquisition
+                        \subsubsection*{
+            Acquisition 9: 212 units of GOOG for £15,427.37
+            (£72.77/unit)%
+                    }
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 212,
+ % if is_aquisition
+    actual cost: £15,427.37.
+
+    Number of units in the pool:
+212%
+,
+    new pool cost: £15,427.37
+    (£72.77/unit)%
+                    .
+
+\end{enumerate}
+
+
+
+\subsection*{01 April 2021}
+                                \subsubsection*{
+            Disposal 4: 40 units of GOOG
+            for £3,075.58
+            (£76.89/unit)%
+                            , £0.04 fees allowed as cost
+                    }
+        Chargeable \textbf{gain} is £164.72
+                Capital gain to date is £25,170.57
+    
+\begin{enumerate}
+\item \textbf{SECTION 104}. Quantity: 40,
+        allowable
+            cost:
+        £2,910.86,
+            \mbox{gain: £164.72.}
+    
+    Number of units left in the pool:
+172%
+,
+    new pool cost: £12,516.55
+    (£72.77/unit)%
+        .
+
+\end{enumerate}
+
+
+
+    \clearpage
+    \section*{Interest and Dividends Events}
+
+    
+    \subsection*{30 December 2020}
+                                 % if is_eri_tax
+                                                    \textbf{Excess Reported Income Distribution 1}: VUAG (dividend) for £22.26
+        (£0.7300/unit)%
+    
+                                 % if is_eri_tax
+                                                    \textbf{Excess Reported Income Distribution 2}: VNRG (dividend) for £0.91
+        (£0.9061/unit)%
+    
+    
+    
+    \subsection*{03 February 2021}
+                                         % if is_interest
+                \textbf{Interest Foreign 1:} USD for £1.03
+    
+    
+    
+    \subsection*{02 April 2021}
+                                                                \textbf{Dividend 1:} NVDA for £0.10
+                    (tax paid at source: £0.00)
+                    
+    
+    
+\clearpage
+\section*{Overall - Capital Gains}
+\subsection*{Number of acquisitions: 9}
+\subsection*{Number of disposals: 4}
+\subsection*{Total disposal proceeds: £43,836.90}
+\subsection*{Total capital gain before loss: £25,170.57}
+\subsection*{Total capital loss: £0}
+\subsection*{Total capital gain after loss: £25,170.57}
+\vspace{1em}
+Amounts are rounded to the nearest penny individually, so a line may differ from its components by a penny.
+\vspace{2em}
+\section*{Overall - Dividends and Interests}
+\subsection*{Number of dividend distributions: 1}
+\subsection*{Number of interest transactions: 1}
+\subsection*{Number of interest tax transactions: 0}
+\subsection*{Number of excess reported income distributions: 2}
+\subsection*{Total amount of dividends proceeds: £23.27}
+\subsubsection*{   (including £23.17 from excess reported income distributions)}
+\subsection*{Total amount of dividends tax allowance due to double taxation treaties: £0.00}
+\subsection*{Total amount of dividends tax yearly allowance: £2,000.00}
+\subsection*{Total amount of taxable dividends proceeds: £0.00}
+\subsection*{Total amount of UK interests proceeds: £0.00}
+\subsection*{Total amount of foreign interests proceeds: £1.03}
+\subsection*{Total amount of interest tax paid: £0.00}
+\end{document}

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -1854,6 +1854,25 @@ def test_run_with_example_files(request: pytest.FixtureRequest) -> None:
         f"{cmd_str} > {expected_file}"
     )
 
+    # The LaTeX source is pinned too. pdflatex leaves no source behind, so
+    # the one CI job that runs it compiles the PDF instead of checking this.
+    if "--no-pdflatex" in cmd:
+        output = Path(report_path(request))
+        tex_path = output.parent / f"{output.stem}.tex"
+        expected_tex_file = (
+            Path("tests")
+            / "general"
+            / "data"
+            / "test_run_with_example_files_report.tex"
+        )
+        assert tex_path.read_text(encoding="utf-8") == expected_tex_file.read_text(
+            encoding="utf-8"
+        ), (
+            "Run with example files generated an unexpected LaTeX report, "
+            "if the change is intended update the golden with:\n"
+            f"{cmd_str} && cp {tex_path} {expected_tex_file}"
+        )
+
 
 def test_main_returns_failure_on_unexpected_error(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/general/test_render_latex_golden.py
+++ b/tests/general/test_render_latex_golden.py
@@ -1,0 +1,287 @@
+"""The LaTeX source of the report is pinned byte for byte.
+
+`test_run_with_example_files` pins the source of the example run. Every
+branch of `template.tex.j2` that run does not reach is rendered here from a
+small scenario and compared with a golden file under `data/latex/`. Together
+they are the standard for template refactors: a change to the source that is
+not a deliberate wording change must leave every golden untouched.
+
+Regenerate the goldens on purpose, after checking the diff is the one
+intended:
+
+    uv run python -m tests.general.test_render_latex_golden
+"""
+
+from __future__ import annotations
+
+import datetime
+from fractions import Fraction
+from pathlib import Path
+import tempfile
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cgt_calc.model import ActionType, Isin
+from cgt_calc.render_latex import render_pdf
+from tests.schwab.test_schwab_options import _report as schwab_report
+
+from .calc_test_data import GBP, transaction
+from .test_calc import (
+    RENAME_DAY,
+    _gbp_trade,
+    _rename_transaction,
+    create_calculator,
+    get_report,
+)
+from .test_spin_off_basis import BUY_DAY, FLAT, SPIN_OFF_DAY, spin_off
+from .test_stock_splits import EVENT_DAY, POOL_DAY, paired_split, trade
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from cgt_calc.model import CapitalGainsReport
+
+GOLDEN_DIR = Path(__file__).parent / "data" / "latex"
+REGENERATE = "uv run python -m tests.general.test_render_latex_golden"
+
+JUNE_1 = datetime.date(2024, 6, 1)
+JUNE_3 = datetime.date(2024, 6, 3)
+JUNE_10 = datetime.date(2024, 6, 10)
+JUNE_11 = datetime.date(2024, 6, 11)
+JUNE_12 = datetime.date(2024, 6, 12)
+JUNE_13 = datetime.date(2024, 6, 13)
+JULY_2 = datetime.date(2024, 7, 2)
+JULY_3 = datetime.date(2024, 7, 3)
+US_ISIN = Isin("US9220427424")
+
+
+def _gifts() -> CapitalGainsReport:
+    """Give shares away at a gain, at a clogged loss, at a loss to anyone else, and at cost."""
+    return get_report(
+        create_calculator(tax_year=2024, balance_check=False),
+        [
+            transaction(JUNE_1, ActionType.BUY, "FOO", 10, 10, 0, -100, GBP),
+            transaction(JUNE_10, ActionType.GIFT, "FOO", 2, 30, 0, None, GBP),
+            transaction(JUNE_11, ActionType.GIFT, "FOO", 2, 5, 0, None, GBP),
+            transaction(
+                JUNE_12, ActionType.GIFT_UNCONNECTED, "FOO", 2, 5, 0, None, GBP
+            ),
+            transaction(JUNE_13, ActionType.GIFT, "FOO", 2, 10, 0, None, GBP),
+        ],
+    )
+
+
+def _exempt() -> CapitalGainsReport:
+    """Dispose of a CGT-exempt instrument at a gain, at cost, and at a loss."""
+    return get_report(
+        create_calculator(
+            tax_year=2024, balance_check=False, cgt_exempt_tickers=["T26"]
+        ),
+        [
+            transaction(
+                datetime.date(2024, 5, 1),
+                ActionType.BUY,
+                "T26",
+                100,
+                100,
+                0,
+                -10000,
+                GBP,
+            ),
+            transaction(
+                datetime.date(2024, 9, 1), ActionType.SELL, "T26", 50, 120, 0, 6000, GBP
+            ),
+            transaction(
+                datetime.date(2024, 9, 2), ActionType.SELL, "T26", 25, 100, 0, 2500, GBP
+            ),
+            transaction(
+                datetime.date(2024, 9, 3), ActionType.SELL, "T26", 25, 80, 0, 2000, GBP
+            ),
+        ],
+    )
+
+
+def _option_grant() -> CapitalGainsReport:
+    """Write two option contracts that expire, as Schwab exports them."""
+    return schwab_report(
+        [
+            "05/17/2024,Expired,META 05/17/2024 500.00 C,Expiration,,2,,",
+            "05/01/2024,Sell to Open,META 05/17/2024 500.00 C,Open,$1.00,2,$1.30,$198.70",
+        ]
+    )
+
+
+def _split() -> CapitalGainsReport:
+    """Restate a holding through a reorganisation the export gave as two share counts."""
+    return get_report(
+        create_calculator(tax_year=2023, balance_check=False),
+        [
+            trade(POOL_DAY, ActionType.BUY, "FOO", "0.9", "100"),
+            trade(EVENT_DAY, ActionType.BUY, "FOO", "0.1", "100"),
+            paired_split(
+                EVENT_DAY, "FOO", "1.0000000000", "0.1111111100", Fraction(1, 9)
+            ),
+        ],
+    )
+
+
+def _rename() -> CapitalGainsReport:
+    """Rename a holding on the day it is sold, matched to a purchase under the new name."""
+    return get_report(
+        create_calculator(tax_year=2024, balance_check=False),
+        [
+            _gbp_trade(datetime.date(2024, 5, 1), ActionType.BUY, "OLD", 100, 1000),
+            _gbp_trade(RENAME_DAY, ActionType.SELL, "OLD", 100, 800),
+            _rename_transaction(RENAME_DAY, "OLD", "NEW"),
+            _gbp_trade(datetime.date(2024, 5, 20), ActionType.BUY, "NEW", 100, 900),
+        ],
+    )
+
+
+def _spouse_transfer() -> CapitalGainsReport:
+    """Pass part of a holding to a spouse at no gain and no loss."""
+    return get_report(
+        create_calculator(tax_year=2024, balance_check=False),
+        [
+            transaction(JUNE_1, ActionType.BUY, "FOO", 10, 10, 0, -100, GBP),
+            transaction(
+                JUNE_10, ActionType.TRANSFER_TO_SPOUSE, "FOO", 4, 25, 0, 0, GBP
+            ),
+        ],
+    )
+
+
+def _spin_off() -> CapitalGainsReport:
+    """Spin a tenth of a holding off into a new one."""
+    _, report = spin_off(
+        [transaction(BUY_DAY, ActionType.BUY, "FOO", 10, 10, 0, -100, GBP)],
+        10,
+        {BUY_DAY: {GBP: FLAT}, SPIN_OFF_DAY: {GBP: FLAT}},
+    )
+    return report
+
+
+def _fee_and_income() -> CapitalGainsReport:
+    """Charge a management fee, pay UK interest and its tax, and a dividend with treaty relief."""
+    return get_report(
+        create_calculator(tax_year=2024, balance_check=False),
+        [
+            transaction(JUNE_1, ActionType.BUY, "FOO", 10, 10, 0, -100, GBP),
+            transaction(JUNE_3, ActionType.FEE, "FOO", None, None, 0, -5, GBP),
+            transaction(
+                JUNE_3,
+                ActionType.DIVIDEND,
+                "BAR",
+                None,
+                None,
+                0,
+                100,
+                GBP,
+                isin=US_ISIN,
+            ),
+            transaction(
+                JUNE_3,
+                ActionType.DIVIDEND_TAX,
+                "BAR",
+                None,
+                None,
+                0,
+                -15,
+                GBP,
+                isin=US_ISIN,
+            ),
+            transaction(JULY_2, ActionType.INTEREST, None, None, None, 0, 3, GBP),
+            transaction(JULY_3, ActionType.INTEREST_TAX, None, None, None, 0, -2, GBP),
+        ],
+    )
+
+
+# Each scenario with the template branches it is there to pin: a phrase per
+# branch, so a scenario that stops reaching one fails loudly rather than
+# pinning a page that no longer says it.
+SCENARIOS: dict[str, tuple[Callable[[], CapitalGainsReport], list[str]]] = {
+    "gifts": (
+        _gifts,
+        [
+            "given away at a market value of",
+            "before any relief",
+            "Clogged loss",
+            "Losses on gifts to date",
+            "Chargeable \\textbf{loss}",
+            "Neither a gain nor a loss.",
+            "Losses on gifts, kept separate",
+        ],
+    ),
+    "exempt": (
+        _exempt,
+        [
+            "Exempt disposal",
+            "disregarded gain",
+            "Neither a gain nor a loss; the gain or loss is disregarded",
+            "disregarded loss",
+            "Number of exempt disposals",
+        ],
+    ),
+    "option_grant": (
+        _option_grant,
+        ["grant of 2", "contracts of the", "does not change the Section 104 holding"],
+    ),
+    "split": (
+        _split,
+        ["Share reorganisation", "Reconciled to that count"],
+    ),
+    "rename": (
+        _rename,
+        ["was renamed to", "BED AND BREAKFAST"],
+    ),
+    "spouse_transfer": (
+        _spouse_transfer,
+        ["Transferred to spouse", "passes to the recipient"],
+    ),
+    "spin_off": (
+        _spin_off,
+        ["Spin-off adjustment", "Cost basis calculated based on cost of"],
+    ),
+    "fee_and_income": (
+        _fee_and_income,
+        [
+            "Management fee for FOO",
+            "Interest UK 1",
+            "Interest tax UK 1",
+            "tax treaty amount",
+        ],
+    ),
+}
+
+
+def _source(report: CapitalGainsReport, directory: Path) -> str:
+    """Render the report to LaTeX source without running pdflatex."""
+    render_pdf(report, directory / "report.pdf", skip_pdflatex=True)
+    return (directory / "report.tex").read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("name", sorted(SCENARIOS))
+def test_latex_source_matches_golden(name: str, tmp_path: Path) -> None:
+    """The rendered source is byte-identical to the golden file."""
+    build, phrases = SCENARIOS[name]
+    source = _source(build(), tmp_path)
+    for phrase in phrases:
+        assert phrase in source, (
+            f"{name} no longer reaches the branch saying {phrase!r}"
+        )
+    golden = GOLDEN_DIR / f"{name}.tex"
+    assert source == golden.read_text(encoding="utf-8"), (
+        f"{golden} differs from the rendered source; if the change is intended, "
+        f"regenerate with: {REGENERATE}"
+    )
+
+
+if __name__ == "__main__":
+    GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as scratch:
+        for scenario, (builder, _) in SCENARIOS.items():
+            (GOLDEN_DIR / f"{scenario}.tex").write_text(
+                _source(builder(), Path(scratch)), encoding="utf-8"
+            )
+            print(f"wrote {scenario}.tex")


### PR DESCRIPTION
The rendered `.tex` was only checked by substring assertions; the template refactor that follows needs a byte-identical standard.

- `test_run_with_example_files` also compares `calculations.tex` against a golden when pdflatex is skipped; the Docker job keeps compiling the PDF.
- New `tests/general/test_render_latex_golden.py` renders eight scenarios covering every template branch the example run misses and compares each to a golden under `tests/general/data/latex/`. Each scenario also asserts the phrases of the branches it pins.
- The whitespace pre-commit hooks skip the golden files, which carry the template's own trailing spaces.

Test-only: no source change.
