### PR TITLE
Read a day's ticker renames as one holding in the first pass

### DIFF
--- a/.harper-ignore.txt
+++ b/.harper-ignore.txt
@@ -48,5 +48,3 @@
 # "how many candidates there are" is correct; ThereIsAgreement expects the noun
 # after the verb, but this construction puts it first.
 ^trading212\.py:.*ThereIsAgreement
-# "giving them new tax semantics" - Harper reads "new" as "knew".
-^rename_planning\.py:.*PronounKnew

--- a/.harper-ignore.txt
+++ b/.harper-ignore.txt
@@ -48,3 +48,5 @@
 # "how many candidates there are" is correct; ThereIsAgreement expects the noun
 # after the verb, but this construction puts it first.
 ^trading212\.py:.*ThereIsAgreement
+# "giving them new tax semantics" - Harper reads "new" as "knew".
+^rename_planning\.py:.*PronounKnew

--- a/cgt_calc/calculator_state.py
+++ b/cgt_calc/calculator_state.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
         OptionDisposalData,
         SpinOff,
     )
+    from .rename_planning import RenameComponent
     from .stock_splits import SplitTransformation
 
 
@@ -31,9 +32,10 @@ class PreparedHistory:
     """What the first pass records for the second pass to replay.
 
     Everything here is written while transactions are being read, and read
-    again while they are matched. The three scratch fields
-    (split_day_capacity, holding_sources, gift_prices) are the first pass's
-    own working notes: nothing in the second pass looks at them.
+    again while they are matched. The four scratch fields
+    (split_day_capacity, holding_sources, gift_prices, rename_components) are
+    the first pass's own working notes: nothing in the second pass looks at
+    them.
     """
 
     acquisition_list: HmrcTransactionLog = field(default_factory=dict)
@@ -77,6 +79,14 @@ class PreparedHistory:
     # Stores old->new mapping when a symbol changes its name.
     rename_list: dict[datetime.date, dict[str, str]] = field(
         default_factory=lambda: defaultdict(dict)
+    )
+    # What a day's renames say is one holding, by date and by each of the
+    # names that holding is spelled under. Only the days and holdings this
+    # pass reads that way: a name a split restates or a spin-off apportions
+    # from is absent, and keeps the pool the RENAME row's own position
+    # leaves it under.
+    rename_components: dict[datetime.date, dict[str, RenameComponent]] = field(
+        default_factory=dict
     )
 
     dividend_list: ForeignAmountLog = field(

--- a/cgt_calc/ingestion.py
+++ b/cgt_calc/ingestion.py
@@ -11,11 +11,7 @@ from typing import TYPE_CHECKING
 
 from colorama import Fore, Style
 
-from .const import (
-    BALANCE_CHECK_CONTEXT_ROWS,
-    ERI_TAX_DATE_DELTA,
-    RENAME_DESCRIPTION_PREFIX,
-)
+from .const import BALANCE_CHECK_CONTEXT_ROWS, ERI_TAX_DATE_DELTA
 from .exceptions import (
     AmountMissingError,
     CalculatedAmountDiscrepancyError,
@@ -39,6 +35,13 @@ from .model import (
     OptionDisposalData,
     Position,
     SpinOff,
+)
+from .rename_planning import (
+    plan_renames,
+    reconcile_rename_day,
+    rename_day_units,
+    rename_pair,
+    two_renames_message,
 )
 from .stock_split_planning import plan_stock_splits, source_account
 from .stock_splits import quantity_sign
@@ -290,10 +293,19 @@ class TransactionIngester:
         below zero until the day's purchases land — so the day's whole
         capacity answers instead, which its decreases cannot exceed because
         planning refused a day that closes below zero.
+
+        A day that renames the holding answers the same way, for a reason of
+        the same shape: the pool moves where the RENAME row sits, so the name
+        a row states holds the shares only on one side of it. What the whole
+        holding can give up, across every name the day's renames connect, is
+        what its decreases draw on there.
         """
         capacity = self.history.split_day_capacity.get((symbol, date_index))
         if capacity is not None:
             return capacity
+        renamed = rename_day_units(self.history, date_index, symbol)
+        if renamed is not None:
+            return renamed
         if symbol not in self.run.portfolio:
             return None
         return self.run.portfolio[symbol].quantity
@@ -983,23 +995,17 @@ class TransactionIngester:
             )
 
     def add_rename(self, transaction: BrokerTransaction) -> None:
-        """Apply a ticker rename during the first calculation pass."""
-        new_symbol = get_symbol_or_fail(transaction)
-        old_symbol = transaction.description[len(RENAME_DESCRIPTION_PREFIX) :]
-        if (
-            not transaction.description.startswith(RENAME_DESCRIPTION_PREFIX)
-            or not old_symbol
-        ):
-            raise InvalidTransactionError(
-                transaction,
-                "Rename transaction does not identify the old symbol",
-            )
+        """Apply a ticker rename during the first calculation pass.
+
+        Where the pool moves, which is what the day's other rows read. Which
+        names the day makes one holding is settled before any of them runs,
+        by ``plan_renames``.
+        """
+        old_symbol, new_symbol = rename_pair(transaction)
         existing = self.history.rename_list[transaction.date].get(old_symbol)
         if existing is not None and existing != new_symbol:
             raise CalculationError(
-                self._two_renames_message(
-                    old_symbol, transaction.date, existing, new_symbol
-                )
+                two_renames_message(old_symbol, transaction.date, existing, new_symbol)
             )
         self.history.rename_list[transaction.date][old_symbol] = new_symbol
         position = self.run.portfolio.pop(old_symbol, Position())
@@ -1109,6 +1115,7 @@ class TransactionIngester:
             ]:
                 del self.history.holding_sources[symbol]
             plan_stock_splits(self.state, transaction.date, days[transaction.date])
+            plan_renames(self.state, transaction.date, days[transaction.date])
         if quantity_sign(transaction.action) > 0 and transaction.symbol:
             self.history.holding_sources[transaction.symbol].add(
                 source_account(transaction)
@@ -1172,6 +1179,17 @@ class TransactionIngester:
         # be in the day's closing units before the first of them is pooled.
         days = self._group_by_date(transactions)
         planned: set[datetime.date] = set()
+        # A rename moves the pool where its row sits, so a purchase or sale
+        # of the same holding written under the name the day is retiring is
+        # left behind under it. Each date's last row gathers those in, once
+        # every row that could add to them has been read. Excess reported
+        # income is left out because its rows leave the loop early, and it
+        # adds nothing to a holding for this to collect.
+        day_last_row = {
+            transaction.date: index
+            for index, transaction in enumerate(transactions)
+            if transaction.action is not ActionType.EXCESS_REPORTED_INCOME
+        }
 
         for i, transaction in enumerate(transactions):
             self._open_transaction_day(transaction, days, planned)
@@ -1322,6 +1340,8 @@ class TransactionIngester:
                 msg += "Tip: If your input file is missing deposits/withdrawals use --no-balance-check."
                 raise CalculationError(msg)
             balance[transaction.broker, transaction.currency] = new_balance
+            if day_last_row[transaction.date] == i:
+                reconcile_rename_day(self.state, transaction.date)
 
         # Withholding belongs to the year of the dividend it was taken from,
         # which is not always the year it was posted in, so the summary reads
@@ -1399,20 +1419,3 @@ class TransactionIngester:
             for (broker, currency), amount in totals.interest_taxes.items():
                 print(f"{bul}{broker}: {round_decimal(-amount, 2)} ({currency})")
         print()
-
-    @staticmethod
-    def _two_renames_message(
-        old_symbol: str,
-        date_index: datetime.date,
-        first: str,
-        second: str,
-    ) -> str:
-        """Explain why one ticker cannot be renamed to two names in a day."""
-        return (
-            f"{old_symbol} is renamed to both {first} and {second} on "
-            f"{date_index}. The holding goes to one name or the other, and a "
-            "date carries no order to choose by, so which one cannot be "
-            "established and the pool would be replayed under a name it never "
-            "reached. Leave the row that does not belong out, or work this "
-            "day out by hand (consider professional advice)."
-        )

--- a/cgt_calc/rename_planning.py
+++ b/cgt_calc/rename_planning.py
@@ -1,22 +1,16 @@
 """First pass: reading a day's ticker renames as one holding.
 
-A rename is neither a disposal nor an acquisition (TCGA 1992 s127, CG51700):
-the same shares carry on under another name. Input carries dates but not
-times, so a date's rows say nothing about when in the day the name changed,
-and a purchase or sale recorded that day means the same shares whichever of
-the two tickers it states.
+A ticker change leaves the same shares under another name. Same-date broker
+rows do not consistently establish where the rename falls relative to trades,
+so ordinary purchases and sales are checked against the whole holding.
 
-The pool itself still moves where the RENAME row sits, which is what a
-price-sensitive corporate action reads. What is planned here is the day's
-alias graph: how many units the whole holding can give up, so that a decrease
-is checked against the holding rather than against the name its row happens to
-use, and which name the day ends under, so that anything left behind under the
-others is gathered in when it closes.
+The provisional pool still moves at the RENAME row. Day-open planning computes
+capacity across the connected tickers; day-close reconciliation gathers any
+remaining positions under the closing ticker. Acquisition and disposal logs
+keep the ticker from the source row for the matching pass.
 
-Only ordinary purchases and disposals are read this way. A holding a split
-restates, a spin-off apportions cost out of, or excess reported income adds
-cost to keeps the behaviour it has: those operations do not commute with a
-rename, and giving them new tax semantics is not this module's business.
+Other holding actions keep their existing processing because they may depend
+on the pool's position or cost when processed.
 """
 
 from __future__ import annotations
@@ -62,12 +56,7 @@ RENAME_DAY_UNSUPPORTED_ACTIONS: Final = frozenset(
         ActionType.FULL_REDEMPTION,
     }
 )
-"""What a rename component may not contain if this planning is to read it.
-
-Everything that moves a holding's units or its pooled cost, other than an
-ordinary purchase or sale. A component containing one of these is left to the
-row-position pool, unchanged, rather than given the day-wide reading below.
-"""
+"""Actions that keep their component on the existing row-position path."""
 
 
 UNNAMED_HOLDING_ACTIONS: Final = frozenset(
@@ -120,12 +109,7 @@ def plan_renames(
     date_index: datetime.date,
     day_transactions: list[BrokerTransaction],
 ) -> None:
-    """Record what each of the day's renamed holdings is and what it holds.
-
-    Runs before any of the day's rows are processed, the way reorganisations
-    are planned, so the graph saying which names are one holding exists before
-    a row states one of them.
-    """
+    """Validate the day's renames and compute capacity for eligible components."""
     pairs = [
         rename_pair(transaction)
         for transaction in day_transactions
@@ -133,21 +117,15 @@ def plan_renames(
     ]
     if not pairs:
         return
-    # Every component is read for sense first, whatever else the day holds.
-    # A holding renamed twice, or renamed to two names, ends up wherever the
-    # input's order of those rows puts it, and neither this planning nor the
-    # row-position pool it may fall back to can answer that. So the refusals
-    # come before anything decides which reading the day gets.
+    # Validate every component before choosing a fallback. Excluded actions
+    # must not bypass chain or conflict checks.
     components = [
         (names, _one_hop_renames(names, pairs, date_index))
         for names in _components(pairs)
     ]
     for _, renames in components:
         _refuse_rename_chain(renames, date_index)
-    # A day carrying a row that changes a pool without naming it cannot be
-    # read as a whole: a decrease this planning lets through under one name
-    # rather than another changes what that pool holds by the time the row
-    # is read, and no component can be told to expect it.
+    # These rows cannot be assigned to components by ticker alone.
     if any(
         transaction.action in UNNAMED_HOLDING_ACTIONS
         for transaction in day_transactions
@@ -181,16 +159,10 @@ def plan_renames(
 def rename_day_units(
     history: PreparedHistory, date_index: datetime.date, symbol: str
 ) -> Decimal | None:
-    """Return what a decrease of this holding may still take today.
+    """Return capacity minus today's disposals under every connected ticker.
 
-    The whole holding's capacity, less what the day's disposals have already
-    taken out of it under any of its names. Everything disposed of on one day
-    is one disposal (TCGA 1992 s105(1)), and the day's renames make these
-    names one holding, so a sale written under either name draws on the same
-    shares and they cannot be sold twice.
-
-    None when the day plans no such holding here, or when it has nothing to
-    give: a day that never held the shares is left to say so as it always has.
+    Return None for an unplanned or empty holding so the existing checks
+    report sales of shares that were never held.
     """
     component = history.rename_components.get(date_index, {}).get(symbol)
     if component is None or component.capacity == 0:
@@ -207,14 +179,10 @@ def rename_day_units(
 
 
 def reconcile_rename_day(state: CalculatorState, date_index: datetime.date) -> None:
-    """Gather what the day left under a renamed name into the closing one.
+    """Move positions left under retired tickers into the closing ticker.
 
-    The rename has already moved the pool, where its row sat. What is left
-    under a name it moved away from is what the rows after it recorded there:
-    an ordinary purchase or sale of the same holding, written under the name
-    the day is retiring. Gathering it in is not a second tax event, and no
-    rename is recorded for it - the units and their cost are the same units
-    and cost under the name the day ends on (TCGA 1992 s127, CG51700).
+    This only reconciles provisional bookkeeping; it records no second rename
+    and does not change the acquisition or disposal logs.
     """
     for name, component in state.history.rename_components.get(date_index, {}).items():
         if name == component.closing_name:
@@ -311,14 +279,9 @@ def _one_hop_renames(
 
 
 def _refuse_rename_chain(renames: dict[str, str], date_index: datetime.date) -> None:
-    """Refuse a holding this component's renames move twice in one day.
+    """Refuse chains and cycles, whose result would depend on rename row order.
 
-    A name that is renamed onward from the name it was just renamed to ends
-    up wherever the input's order of those two rows puts it, and swapping the
-    rows moves it somewhere else. A date carries no order, so neither reading
-    is established. A cycle is the same thing joined up, and the same test
-    catches it. The names are taken in order so that one day is always
-    refused by naming the same pair.
+    Sort names so either row order produces the same diagnostic.
     """
     for name in sorted({*renames, *renames.values()}):
         onward = renames.get(name)

--- a/cgt_calc/rename_planning.py
+++ b/cgt_calc/rename_planning.py
@@ -1,0 +1,339 @@
+"""First pass: reading a day's ticker renames as one holding.
+
+A rename is neither a disposal nor an acquisition (TCGA 1992 s127, CG51700):
+the same shares carry on under another name. Input carries dates but not
+times, so a date's rows say nothing about when in the day the name changed,
+and a purchase or sale recorded that day means the same shares whichever of
+the two tickers it states.
+
+The pool itself still moves where the RENAME row sits, which is what a
+price-sensitive corporate action reads. What is planned here is the day's
+alias graph: how many units the whole holding can give up, so that a decrease
+is checked against the holding rather than against the name its row happens to
+use, and which name the day ends under, so that anything left behind under the
+others is gathered in when it closes.
+
+Only ordinary purchases and disposals are read this way. A holding a split
+restates, a spin-off apportions cost out of, or excess reported income adds
+cost to keeps the behaviour it has: those operations do not commute with a
+rename, and giving them new tax semantics is not this module's business.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import TYPE_CHECKING, Final
+
+from .const import RENAME_DESCRIPTION_PREFIX
+from .exceptions import CalculationError, InvalidTransactionError, SymbolMissingError
+from .model import ActionType, Position
+from .stock_split_planning import signed_quantity
+from .stock_splits import quantity_sign
+from .transaction_log import has_key
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    import datetime
+
+    from .calculator_state import CalculatorState, PreparedHistory
+    from .model import BrokerTransaction
+
+
+RENAME_DAY_UNSUPPORTED_ACTIONS: Final = frozenset(
+    {
+        # Restate or apportion the pool itself, so where the pool sits when
+        # the row is read decides what they do.
+        ActionType.SPIN_OFF,
+        ActionType.STOCK_SPLIT,
+        ActionType.FEE,
+        ActionType.EXCESS_REPORTED_INCOME,
+        # Take a cost out of the pool, or put one in, at a figure worked out
+        # from the holding as the row finds it.
+        ActionType.STOCK_ACTIVITY,
+        ActionType.REINVEST_SHARES,
+        ActionType.TRANSFER_FROM_SPOUSE,
+        ActionType.TRANSFER_TO_SPOUSE,
+        ActionType.GIFT,
+        ActionType.GIFT_UNCONNECTED,
+        ActionType.UNCLASSIFIED_GIFT,
+        ActionType.CASH_MERGER,
+        ActionType.FULL_REDEMPTION,
+    }
+)
+"""What a rename component may not contain if this planning is to read it.
+
+Everything that moves a holding's units or its pooled cost, other than an
+ordinary purchase or sale. A component containing one of these is left to the
+row-position pool, unchanged, rather than given the day-wide reading below.
+"""
+
+
+UNNAMED_HOLDING_ACTIONS: Final = frozenset(
+    {ActionType.SPIN_OFF, ActionType.EXCESS_REPORTED_INCOME}
+)
+"""Rows that change a pool without naming it, so no component can exclude them.
+
+A spin-off row names only the holding it creates: its source is chosen when
+the row is read, out of the portfolio as the day's earlier rows have left it.
+An excess reported income row names no ticker at all, only an ISIN, which is
+resolved to the holdings it adds cost to when that row is read. Neither can be
+matched to a rename component by the ticker on its own row, so a day carrying
+either is left to the row-position pool in its entirety.
+"""
+
+
+@dataclass(frozen=True)
+class RenameComponent:
+    """One holding the day's renames spell under more than one ticker.
+
+    `names` is every ticker the day's renames connect, `closing_name` the one
+    they all end under, and `capacity` what the whole holding can give up that
+    day: what its names opened with, plus what the day's purchases add to any
+    of them.
+    """
+
+    names: tuple[str, ...]
+    closing_name: str
+    capacity: Decimal
+
+
+def rename_pair(transaction: BrokerTransaction) -> tuple[str, str]:
+    """Return the old and new names one RENAME row states."""
+    if transaction.symbol is None:
+        raise SymbolMissingError(transaction)
+    old_symbol = transaction.description[len(RENAME_DESCRIPTION_PREFIX) :]
+    if (
+        not transaction.description.startswith(RENAME_DESCRIPTION_PREFIX)
+        or not old_symbol
+    ):
+        raise InvalidTransactionError(
+            transaction,
+            "Rename transaction does not identify the old symbol",
+        )
+    return old_symbol, transaction.symbol
+
+
+def plan_renames(
+    state: CalculatorState,
+    date_index: datetime.date,
+    day_transactions: list[BrokerTransaction],
+) -> None:
+    """Record what each of the day's renamed holdings is and what it holds.
+
+    Runs before any of the day's rows are processed, the way reorganisations
+    are planned, so the graph saying which names are one holding exists before
+    a row states one of them.
+    """
+    pairs = [
+        rename_pair(transaction)
+        for transaction in day_transactions
+        if transaction.action is ActionType.RENAME
+    ]
+    if not pairs:
+        return
+    # Every component is read for sense first, whatever else the day holds.
+    # A holding renamed twice, or renamed to two names, ends up wherever the
+    # input's order of those rows puts it, and neither this planning nor the
+    # row-position pool it may fall back to can answer that. So the refusals
+    # come before anything decides which reading the day gets.
+    components = [
+        (names, _one_hop_renames(names, pairs, date_index))
+        for names in _components(pairs)
+    ]
+    for _, renames in components:
+        _refuse_rename_chain(renames, date_index)
+    # A day carrying a row that changes a pool without naming it cannot be
+    # read as a whole: a decrease this planning lets through under one name
+    # rather than another changes what that pool holds by the time the row
+    # is read, and no component can be told to expect it.
+    if any(
+        transaction.action in UNNAMED_HOLDING_ACTIONS
+        for transaction in day_transactions
+    ):
+        return
+    planned: dict[str, RenameComponent] = {}
+    for names, renames in components:
+        rows = [
+            transaction
+            for transaction in day_transactions
+            if transaction.symbol in names
+        ]
+        if any(
+            transaction.action in RENAME_DAY_UNSUPPORTED_ACTIONS for transaction in rows
+        ):
+            continue
+        component = RenameComponent(
+            names=tuple(sorted(names)),
+            closing_name=_closing_name(renames),
+            capacity=sum(
+                (state.run.portfolio.get(name, Position()).quantity for name in names),
+                signed_quantity([row for row in rows if quantity_sign(row.action) > 0]),
+            ),
+        )
+        for name in names:
+            planned[name] = component
+    if planned:
+        state.history.rename_components[date_index] = planned
+
+
+def rename_day_units(
+    history: PreparedHistory, date_index: datetime.date, symbol: str
+) -> Decimal | None:
+    """Return what a decrease of this holding may still take today.
+
+    The whole holding's capacity, less what the day's disposals have already
+    taken out of it under any of its names. Everything disposed of on one day
+    is one disposal (TCGA 1992 s105(1)), and the day's renames make these
+    names one holding, so a sale written under either name draws on the same
+    shares and they cannot be sold twice.
+
+    None when the day plans no such holding here, or when it has nothing to
+    give: a day that never held the shares is left to say so as it always has.
+    """
+    component = history.rename_components.get(date_index, {}).get(symbol)
+    if component is None or component.capacity == 0:
+        return None
+    taken = sum(
+        (
+            history.disposal_list[date_index][name].quantity
+            for name in component.names
+            if has_key(history.disposal_list, date_index, name)
+        ),
+        Decimal(0),
+    )
+    return component.capacity - taken
+
+
+def reconcile_rename_day(state: CalculatorState, date_index: datetime.date) -> None:
+    """Gather what the day left under a renamed name into the closing one.
+
+    The rename has already moved the pool, where its row sat. What is left
+    under a name it moved away from is what the rows after it recorded there:
+    an ordinary purchase or sale of the same holding, written under the name
+    the day is retiring. Gathering it in is not a second tax event, and no
+    rename is recorded for it - the units and their cost are the same units
+    and cost under the name the day ends on (TCGA 1992 s127, CG51700).
+    """
+    for name, component in state.history.rename_components.get(date_index, {}).items():
+        if name == component.closing_name:
+            continue
+        position = state.run.portfolio.pop(name, None)
+        if position is not None:
+            state.run.portfolio[component.closing_name] += position
+        # The units keep the accounts that put them there; only the name
+        # changes. Which holdings have emptied is settled where every earlier
+        # day has closed, in ``_open_transaction_day``.
+        moved = state.history.holding_sources.pop(name, set())
+        if moved:
+            state.history.holding_sources[component.closing_name] |= moved
+
+
+def two_renames_message(
+    old_symbol: str,
+    date_index: datetime.date,
+    first: str,
+    second: str,
+) -> str:
+    """Explain why one ticker cannot be renamed to two names in a day."""
+    return (
+        f"{old_symbol} is renamed to both {first} and {second} on "
+        f"{date_index}. The holding goes to one name or the other, and a "
+        "date carries no order to choose by, so which one cannot be "
+        "established and the pool would be replayed under a name it never "
+        "reached. Leave the row that does not belong out, or work this "
+        "day out by hand (consider professional advice)."
+    )
+
+
+def rename_chain_message(
+    old_symbol: str,
+    middle: str,
+    new_symbol: str,
+    date_index: datetime.date,
+) -> str:
+    """Explain why a holding renamed twice in a day cannot be worked out."""
+    return (
+        f"Cannot apply the renames of {old_symbol} on {date_index}: it is "
+        f"renamed to {middle}, and {middle} is renamed to {new_symbol}, the "
+        "same day. The renames are applied in the order the input lists them, "
+        "so where the holding ends up depends on which of the two rows comes "
+        "first, and a date carries no order to choose by. Put the renames on "
+        "the days they happened, or work this day out by hand (consider "
+        "professional advice)."
+    )
+
+
+def _components(pairs: list[tuple[str, str]]) -> Iterator[set[str]]:
+    """Group the day's renames into the holdings they connect.
+
+    A rename says two tickers are one security, so two holdings the day
+    renames onto the same name belong together, even though no single row
+    names them both. The graph is walked in both directions for that reason.
+    """
+    neighbours: dict[str, set[str]] = defaultdict(set)
+    for old_name, new_name in pairs:
+        neighbours[old_name].add(new_name)
+        neighbours[new_name].add(old_name)
+    seen: set[str] = set()
+    for name in neighbours:
+        if name in seen:
+            continue
+        group = {name}
+        frontier = [name]
+        while frontier:
+            for other in neighbours[frontier.pop()]:
+                if other not in group:
+                    group.add(other)
+                    frontier.append(other)
+        seen |= group
+        yield group
+
+
+def _one_hop_renames(
+    names: set[str],
+    pairs: list[tuple[str, str]],
+    date_index: datetime.date,
+) -> dict[str, str]:
+    """Return one component's old to new mappings, refusing a split holding."""
+    renames: dict[str, str] = {}
+    for old_name, new_name in pairs:
+        if old_name not in names:
+            continue
+        existing = renames.get(old_name)
+        if existing is not None and existing != new_name:
+            raise CalculationError(
+                two_renames_message(old_name, date_index, existing, new_name)
+            )
+        renames[old_name] = new_name
+    return renames
+
+
+def _refuse_rename_chain(renames: dict[str, str], date_index: datetime.date) -> None:
+    """Refuse a holding this component's renames move twice in one day.
+
+    A name that is renamed onward from the name it was just renamed to ends
+    up wherever the input's order of those two rows puts it, and swapping the
+    rows moves it somewhere else. A date carries no order, so neither reading
+    is established. A cycle is the same thing joined up, and the same test
+    catches it. The names are taken in order so that one day is always
+    refused by naming the same pair.
+    """
+    for name in sorted({*renames, *renames.values()}):
+        onward = renames.get(name)
+        if onward is not None and onward in renames:
+            raise CalculationError(
+                rename_chain_message(name, onward, renames[onward], date_index)
+            )
+
+
+def _closing_name(renames: dict[str, str]) -> str:
+    """Return the one name this holding's renames leave it under.
+
+    One holding, one destination: a second one could only join this component
+    through a name that is both renamed and renamed to, which is the chain
+    ``_refuse_rename_chain`` has already ruled out.
+    """
+    (closing_name,) = set(renames.values())
+    return closing_name

--- a/cgt_calc/stock_split_planning.py
+++ b/cgt_calc/stock_split_planning.py
@@ -392,8 +392,8 @@ def _plan_stock_split(
             f"of {strip_zeros(holding_at_event)}."
         )
 
-    post_split_delta = _signed_quantity(after_rows)
-    normalised_day_delta = post_split_delta + _signed_quantity(before_rows)
+    post_split_delta = signed_quantity(after_rows)
+    normalised_day_delta = post_split_delta + signed_quantity(before_rows)
     if mode is SplitMode.BROKER_EXACT:
         expected_day_close = event.after_quantity + post_split_delta
         reconciliation_delta = expected_day_close - (
@@ -445,7 +445,7 @@ def _plan_stock_split(
     # Decreases draw on this rather than on the running count.
     state.history.split_day_capacity[symbol, date_index] = (
         scaled_day_open_quantity
-        + _signed_quantity(
+        + signed_quantity(
             [
                 other
                 for other in (*before_rows, *after_rows)
@@ -456,7 +456,7 @@ def _plan_stock_split(
     )
 
 
-def _signed_quantity(transactions: list[BrokerTransaction]) -> Decimal:
+def signed_quantity(transactions: list[BrokerTransaction]) -> Decimal:
     """Net units these rows add to a holding, in their pooled counts."""
     total = Decimal(0)
     for transaction in transactions:

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -6,6 +6,7 @@ import copy
 import datetime
 from decimal import Decimal, localcontext
 from enum import Enum
+import itertools
 import logging
 from pathlib import Path
 import subprocess
@@ -39,7 +40,12 @@ from cgt_calc.model import (
 )
 from cgt_calc.parsers.broker_registry import _transaction_sort_key
 from cgt_calc.parsers.eri.model import ERITransaction
+from cgt_calc.rename_planning import RENAME_DAY_UNSUPPORTED_ACTIONS
 from cgt_calc.spin_off_handler import SpinOffHandler
+from cgt_calc.stock_splits import (
+    QUANTITY_DECREASING_ACTIONS,
+    QUANTITY_INCREASING_ACTIONS,
+)
 from cgt_calc.util import round_decimal
 from tests.utils import build_cmd, report_path
 
@@ -1140,6 +1146,17 @@ def test_rename_without_old_symbol_has_a_transaction_error(description: str) -> 
         )
 
 
+def test_rename_without_a_new_symbol_has_a_transaction_error() -> None:
+    """A rename row that cannot name its destination is invalid input."""
+    transaction = _rename_transaction(datetime.date(2024, 5, 10), "OLD", "NEW")
+    transaction.symbol = None
+
+    with pytest.raises(InvalidTransactionError, match="Symbol missing"):
+        create_calculator(tax_year=2024, balance_check=False).prepare_history(
+            [transaction]
+        )
+
+
 def test_section_104_disposal_uses_renamed_pool_cost() -> None:
     """After a rename, S104 disposal under NEW uses the pool cost carried from OLD."""
     calculator = create_calculator(tax_year=2024, balance_check=False)
@@ -1283,17 +1300,11 @@ def _rename_day_rows(
     ]
 
 
+@pytest.mark.parametrize("sale_spelling", ["OLD", "NEW"])
 @pytest.mark.parametrize(
-    ("sale_spelling", "order"),
-    [
-        ("OLD", ("sell", "rename", "buy")),
-        ("OLD", ("sell", "buy", "rename")),
-        ("OLD", ("buy", "sell", "rename")),
-        ("NEW", ("rename", "sell", "buy")),
-        ("NEW", ("rename", "buy", "sell")),
-        ("NEW", ("buy", "rename", "sell")),
-        ("NEW", ("buy", "sell", "rename")),
-    ],
+    "order",
+    list(itertools.permutations(("rename", "sell", "buy"))),
+    ids=",".join,
 )
 def test_same_day_match_carries_the_disposal_date_rename(
     sale_spelling: str, order: tuple[str, ...]
@@ -1303,12 +1314,14 @@ def test_same_day_match_carries_the_disposal_date_rename(
     The rename takes effect at the end of the day it is recorded on, so the
     day's rows may state either ticker and mean the same shares. Neither the
     spelling the sale uses nor where the rename row sits changes what was
-    sold, so all seven readings give the one same-day match.
+    sold, so all twelve readings give the one same-day match.
 
-    The orders left out are the ones the first pass rejects as written: it
-    reads the day's rows in the order the file lists them, so a sale under a
-    name that row order has already renamed away, or not yet bought, is
-    refused there before identification is reached.
+    A date carries no order, and Vanguard's export writes the rename ahead of
+    the day's trades, so every reading has to be worked out. Five of these
+    were refused before the day's own facts were looked at: the first pass
+    read each row against the name it states, so a sale under the name the
+    row order had already retired, or under the one it had yet to create,
+    had nothing to sell.
     """
     calculator = create_calculator(tax_year=2024, balance_check=False)
 
@@ -1615,7 +1628,11 @@ def test_sales_under_two_names_of_one_holding_are_refused() -> None:
 
 
 def test_a_holding_renamed_twice_on_a_disposal_date_is_refused() -> None:
-    """Where the shares end up depends on which of the two rename rows ran."""
+    """Where the shares end up depends on which of the two rename rows ran.
+
+    Refused as the day opens, before any of its rows is read, because a
+    holding renamed twice has no one name for the day to close under.
+    """
     calculator = create_calculator(tax_year=2024, balance_check=False)
     transactions = [
         _gbp_trade(datetime.date(2024, 5, 1), ActionType.BUY, "OLD", 100, 1000),
@@ -1628,7 +1645,7 @@ def test_a_holding_renamed_twice_on_a_disposal_date_is_refused() -> None:
         get_report(calculator, transactions)
 
     assert str(excinfo.value).startswith(
-        f"Cannot compute the disposal of OLD on {RENAME_DAY}: it is renamed to "
+        f"Cannot apply the renames of OLD on {RENAME_DAY}: it is renamed to "
         "MID, and MID is renamed to NEW, the same day."
     )
 
@@ -1671,6 +1688,288 @@ def test_a_day_buying_under_both_names_of_one_holding_is_refused() -> None:
         "make NEW and OLD one holding, and shares were bought under each of "
         "them today."
     )
+
+
+@pytest.mark.parametrize("rename_first", [True, False], ids=["rename first", "last"])
+def test_a_rename_day_refuses_more_units_than_the_whole_holding_has(
+    *, rename_first: bool
+) -> None:
+    """The two names are one holding, so its shares cannot be sold twice.
+
+    Reading each sale against the name its own row states lets both through:
+    one draws on the pool before the rename moves it, the other on the pool
+    after. There are only a hundred shares.
+    """
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    rename = _rename_transaction(RENAME_DAY, "OLD", "NEW")
+    sales = [
+        _gbp_trade(RENAME_DAY, ActionType.SELL, "OLD", 60, 900),
+        _gbp_trade(RENAME_DAY, ActionType.SELL, "NEW", 60, 900),
+    ]
+    transactions = [
+        _gbp_trade(datetime.date(2024, 5, 1), ActionType.BUY, "OLD", 100, 1000),
+        *([rename, *sales] if rename_first else [*sales, rename]),
+    ]
+
+    with pytest.raises(
+        InvalidTransactionError, match=r"more than the available balance\(40\)"
+    ):
+        get_report(calculator, transactions)
+
+
+def test_a_purchase_under_the_retired_name_is_there_to_sell_later() -> None:
+    """Shares bought under the name the day retires are the same holding.
+
+    The rename moves the pool where its row sits, so a purchase listed after
+    it lands under the name being retired and is stranded there. The day
+    gathers it in as it closes, and the whole holding is available to sell
+    the following week.
+    """
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    transactions = [
+        _gbp_trade(datetime.date(2024, 5, 1), ActionType.BUY, "OLD", 100, 1000),
+        _rename_transaction(RENAME_DAY, "OLD", "NEW"),
+        _gbp_trade(RENAME_DAY, ActionType.BUY, "OLD", 50, 750),
+        _gbp_trade(datetime.date(2024, 5, 20), ActionType.SELL, "NEW", 150, 3000),
+    ]
+
+    report = get_report(calculator, transactions)
+
+    assert report.total_gain() == Decimal(1250)
+    assert calculator.portfolio["NEW"] == Position()
+
+
+def test_the_first_pass_leaves_a_rename_day_under_the_closing_ticker() -> None:
+    """Nothing is left behind under a name the day has renamed away from."""
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+
+    calculator.prepare_history(
+        [
+            _gbp_trade(datetime.date(2024, 5, 1), ActionType.BUY, "OLD", 100, 1000),
+            _rename_transaction(RENAME_DAY, "OLD", "NEW"),
+            _gbp_trade(RENAME_DAY, ActionType.BUY, "OLD", 50, 750),
+        ]
+    )
+
+    assert dict(calculator.portfolio) == {"NEW": Position(Decimal(150), Decimal(1750))}
+
+
+@pytest.mark.parametrize("backwards", [False, True], ids=["in order", "backwards"])
+def test_a_day_whose_only_rows_are_a_rename_chain_is_refused(
+    *, backwards: bool
+) -> None:
+    """Renamed onward the same day, with no trade to bring the question up.
+
+    Where the holding ends up is which of the two rows the input lists first,
+    and a date carries no order to choose by. Listing them the other way round
+    leaves the pool at the middle name instead, so it is the same refusal
+    rather than a second answer.
+    """
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    renames = [
+        _rename_transaction(RENAME_DAY, "OLD", "MID"),
+        _rename_transaction(RENAME_DAY, "MID", "NEW"),
+    ]
+    transactions = [
+        _gbp_trade(datetime.date(2024, 5, 1), ActionType.BUY, "OLD", 100, 1000),
+        *(reversed(renames) if backwards else renames),
+    ]
+
+    with pytest.raises(CalculationError) as excinfo:
+        get_report(calculator, transactions)
+
+    assert str(excinfo.value).startswith(
+        f"Cannot apply the renames of OLD on {RENAME_DAY}: it is renamed to "
+        "MID, and MID is renamed to NEW, the same day."
+    )
+
+
+def test_every_action_says_what_a_rename_day_does_with_it() -> None:
+    """A new kind of row has to say which reading of a rename day it takes.
+
+    An ordinary purchase or sale, and the rename itself, are read as part of
+    the whole holding. Everything else that moves a holding's units or its
+    pooled cost keeps the pool where the RENAME row's own position leaves it,
+    and says so by being listed in `RENAME_DAY_UNSUPPORTED_ACTIONS`. The rest
+    never touch a holding, so a rename day may read straight past them.
+
+    The three readings partition the actions, so an action added without one
+    of them fails here rather than silently taking the first.
+    """
+    read_as_one_holding = {ActionType.BUY, ActionType.SELL, ActionType.RENAME}
+    touch_no_holding = {
+        ActionType.ADJUSTMENT,
+        ActionType.CANCEL_BUY,
+        ActionType.CAPITAL_GAIN,
+        ActionType.DIVIDEND,
+        ActionType.DIVIDEND_TAX,
+        ActionType.INTEREST,
+        ActionType.INTEREST_TAX,
+        ActionType.OPTION_ASSIGNMENT,
+        ActionType.OPTION_CLOSE,
+        ActionType.OPTION_EXPIRY,
+        ActionType.OPTION_GRANT,
+        ActionType.REINVEST_DIVIDENDS,
+        ActionType.TRANSFER,
+        ActionType.WIRE_FUNDS_RECEIVED,
+    }
+    readings = [read_as_one_holding, touch_no_holding, RENAME_DAY_UNSUPPORTED_ACTIONS]
+
+    assert set().union(*readings) == set(ActionType)
+    assert sum(len(reading) for reading in readings) == len(ActionType)
+    # Two of the unsupported rows carry no units at all, so a check on what
+    # moves a share count would not notice either of them going missing.
+    assert {ActionType.FEE, ActionType.EXCESS_REPORTED_INCOME} <= (
+        RENAME_DAY_UNSUPPORTED_ACTIONS
+    )
+    # Nothing that moves a share count is read as part of the whole holding
+    # but an ordinary purchase or sale.
+    assert (QUANTITY_INCREASING_ACTIONS | QUANTITY_DECREASING_ACTIONS) - {
+        ActionType.BUY,
+        ActionType.SELL,
+    } <= RENAME_DAY_UNSUPPORTED_ACTIONS
+
+
+def test_two_holdings_renamed_on_one_day_are_told_apart() -> None:
+    """A day's renames can move two holdings without pooling them.
+
+    Each sale is written under the name its own holding is losing, so both
+    need the day read as a whole, and each is answered by its own holding.
+    What one of them may not do is draw on the other, which is
+    `test_one_renamed_holding_cannot_borrow_the_other_s_shares`.
+    """
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    buy_day = datetime.date(2024, 5, 1)
+    transactions = [
+        _gbp_trade(buy_day, ActionType.BUY, "OLD", 100, 1000),
+        _gbp_trade(buy_day, ActionType.BUY, "FOO", 100, 2000),
+        _rename_transaction(RENAME_DAY, "OLD", "NEW"),
+        _rename_transaction(RENAME_DAY, "FOO", "BAR"),
+        _gbp_trade(RENAME_DAY, ActionType.SELL, "OLD", 60, 900),
+        _gbp_trade(RENAME_DAY, ActionType.SELL, "FOO", 60, 1500),
+    ]
+
+    report = get_report(calculator, transactions)
+
+    assert report.total_gain() == Decimal(600)
+    assert calculator.portfolio["NEW"] == Position(Decimal(40), Decimal(400))
+    assert calculator.portfolio["BAR"] == Position(Decimal(40), Decimal(800))
+
+
+def test_one_renamed_holding_cannot_borrow_the_other_s_shares() -> None:
+    """Two holdings renamed on one day are two capacities, not one.
+
+    Both sales are written under the names the day is retiring, so both are
+    answered by the whole holding rather than by the name on the row. The
+    smaller holding is still only fifty shares.
+    """
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    buy_day = datetime.date(2024, 5, 1)
+    transactions = [
+        _gbp_trade(buy_day, ActionType.BUY, "OLD", 100, 1000),
+        _gbp_trade(buy_day, ActionType.BUY, "FOO", 50, 1000),
+        _rename_transaction(RENAME_DAY, "OLD", "NEW"),
+        _rename_transaction(RENAME_DAY, "FOO", "BAR"),
+        _gbp_trade(RENAME_DAY, ActionType.SELL, "OLD", 60, 900),
+        _gbp_trade(RENAME_DAY, ActionType.SELL, "FOO", 60, 900),
+    ]
+
+    with pytest.raises(
+        InvalidTransactionError, match=r"more than the available balance\(50\)"
+    ):
+        get_report(calculator, transactions)
+
+
+def test_a_holding_renamed_to_two_names_on_a_trading_day_is_refused() -> None:
+    """The holding goes to one name or the other, and the day says neither."""
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    transactions = [
+        _gbp_trade(datetime.date(2024, 5, 1), ActionType.BUY, "OLD", 100, 1000),
+        _rename_transaction(RENAME_DAY, "OLD", "AAA"),
+        _rename_transaction(RENAME_DAY, "OLD", "BBB"),
+        _gbp_trade(RENAME_DAY, ActionType.SELL, "OLD", 50, 1000),
+    ]
+
+    with pytest.raises(CalculationError) as excinfo:
+        get_report(calculator, transactions)
+
+    assert str(excinfo.value).startswith(
+        f"OLD is renamed to both AAA and BBB on {RENAME_DAY}."
+    )
+
+
+@pytest.mark.parametrize("backwards", [False, True], ids=["in order", "backwards"])
+@pytest.mark.parametrize("third_row", ["fee", "excess reported income"])
+def test_a_rename_chain_is_refused_whatever_else_the_day_holds(
+    third_row: str, *, backwards: bool
+) -> None:
+    """A day the planning does not read is still read for sense.
+
+    A fee, and excess reported income, each leave their component to the
+    row-position pool. That is a reading of the day, not a reason to stop
+    asking whether the day makes sense: a holding renamed twice still ends up
+    wherever the input's order of those two rows puts it, and the pool moved
+    by file position is the thing this fix exists to stop. So the chain is
+    refused before anything decides which reading the day gets.
+    """
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    calculator.isin_converter.data[ERI_ISIN] = {"OLD"}
+    renames = [
+        _rename_transaction(RENAME_DAY, "OLD", "MID"),
+        _rename_transaction(RENAME_DAY, "MID", "NEW"),
+    ]
+    extra: BrokerTransaction = (
+        _gbp_fee(RENAME_DAY, "OLD", 5)
+        if third_row == "fee"
+        else ERITransaction(
+            date=RENAME_DAY,
+            isin=ERI_ISIN,
+            price=Decimal(1),
+            currency=CurrencyCode("GBP"),
+        )
+    )
+    transactions = [
+        _gbp_trade(datetime.date(2024, 5, 1), ActionType.BUY, "OLD", 100, 1000),
+        extra,
+        *(reversed(renames) if backwards else renames),
+        _gbp_trade(datetime.date(2024, 5, 20), ActionType.SELL, "NEW", 100, 1500),
+    ]
+
+    with pytest.raises(CalculationError) as excinfo:
+        get_report(calculator, transactions)
+
+    assert str(excinfo.value).startswith(
+        f"Cannot apply the renames of OLD on {RENAME_DAY}: it is renamed to "
+        "MID, and MID is renamed to NEW, the same day."
+    )
+
+
+def test_a_rename_day_carrying_excess_reported_income_is_read_row_by_row() -> None:
+    """Excess reported income names an ISIN, so its day keeps its row order.
+
+    The income adds to a pool's cost, and its row does not say which pool:
+    the ISIN is resolved to the tickers it belongs to only when that row is
+    read. So no rename component can be told it is there, and reading the day
+    as one holding would move the pool out from under the name the income is
+    recorded against and lose it. The day is left as `origin/main` reads it,
+    which refuses this order.
+    """
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    calculator.isin_converter.data[ERI_ISIN] = {"OLD"}
+    transactions: list[BrokerTransaction] = [
+        _gbp_trade(datetime.date(2024, 5, 1), ActionType.BUY, "OLD", 100, 1000),
+        _gbp_trade(RENAME_DAY, ActionType.SELL, "NEW", 50, 1000),
+        ERITransaction(
+            date=RENAME_DAY,
+            isin=ERI_ISIN,
+            price=Decimal(1),
+            currency=CurrencyCode("GBP"),
+        ),
+        _rename_transaction(RENAME_DAY, "OLD", "NEW"),
+    ]
+
+    with pytest.raises(InvalidTransactionError, match="not owned symbol"):
+        get_report(calculator, transactions)
 
 
 def test_same_day_vest_ordered_before_sale() -> None:

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -1282,16 +1282,18 @@ RENAME_DAY = datetime.date(2024, 5, 10)
 
 
 def _rename_day_rows(
-    sale_spelling: str, order: tuple[str, ...]
+    sale_spelling: str, order: tuple[str, ...], sale_quantity: int
 ) -> list[BrokerTransaction]:
-    """Build the day the pool is renamed, its rows in the order given.
-
-    100 OLD shares costing GBP 1,000 are held. On the day, OLD is renamed to
-    NEW, 50 shares are sold for GBP 1,000, and 50 NEW are bought for GBP 750.
-    """
+    """Open with 100 OLD at GBP 10; buy 50 NEW at GBP 15 and sell at GBP 20."""
     rows = {
         "rename": _rename_transaction(RENAME_DAY, "OLD", "NEW"),
-        "sell": _gbp_trade(RENAME_DAY, ActionType.SELL, sale_spelling, 50, 1000),
+        "sell": _gbp_trade(
+            RENAME_DAY,
+            ActionType.SELL,
+            sale_spelling,
+            sale_quantity,
+            sale_quantity * 20,
+        ),
         "buy": _gbp_trade(RENAME_DAY, ActionType.BUY, "NEW", 50, 750),
     }
     return [
@@ -1300,6 +1302,11 @@ def _rename_day_rows(
     ]
 
 
+@pytest.mark.parametrize(
+    ("sale_quantity", "allowable_cost", "gain", "closing_quantity"),
+    [(50, 750, 250, 100), (120, 1450, 950, 30)],
+    ids=["same-day match", "purchase needed for capacity"],
+)
 @pytest.mark.parametrize("sale_spelling", ["OLD", "NEW"])
 @pytest.mark.parametrize(
     "order",
@@ -1307,35 +1314,40 @@ def _rename_day_rows(
     ids=",".join,
 )
 def test_same_day_match_carries_the_disposal_date_rename(
-    sale_spelling: str, order: tuple[str, ...]
+    sale_spelling: str,
+    order: tuple[str, ...],
+    sale_quantity: int,
+    allowable_cost: int,
+    gain: int,
+    closing_quantity: int,
 ) -> None:
     """A sale is matched with the day's purchase under either of its names.
 
-    The rename takes effect at the end of the day it is recorded on, so the
-    day's rows may state either ticker and mean the same shares. Neither the
-    spelling the sale uses nor where the rename row sits changes what was
-    sold, so all twelve readings give the one same-day match.
-
-    A date carries no order, and Vanguard's export writes the rename ahead of
-    the day's trades, so every reading has to be worked out. Five of these
-    were refused before the day's own facts were looked at: the first pass
-    read each row against the name it states, so a sale under the name the
-    row order had already retired, or under the one it had yet to create,
-    had nothing to sell.
+    Selling 120 requires the day's purchase to count towards capacity even
+    when the sale is read first. Each case must agree across all row orders.
     """
     calculator = create_calculator(tax_year=2024, balance_check=False)
 
-    report = get_report(calculator, _rename_day_rows(sale_spelling, order))
+    report = get_report(
+        calculator, _rename_day_rows(sale_spelling, order, sale_quantity)
+    )
 
     entries = report.calculation_log[RENAME_DAY][f"sell${sale_spelling}"]
-    assert len(entries) == 1
+    assert len(entries) == (1 if sale_quantity == 50 else 2)
     assert entries[0].rule_type is RuleType.SAME_DAY
     assert entries[0].quantity == Decimal(50)
     assert entries[0].allowable_cost == Decimal(750)
     assert entries[0].gain == Decimal(250)
-    assert report.total_gain() == Decimal(250)
-    # The 100 shares held from May 1 are untouched, and keep their cost.
-    assert calculator.portfolio["NEW"] == Position(Decimal(100), Decimal(1000))
+    if sale_quantity == 120:
+        assert entries[1].rule_type is RuleType.SECTION_104
+        assert entries[1].quantity == Decimal(70)
+        assert entries[1].allowable_cost == Decimal(700)
+        assert entries[1].gain == Decimal(700)
+    assert report.allowable_costs == Decimal(allowable_cost)
+    assert report.total_gain() == Decimal(gain)
+    assert calculator.portfolio["NEW"] == Position(
+        Decimal(closing_quantity), Decimal(closing_quantity * 10)
+    )
 
 
 def test_a_sale_under_the_new_name_draws_on_the_pool_under_the_old_one() -> None:
@@ -1694,11 +1706,9 @@ def test_a_day_buying_under_both_names_of_one_holding_is_refused() -> None:
 def test_a_rename_day_refuses_more_units_than_the_whole_holding_has(
     *, rename_first: bool
 ) -> None:
-    """The two names are one holding, so its shares cannot be sold twice.
+    """Selling 60 under one alias leaves only 40 available under the other.
 
-    Reading each sale against the name its own row states lets both through:
-    one draws on the pool before the rename moves it, the other on the pool
-    after. There are only a hundred shares.
+    The second sale must be refused whether the rename is read first or last.
     """
     calculator = create_calculator(tax_year=2024, balance_check=False)
     rename = _rename_transaction(RENAME_DAY, "OLD", "NEW")
@@ -1718,13 +1728,7 @@ def test_a_rename_day_refuses_more_units_than_the_whole_holding_has(
 
 
 def test_a_purchase_under_the_retired_name_is_there_to_sell_later() -> None:
-    """Shares bought under the name the day retires are the same holding.
-
-    The rename moves the pool where its row sits, so a purchase listed after
-    it lands under the name being retired and is stranded there. The day
-    gathers it in as it closes, and the whole holding is available to sell
-    the following week.
-    """
+    """A purchase under the retired ticker is available under NEW on a later day."""
     calculator = create_calculator(tax_year=2024, balance_check=False)
     transactions = [
         _gbp_trade(datetime.date(2024, 5, 1), ActionType.BUY, "OLD", 100, 1000),
@@ -1740,31 +1744,32 @@ def test_a_purchase_under_the_retired_name_is_there_to_sell_later() -> None:
 
 
 def test_the_first_pass_leaves_a_rename_day_under_the_closing_ticker() -> None:
-    """Nothing is left behind under a name the day has renamed away from."""
+    """Reconciliation carries both shares and their source accounts to NEW."""
     calculator = create_calculator(tax_year=2024, balance_check=False)
+    opening = _gbp_trade(datetime.date(2024, 5, 1), ActionType.BUY, "OLD", 100, 1000)
+    opening.source = TransactionSource(account="Account A")
+    purchase = _gbp_trade(RENAME_DAY, ActionType.BUY, "OLD", 50, 750)
+    purchase.source = TransactionSource(account="Account B")
 
     calculator.prepare_history(
         [
-            _gbp_trade(datetime.date(2024, 5, 1), ActionType.BUY, "OLD", 100, 1000),
+            opening,
             _rename_transaction(RENAME_DAY, "OLD", "NEW"),
-            _gbp_trade(RENAME_DAY, ActionType.BUY, "OLD", 50, 750),
+            purchase,
         ]
     )
 
     assert dict(calculator.portfolio) == {"NEW": Position(Decimal(150), Decimal(1750))}
+    assert dict(calculator.state.history.holding_sources) == {
+        "NEW": {"Account A", "Account B"}
+    }
 
 
 @pytest.mark.parametrize("backwards", [False, True], ids=["in order", "backwards"])
 def test_a_day_whose_only_rows_are_a_rename_chain_is_refused(
     *, backwards: bool
 ) -> None:
-    """Renamed onward the same day, with no trade to bring the question up.
-
-    Where the holding ends up is which of the two rows the input lists first,
-    and a date carries no order to choose by. Listing them the other way round
-    leaves the pool at the middle name instead, so it is the same refusal
-    rather than a second answer.
-    """
+    """Refuse a chain in either order even when no disposal invokes the matcher."""
     calculator = create_calculator(tax_year=2024, balance_check=False)
     renames = [
         _rename_transaction(RENAME_DAY, "OLD", "MID"),
@@ -1785,16 +1790,9 @@ def test_a_day_whose_only_rows_are_a_rename_chain_is_refused(
 
 
 def test_every_action_says_what_a_rename_day_does_with_it() -> None:
-    """A new kind of row has to say which reading of a rename day it takes.
+    """Every action must explicitly support planning, trigger fallback, or do neither.
 
-    An ordinary purchase or sale, and the rename itself, are read as part of
-    the whole holding. Everything else that moves a holding's units or its
-    pooled cost keeps the pool where the RENAME row's own position leaves it,
-    and says so by being listed in `RENAME_DAY_UNSUPPORTED_ACTIONS`. The rest
-    never touch a holding, so a rename day may read straight past them.
-
-    The three readings partition the actions, so an action added without one
-    of them fails here rather than silently taking the first.
+    Adding an action without classifying it must fail this test.
     """
     read_as_one_holding = {ActionType.BUY, ActionType.SELL, ActionType.RENAME}
     touch_no_holding = {
@@ -1831,13 +1829,7 @@ def test_every_action_says_what_a_rename_day_does_with_it() -> None:
 
 
 def test_two_holdings_renamed_on_one_day_are_told_apart() -> None:
-    """A day's renames can move two holdings without pooling them.
-
-    Each sale is written under the name its own holding is losing, so both
-    need the day read as a whole, and each is answered by its own holding.
-    What one of them may not do is draw on the other, which is
-    `test_one_renamed_holding_cannot_borrow_the_other_s_shares`.
-    """
+    """Sales under two retired tickers draw on their respective holdings."""
     calculator = create_calculator(tax_year=2024, balance_check=False)
     buy_day = datetime.date(2024, 5, 1)
     transactions = [
@@ -1857,12 +1849,7 @@ def test_two_holdings_renamed_on_one_day_are_told_apart() -> None:
 
 
 def test_one_renamed_holding_cannot_borrow_the_other_s_shares() -> None:
-    """Two holdings renamed on one day are two capacities, not one.
-
-    Both sales are written under the names the day is retiring, so both are
-    answered by the whole holding rather than by the name on the row. The
-    smaller holding is still only fifty shares.
-    """
+    """A sale exceeding its holding's capacity cannot use another holding's shares."""
     calculator = create_calculator(tax_year=2024, balance_check=False)
     buy_day = datetime.date(2024, 5, 1)
     transactions = [
@@ -1903,14 +1890,9 @@ def test_a_holding_renamed_to_two_names_on_a_trading_day_is_refused() -> None:
 def test_a_rename_chain_is_refused_whatever_else_the_day_holds(
     third_row: str, *, backwards: bool
 ) -> None:
-    """A day the planning does not read is still read for sense.
+    """Fees and ERI trigger different fallback paths.
 
-    A fee, and excess reported income, each leave their component to the
-    row-position pool. That is a reading of the day, not a reason to stop
-    asking whether the day makes sense: a holding renamed twice still ends up
-    wherever the input's order of those two rows puts it, and the pool moved
-    by file position is the thing this fix exists to stop. So the chain is
-    refused before anything decides which reading the day gets.
+    Neither may bypass rename-chain validation, in either row order.
     """
     calculator = create_calculator(tax_year=2024, balance_check=False)
     calculator.isin_converter.data[ERI_ISIN] = {"OLD"}
@@ -1945,14 +1927,9 @@ def test_a_rename_chain_is_refused_whatever_else_the_day_holds(
 
 
 def test_a_rename_day_carrying_excess_reported_income_is_read_row_by_row() -> None:
-    """Excess reported income names an ISIN, so its day keeps its row order.
+    """An ERI day preserves the existing refusal of a sale before its ticker exists.
 
-    The income adds to a pool's cost, and its row does not say which pool:
-    the ISIN is resolved to the tickers it belongs to only when that row is
-    read. So no rename component can be told it is there, and reading the day
-    as one holding would move the pool out from under the name the income is
-    recorded against and lose it. The day is left as `origin/main` reads it,
-    which refuses this order.
+    ERI names an ISIN, so ticker-based filtering cannot exclude affected holdings.
     """
     calculator = create_calculator(tax_year=2024, balance_check=False)
     calculator.isin_converter.data[ERI_ISIN] = {"OLD"}

--- a/tests/general/test_spin_off_basis.py
+++ b/tests/general/test_spin_off_basis.py
@@ -710,11 +710,15 @@ def _rename(old: str, new: str) -> BrokerTransaction:
     )
 
 
-def test_a_source_renamed_twice_on_the_day_is_still_apportioned() -> None:
-    """OLD to MID to NEW in one morning: the pool is two renames back.
+@pytest.mark.parametrize("backwards", [False, True], ids=["in order", "backwards"])
+def test_a_source_renamed_twice_on_the_day_is_refused(*, backwards: bool) -> None:
+    """OLD to MID to NEW in one morning, with no saying where it lands.
 
-    Following only one rename found MID's pool, which is empty, and BAR got
-    a cost of nothing.
+    The renames are applied in the order the input lists them, so listed this
+    way round the shares reach NEW and the spin-off apportions from them,
+    while listed the other way they stop at MID and NEW has nothing to spin
+    anything off. A date carries no order to choose by, so the day is refused
+    as it opens rather than answered from the order the file happens to have.
     """
     converter = CurrencyConverter(None, {})
     handler = SpinOffHandler()
@@ -733,20 +737,22 @@ def test_a_source_renamed_twice_on_the_day_is_still_apportioned() -> None:
         interest_fund_tickers=[],
         balance_check=False,
     )
-    get_report(
-        calculator,
-        [
-            transaction(BUY_DAY, ActionType.BUY, "OLD", 10, 10, 0, -100, GBP),
-            _rename("OLD", "MID"),
-            _rename("MID", "NEW"),
-            transaction(
-                SPIN_OFF_DAY, ActionType.SPIN_OFF, "BAR", 10, 10, 0, currency=GBP
-            ),
-        ],
-    )
+    renames = [_rename("OLD", "MID"), _rename("MID", "NEW")]
 
-    assert calculator.portfolio["NEW"].amount == Decimal(90)
-    assert calculator.portfolio["BAR"].amount == Decimal(10)
+    with pytest.raises(
+        CalculationError,
+        match="is renamed to MID, and MID is renamed to NEW, the same day",
+    ):
+        get_report(
+            calculator,
+            [
+                transaction(BUY_DAY, ActionType.BUY, "OLD", 10, 10, 0, -100, GBP),
+                *(reversed(renames) if backwards else renames),
+                transaction(
+                    SPIN_OFF_DAY, ActionType.SPIN_OFF, "BAR", 10, 10, 0, currency=GBP
+                ),
+            ],
+        )
 
 
 @pytest.mark.parametrize(
@@ -755,7 +761,11 @@ def test_a_source_renamed_twice_on_the_day_is_still_apportioned() -> None:
         pytest.param(
             [("A", "NEW"), ("B", "NEW")], "separate holdings", id="two-into-one"
         ),
-        pytest.param([("NEW", "B"), ("B", "NEW")], "round in a circle", id="circle"),
+        pytest.param(
+            [("NEW", "B"), ("B", "NEW")],
+            "is renamed to NEW, and NEW is renamed to B",
+            id="circle",
+        ),
     ],
 )
 def test_a_rename_graph_with_no_single_pool_is_refused(

--- a/tests/general/test_spin_off_basis.py
+++ b/tests/general/test_spin_off_basis.py
@@ -712,14 +712,7 @@ def _rename(old: str, new: str) -> BrokerTransaction:
 
 @pytest.mark.parametrize("backwards", [False, True], ids=["in order", "backwards"])
 def test_a_source_renamed_twice_on_the_day_is_refused(*, backwards: bool) -> None:
-    """OLD to MID to NEW in one morning, with no saying where it lands.
-
-    The renames are applied in the order the input lists them, so listed this
-    way round the shares reach NEW and the spin-off apportions from them,
-    while listed the other way they stop at MID and NEW has nothing to spin
-    anything off. A date carries no order to choose by, so the day is refused
-    as it opens rather than answered from the order the file happens to have.
-    """
+    """A spin-off must not bypass chain validation in either rename row order."""
     converter = CurrencyConverter(None, {})
     handler = SpinOffHandler()
     handler.cache = {"BAR": "NEW"}

--- a/tests/general/test_stock_splits.py
+++ b/tests/general/test_stock_splits.py
@@ -2033,10 +2033,12 @@ def test_a_holding_renamed_along_into_the_reorganised_one_is_refused() -> None:
 
     Nothing renames straight into the reorganised name, so looking only at the
     renames it is named in finds an empty holding and lets the day through.
-    The three units come along the chain and are never restated.
+    The three units come along the chain and are never restated. The chain is
+    what the day is refused for: it is read for sense as the day opens,
+    before the reorganisation is planned at all.
     """
     with pytest.raises(
-        CalculationError, match="pool it with OLD, which holds shares of its own"
+        CalculationError, match="is renamed to MID, and MID is renamed to NEW"
     ):
         run(
             [
@@ -2379,3 +2381,29 @@ def test_a_reorganisation_is_not_a_disposal_row_of_its_own(
     assert calculator.portfolio["NEW"] == Position(
         Decimal(closing[0]), Decimal(closing[1])
     )
+
+
+def test_a_reorganised_holding_s_rename_day_is_still_read_row_by_row() -> None:
+    """Scaling a pool and renaming it do not commute, so the day keeps its order.
+
+    An ordinary rename day is read as one holding: what its names hold
+    together is what its sales may take, and what the day leaves under a name
+    it retires is gathered into the closing one as it closes. A day that also
+    restates the pool is left out of that, because where the restatement falls
+    among the day's rows is what decides the units it acts on.
+
+    So a purchase written under the old name after the rename row stays there,
+    as it does on `origin/main`, and the following month's sale of the whole
+    holding under the new name finds only the twenty units the rename carried
+    across.
+    """
+    with pytest.raises(InvalidTransactionError, match=r"available balance\(20\.0*\)"):
+        run(
+            [
+                trade(POOL_DAY, ActionType.BUY, "OLD", "10", "10"),
+                legacy_split(EVENT_DAY, "OLD", "10"),
+                rename(EVENT_DAY, "OLD", "NEW"),
+                trade(EVENT_DAY, ActionType.BUY, "OLD", "5", "10"),
+                trade(LATER_DAY, ActionType.SELL, "NEW", "25", "10"),
+            ]
+        )

--- a/tests/general/test_stock_splits.py
+++ b/tests/general/test_stock_splits.py
@@ -2034,8 +2034,7 @@ def test_a_holding_renamed_along_into_the_reorganised_one_is_refused() -> None:
     Nothing renames straight into the reorganised name, so looking only at the
     renames it is named in finds an empty holding and lets the day through.
     The three units come along the chain and are never restated. The chain is
-    what the day is refused for: it is read for sense as the day opens,
-    before the reorganisation is planned at all.
+    refused before the day's transaction rows are processed.
     """
     with pytest.raises(
         CalculationError, match="is renamed to MID, and MID is renamed to NEW"
@@ -2384,18 +2383,10 @@ def test_a_reorganisation_is_not_a_disposal_row_of_its_own(
 
 
 def test_a_reorganised_holding_s_rename_day_is_still_read_row_by_row() -> None:
-    """Scaling a pool and renaming it do not commute, so the day keeps its order.
+    """A split day keeps the existing row-position handling of renames.
 
-    An ordinary rename day is read as one holding: what its names hold
-    together is what its sales may take, and what the day leaves under a name
-    it retires is gathered into the closing one as it closes. A day that also
-    restates the pool is left out of that, because where the restatement falls
-    among the day's rows is what decides the units it acts on.
-
-    So a purchase written under the old name after the rename row stays there,
-    as it does on `origin/main`, and the following month's sale of the whole
-    holding under the new name finds only the twenty units the rename carried
-    across.
+    The later purchase stays under OLD, so selling 25 NEW exceeds the 20
+    shares carried across by the rename.
     """
     with pytest.raises(InvalidTransactionError, match=r"available balance\(20\.0*\)"):
         run(


### PR DESCRIPTION
If a share changes ticker on the day you trade it, the calculator can reject your file even though you own enough shares. Whether it succeeds currently depends on the order of rows in the file and whether the sale uses the old or new ticker.

For example, you own 100 shares under the ticker `OLD`. Your broker records these events on the same date:

1. The ticker changes from `OLD` to `NEW`.
2. You sell 50 shares, recorded as `OLD`.
3. You buy 50 shares, recorded as `NEW`.

The calculator reads the rename first and moves all 100 shares to `NEW`. When it reaches the sale, it finds no shares under `OLD` and stops with "Tried to sell not owned symbol, reversed order?". These are still the same shares, but the calculator treats the old ticker as a holding you no longer own. It stops before calculating the gain.

This PR lets the initial checks count shares under both names as one holding for ordinary purchases and sales on the rename date, including shares bought that day. Each sale reduces the same available total, so using both names cannot let you sell the shares twice. The example can then reach the gain calculation regardless of row order or which ticker the sale uses, leaving 100 shares under `NEW`.

The holding still moves when the rename row is read. At the end of the day, any shares left under the old name are gathered under the new name, making them available for later trades.

The gain calculation already understands these ticker changes following #1097, which fixed #1050. This PR fixes the remaining rejection that prevented valid files from reaching that calculation; it does not change tax matching. Fixes #1094.

The change is limited to ordinary purchases and sales. Holdings with a same-day split, fee, gift, spouse transfer, or another action affecting their shares or cost keep their existing processing and may still encounter the row-order problem. A spin-off or excess reported income entry keeps the existing processing for the whole day. Rename chains, cycles, and conflicting destinations are rejected with an explanatory error before the day's transaction rows are processed.
