### PR TITLE
Build the report's view in Python and leave the template to print it

### DIFF
--- a/.harper-ignore.txt
+++ b/.harper-ignore.txt
@@ -43,6 +43,8 @@
 # "True on every one of them" counts the rows one at a time; Harper reads it
 # as the closed compound "everyone".
 ^model\.py:.*Everyone
+# "every one of those decisions" is two words; the Everyone rule misfires.
+^report_view\.py:.*Everyone
 # "how many candidates there are" is correct; ThereIsAgreement expects the noun
 # after the verb, but this construction puts it first.
 ^trading212\.py:.*ThereIsAgreement

--- a/cgt_calc/render_latex.py
+++ b/cgt_calc/render_latex.py
@@ -1,6 +1,5 @@
 """Render PDF report with LaTeX."""
 
-from decimal import Decimal
 import logging
 from pathlib import Path
 import shutil
@@ -15,7 +14,8 @@ from .const import LATEX_TEMPLATE_RESOURCE, PACKAGE_NAME
 from .exceptions import LatexRenderError, MissingExternalToolError
 from .logging import style_text
 from .model import CapitalGainsReport
-from .util import round_decimal, strip_zeros
+from .report_view import build_report_view
+from .util import strip_zeros
 
 LOGGER = logging.getLogger(__name__)
 
@@ -53,12 +53,11 @@ def render_pdf(
         loader=jinja2.PackageLoader(PACKAGE_NAME, "resources"),
         extensions=["jinja2.ext.loopcontrols"],
     )
+    latex_template_env.filters["money"] = "{:,}".format
     template = latex_template_env.get_template(LATEX_TEMPLATE_RESOURCE)
     output_text = template.render(
-        report=report,
-        round_decimal=round_decimal,
+        view=build_report_view(report),
         strip_zeros=strip_zeros,
-        Decimal=Decimal,
     )
 
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/cgt_calc/render_latex.py
+++ b/cgt_calc/render_latex.py
@@ -49,6 +49,7 @@ def render_pdf(
         line_statement_prefix="%%",
         line_comment_prefix="%#",
         trim_blocks=True,
+        lstrip_blocks=True,
         autoescape=False,
         loader=jinja2.PackageLoader(PACKAGE_NAME, "resources"),
         extensions=["jinja2.ext.loopcontrols"],

--- a/cgt_calc/report_view.py
+++ b/cgt_calc/report_view.py
@@ -1,0 +1,587 @@
+"""Typed view of a capital gains report, ready for a template to print.
+
+The calculation log names each event with a string key (``sell$FOO``,
+``excess-reported-income-distribution$FOO``), and the report's figures need
+rounding, counting and adding up before they can be printed. This module is
+the only place that does any of it: it decodes the keys, counts the events,
+keeps the running totals and rounds every figure exactly where the report
+shows it rounded.
+
+A template over the result is loops and substitutions. Every number here is a
+``Decimal`` already rounded the way the report prints it, so formatting
+(thousands separators, date formats) is all a renderer has left to decide.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from decimal import Decimal
+from enum import StrEnum
+from typing import TYPE_CHECKING, Final
+
+from .exceptions import CalculationError
+from .model import RuleType
+from .util import round_decimal
+
+if TYPE_CHECKING:
+    import datetime
+
+    from .model import CalculationEntry, CapitalGainsReport
+    from .stock_splits import StockSplitDetail
+
+
+class EventKind(StrEnum):
+    """Kind of capital gains event, decoded from its calculation log key."""
+
+    DISPOSAL = "disposal"
+    OPTION_GRANT = "option_grant"
+    GIFT_CONNECTED = "gift_connected"
+    GIFT_UNCONNECTED = "gift_unconnected"
+    ACQUISITION = "acquisition"
+    MANAGEMENT_FEE = "management_fee"
+    SPIN_OFF = "spin_off"
+    ERI = "eri"
+    RENAME = "rename"
+    SPLIT = "split"
+    TRANSFER_TO_SPOUSE = "transfer_to_spouse"
+    EXEMPT = "exempt"
+
+
+class Outcome(StrEnum):
+    """What a disposal came to, once its gain is rounded to the penny."""
+
+    GAIN = "gain"
+    NIL = "nil"
+    LOSS = "loss"
+    CLOGGED_LOSS = "clogged_loss"
+
+
+class IncomeKind(StrEnum):
+    """Kind of income event, decoded from its calculation log key."""
+
+    DIVIDEND = "dividend"
+    INTEREST = "interest"
+    INTEREST_TAX = "interest_tax"
+    ERI_DISTRIBUTION = "eri_distribution"
+
+
+@dataclass(frozen=True)
+class EriLineView:
+    """Excess reported income added to the cost of one acquisition."""
+
+    cost: Decimal
+    unit_price: Decimal
+    date: datetime.date
+
+
+@dataclass(frozen=True)
+class LineView:
+    """One matching rule applied within an event."""
+
+    rule: str
+    quantity: Decimal
+    new_quantity: Decimal
+    shows_proceeds: bool
+    is_gain: bool
+    proceeds: Decimal | None = None
+    cost: Decimal | None = None
+    bnb_date: datetime.date | None = None
+    gain: Decimal | None = None
+    amount: Decimal | None = None
+    new_pool_cost: Decimal | None = None
+    pool_per_unit: Decimal | None = None
+    spin_off_source: str | None = None
+    eris: tuple[EriLineView, ...] = ()
+
+
+@dataclass(frozen=True)
+class EventView:
+    """One symbol's events on one day, as the report presents them."""
+
+    kind: EventKind
+    symbol: str
+    is_disposal: bool
+    is_acquisition: bool
+    is_gift: bool
+    pool_units_left: bool
+    quantity: Decimal
+    fees: Decimal
+    lines: tuple[LineView, ...]
+    number: int | None = None
+    proceeds: Decimal | None = None
+    per_unit: Decimal | None = None
+    cost: Decimal | None = None
+    gain: Decimal | None = None
+    outcome: Outcome | None = None
+    gain_to_date: Decimal | None = None
+    loss_to_date: Decimal | None = None
+    gift_loss_to_date: Decimal | None = None
+    base_cost_passed: Decimal | None = None
+    eri_unit_price: Decimal | None = None
+    renamed_to: str | None = None
+    split: StockSplitDetail | None = None
+    spin_off_source: str | None = None
+    spin_off_dest: str | None = None
+    pool_quantity: Decimal | None = None
+    pool_cost: Decimal | None = None
+    pool_per_unit: Decimal | None = None
+
+
+@dataclass(frozen=True)
+class DayView:
+    """Capital gains events recorded on one day."""
+
+    date: datetime.date
+    events: tuple[EventView, ...]
+
+
+@dataclass(frozen=True)
+class IncomeEventView:
+    """One dividend, interest, interest tax or ERI distribution event."""
+
+    kind: IncomeKind
+    number: int
+    symbol: str
+    amount: Decimal
+    is_interest: bool
+    origin: str | None = None
+    tax_at_source: Decimal | None = None
+    treaty_country: str | None = None
+    treaty_rate: Decimal | None = None
+    treaty_amount: Decimal | None = None
+    unit_price: Decimal | None = None
+
+
+@dataclass(frozen=True)
+class IncomeDayView:
+    """Income events recorded on one day."""
+
+    date: datetime.date
+    events: tuple[IncomeEventView, ...]
+
+
+@dataclass(frozen=True)
+class SummaryView:
+    """Capital gains totals for the whole report."""
+
+    acquisition_count: int
+    disposal_count: int
+    disposal_proceeds: Decimal
+    total_gain: Decimal
+    total_loss: Decimal
+    gift_loss: Decimal
+    net_gain: Decimal
+    exempt_disposal_count: int
+    exempt_disposal_proceeds: Decimal
+
+
+@dataclass(frozen=True)
+class IncomeSummaryView:
+    """Dividend and interest totals for the whole report."""
+
+    dividend_count: int
+    interest_count: int
+    interest_tax_count: int
+    eri_count: int
+    total_dividends: Decimal
+    treaty_allowance: Decimal
+    dividend_allowance: Decimal
+    taxable_dividends: Decimal
+    uk_interest: Decimal
+    foreign_interest: Decimal
+    interest_tax: Decimal
+    eri_dividends: Decimal | None = None
+    eri_interest: Decimal | None = None
+
+
+@dataclass(frozen=True)
+class ReportView:
+    """The whole report, ready to print."""
+
+    title_period: str
+    days: tuple[DayView, ...]
+    income_days: tuple[IncomeDayView, ...]
+    summary: SummaryView
+    income_summary: IncomeSummaryView
+
+
+# Event kind by log key prefix, in the order the report has always tested
+# them: the first match wins.
+_EVENT_PREFIXES: Final = (
+    ("sell$", EventKind.DISPOSAL),
+    ("buy$", EventKind.ACQUISITION),
+    ("spin-off$", EventKind.SPIN_OFF),
+    ("excess-reported-income$", EventKind.ERI),
+    ("rename$", EventKind.RENAME),
+    ("split$", EventKind.SPLIT),
+    ("transfer-to-spouse$", EventKind.TRANSFER_TO_SPOUSE),
+    ("gift$", EventKind.GIFT_CONNECTED),
+    ("gift-unconnected$", EventKind.GIFT_UNCONNECTED),
+    ("exempt$", EventKind.EXEMPT),
+    ("option$", EventKind.OPTION_GRANT),
+)
+
+_GIFT_KINDS: Final = frozenset({EventKind.GIFT_CONNECTED, EventKind.GIFT_UNCONNECTED})
+_DISPOSAL_KINDS: Final = frozenset(
+    {EventKind.DISPOSAL, EventKind.OPTION_GRANT, *_GIFT_KINDS}
+)
+_ACQUISITION_KINDS: Final = frozenset({EventKind.ACQUISITION, EventKind.MANAGEMENT_FEE})
+# Events the report states in prose alone, with no list of matching rules.
+_WITHOUT_LINES: Final = frozenset(
+    {EventKind.RENAME, EventKind.SPLIT, EventKind.TRANSFER_TO_SPOUSE}
+)
+
+_UK_CURRENCY_CODE: Final = "GBP"
+
+
+def _total(entries: list[CalculationEntry], attribute: str) -> Decimal:
+    """Sum one attribute over the entries, in log order."""
+    return sum((getattr(entry, attribute) for entry in entries), Decimal(0))
+
+
+def _decode_event(key: str) -> tuple[EventKind, str]:
+    """Return the event kind a log key names, and the symbol it carries."""
+    for prefix, kind in _EVENT_PREFIXES:
+        if key.startswith(prefix):
+            return kind, key.split("$", maxsplit=1)[1]
+    raise CalculationError(f"Unknown calculation log key: {key}")
+
+
+def _decode_income(key: str) -> tuple[IncomeKind, str, str | None]:
+    """Return the income kind a log key names, its symbol and its origin.
+
+    Interest and interest tax are named after the currency they were paid in
+    rather than the broker, which is why they read the part of the key before
+    the ``$`` while the others read the part after it.
+    """
+    if key.startswith("dividend$"):
+        return IncomeKind.DIVIDEND, key.split("$", maxsplit=1)[1], None
+    if key.startswith("interestTax"):
+        currency = key.split("$", maxsplit=1)[0].removeprefix("interestTax")
+        origin = "UK" if currency == _UK_CURRENCY_CODE else "Foreign"
+        return IncomeKind.INTEREST_TAX, currency, origin
+    if key.startswith("interestUK$"):
+        return IncomeKind.INTEREST, key.split("$", maxsplit=1)[1], "UK"
+    if key.startswith("interest"):
+        return (
+            IncomeKind.INTEREST,
+            key.split("$", maxsplit=1)[0].removeprefix("interest"),
+            "Foreign",
+        )
+    if key.startswith("excess-reported-income-distribution$"):
+        return IncomeKind.ERI_DISTRIBUTION, key.split("$", maxsplit=1)[1], None
+    raise CalculationError(f"Unknown income log key: {key}")
+
+
+def _per_unit(amount: Decimal, quantity: Decimal) -> Decimal | None:
+    """Price per unit, or None when there are no units to divide by."""
+    if quantity == 0:
+        return None
+    return round_decimal(amount / quantity, 2)
+
+
+def _build_line(
+    entry: CalculationEntry, kind: EventKind, overall_quantity: Decimal
+) -> LineView:
+    """Build the view of one matching rule within an event."""
+    is_acquisition = kind in _ACQUISITION_KINDS
+    spin_off = entry.spin_off
+    shows_spin_off = spin_off is not None and (
+        is_acquisition or kind is EventKind.SPIN_OFF
+    )
+    return LineView(
+        rule=entry.rule_type.name.replace("_", " "),
+        quantity=entry.quantity,
+        new_quantity=entry.new_quantity,
+        shows_proceeds=entry.quantity < overall_quantity,
+        is_gain=entry.gain > 0,
+        proceeds=round_decimal(entry.amount + entry.fees, 2),
+        cost=round_decimal(entry.allowable_cost, 2),
+        bnb_date=(
+            entry.bed_and_breakfast_date_index
+            if entry.rule_type is RuleType.BED_AND_BREAKFAST
+            else None
+        ),
+        gain=round_decimal(entry.gain, 2),
+        amount=round_decimal(-entry.amount, 2),
+        new_pool_cost=round_decimal(entry.new_pool_cost, 2),
+        pool_per_unit=_per_unit(entry.new_pool_cost, entry.new_quantity),
+        spin_off_source=spin_off.source if shows_spin_off and spin_off else None,
+        eris=tuple(
+            EriLineView(
+                cost=round_decimal(eri.price * entry.quantity, 2),
+                unit_price=round_decimal(eri.price, 4),
+                date=eri.date,
+            )
+            for eri in entry.eris
+        )
+        if is_acquisition
+        else (),
+    )
+
+
+@dataclass
+class _Totals:
+    """Running counts and totals kept while walking the calculation log."""
+
+    total_gain: Decimal = Decimal(0)
+    total_loss: Decimal = Decimal(0)
+    gift_loss: Decimal = Decimal(0)
+    acquisitions: int = 0
+    disposals: int = 0
+    dividends: int = 0
+    interests: int = 0
+    interest_taxes: int = 0
+    eris: int = 0
+
+
+def _with_disposal(
+    event: EventView, entries: list[CalculationEntry], totals: _Totals
+) -> EventView:
+    """Add the proceeds, gain, outcome and running total of a disposal.
+
+    Exempt disposals share the arithmetic but count towards nothing: an exempt
+    asset is neither a chargeable disposal nor part of any total.
+    """
+    proceeds = round_decimal(_total(entries, "amount") + _total(entries, "fees"), 2)
+    gain = round_decimal(_total(entries, "gain"), 2)
+    event = replace(
+        event,
+        proceeds=proceeds,
+        gain=gain,
+        per_unit=(
+            None
+            if event.kind is EventKind.OPTION_GRANT
+            else _per_unit(proceeds, event.quantity)
+        ),
+    )
+    if event.is_disposal:
+        totals.disposals += 1
+        event = replace(event, number=totals.disposals)
+    if gain > 0:
+        if not event.is_disposal:
+            return replace(event, outcome=Outcome.GAIN)
+        totals.total_gain += gain
+        return replace(event, outcome=Outcome.GAIN, gain_to_date=totals.total_gain)
+    if gain == 0:
+        return replace(event, outcome=Outcome.NIL)
+    if event.kind is EventKind.GIFT_CONNECTED:
+        totals.gift_loss -= gain
+        return replace(
+            event, outcome=Outcome.CLOGGED_LOSS, gift_loss_to_date=totals.gift_loss
+        )
+    if not event.is_disposal:
+        return replace(event, outcome=Outcome.LOSS)
+    totals.total_loss -= gain
+    return replace(event, outcome=Outcome.LOSS, loss_to_date=totals.total_loss)
+
+
+def _with_pool_after(event: EventView, entry: CalculationEntry) -> EventView:
+    """Add the pool the event leaves behind, as the report states it."""
+    return replace(
+        event,
+        pool_quantity=entry.new_quantity,
+        pool_cost=round_decimal(entry.new_pool_cost, 2),
+        pool_per_unit=_per_unit(entry.new_pool_cost, entry.new_quantity),
+    )
+
+
+def _with_kind_fields(
+    event: EventView, entries: list[CalculationEntry], totals: _Totals
+) -> EventView:
+    """Add the fields only this kind of event carries."""
+    kind = event.kind
+    if event.is_disposal or kind is EventKind.EXEMPT:
+        return _with_disposal(event, entries, totals)
+    if kind is EventKind.RENAME:
+        return replace(
+            event,
+            renamed_to=entries[0].renamed_to,
+            cost=round_decimal(entries[0].allowable_cost, 2),
+        )
+    if kind is EventKind.SPLIT:
+        return _with_pool_after(
+            replace(event, split=entries[0].stock_split), entries[0]
+        )
+    if kind is EventKind.TRANSFER_TO_SPOUSE:
+        return _with_pool_after(
+            replace(
+                event,
+                base_cost_passed=round_decimal(_total(entries, "allowable_cost"), 2),
+            ),
+            entries[-1],
+        )
+    # What is left states the cost the event added to the pool.
+    cost = round_decimal(entries[0].allowable_cost, 2)
+    if kind is EventKind.MANAGEMENT_FEE:
+        return replace(event, cost=cost)
+    if kind is EventKind.ACQUISITION:
+        totals.acquisitions += 1
+        return replace(
+            event,
+            cost=cost,
+            number=totals.acquisitions,
+            per_unit=_per_unit(cost, event.quantity),
+        )
+    if kind is EventKind.SPIN_OFF:
+        spin_off = entries[0].spin_off
+        assert spin_off is not None
+        number = None
+        if event.quantity > 0:
+            totals.acquisitions += 1
+            number = totals.acquisitions
+        return replace(
+            event,
+            cost=cost,
+            number=number,
+            spin_off_source=spin_off.source,
+            spin_off_dest=spin_off.dest,
+        )
+    return replace(
+        event, cost=cost, eri_unit_price=round_decimal(entries[0].eris[0].price, 4)
+    )
+
+
+def _build_event(
+    key: str, entries: list[CalculationEntry], totals: _Totals
+) -> EventView:
+    """Build the view of every entry logged for one symbol on one day."""
+    kind, symbol = _decode_event(key)
+    quantity = _total(entries, "quantity")
+    if kind is EventKind.ACQUISITION and quantity <= 0:
+        kind = EventKind.MANAGEMENT_FEE
+    is_disposal = kind in _DISPOSAL_KINDS
+    event = EventView(
+        kind=kind,
+        symbol=symbol,
+        is_disposal=is_disposal,
+        is_acquisition=kind in _ACQUISITION_KINDS,
+        is_gift=kind in _GIFT_KINDS,
+        pool_units_left=is_disposal or kind is EventKind.EXEMPT,
+        quantity=quantity,
+        fees=round_decimal(_total(entries, "fees"), 2),
+        lines=()
+        if kind in _WITHOUT_LINES
+        else tuple(_build_line(entry, kind, quantity) for entry in entries),
+    )
+    return _with_kind_fields(event, entries, totals)
+
+
+def _build_income_event(
+    key: str, entries: list[CalculationEntry], totals: _Totals
+) -> IncomeEventView:
+    """Build the view of one income event."""
+    kind, symbol, origin = _decode_income(key)
+    entry = entries[0]
+    amount = round_decimal(entry.amount, 2)
+
+    if kind is IncomeKind.DIVIDEND:
+        dividend = entry.dividend
+        assert dividend is not None
+        totals.dividends += 1
+        treaty = dividend.tax_treaty
+        return IncomeEventView(
+            kind=kind,
+            number=totals.dividends,
+            symbol=symbol,
+            amount=amount,
+            is_interest=dividend.is_interest,
+            tax_at_source=round_decimal(-dividend.tax_at_source, 2),
+            treaty_country=treaty.country if treaty is not None else None,
+            treaty_rate=(
+                round_decimal(100 * treaty.treaty_rate, 2)
+                if treaty is not None
+                else None
+            ),
+            treaty_amount=(
+                round_decimal(dividend.tax_treaty_amount, 2)
+                if treaty is not None
+                else None
+            ),
+        )
+    if kind is IncomeKind.ERI_DISTRIBUTION:
+        eri = entry.eris[0]
+        totals.eris += 1
+        return IncomeEventView(
+            kind=kind,
+            number=totals.eris,
+            symbol=symbol,
+            amount=amount,
+            is_interest=eri.is_interest,
+            unit_price=round_decimal(eri.price, 4),
+        )
+    if kind is IncomeKind.INTEREST:
+        totals.interests += 1
+        number = totals.interests
+    else:
+        totals.interest_taxes += 1
+        number = totals.interest_taxes
+    return IncomeEventView(
+        kind=kind,
+        number=number,
+        symbol=symbol,
+        amount=amount,
+        is_interest=False,
+        origin=origin,
+    )
+
+
+def build_report_view(report: CapitalGainsReport) -> ReportView:
+    """Build the printable view of a finished report."""
+    totals = _Totals()
+    days = tuple(
+        DayView(
+            date=date,
+            events=tuple(
+                _build_event(key, entries, totals) for key, entries in symbols.items()
+            ),
+        )
+        for date, symbols in report.calculation_log.items()
+    )
+    income_days = tuple(
+        IncomeDayView(
+            date=date,
+            events=tuple(
+                _build_income_event(key, entries, totals)
+                for key, entries in symbols.items()
+            ),
+        )
+        for date, symbols in report.calculation_log_yields.items()
+    )
+    eri_dividends = report.total_eri_amount(is_interest=False)
+    eri_interest = report.total_eri_amount(is_interest=True)
+    return ReportView(
+        title_period=report.title_period,
+        days=days,
+        income_days=income_days,
+        summary=SummaryView(
+            acquisition_count=totals.acquisitions,
+            disposal_count=totals.disposals,
+            disposal_proceeds=report.disposal_proceeds,
+            total_gain=totals.total_gain,
+            total_loss=totals.total_loss,
+            gift_loss=totals.gift_loss,
+            net_gain=totals.total_gain - totals.total_loss,
+            exempt_disposal_count=report.exempt_disposal_count,
+            exempt_disposal_proceeds=report.exempt_disposal_proceeds,
+        ),
+        income_summary=IncomeSummaryView(
+            dividend_count=totals.dividends,
+            interest_count=totals.interests,
+            interest_tax_count=totals.interest_taxes,
+            eri_count=totals.eris,
+            total_dividends=round_decimal(report.total_dividends_amount(), 2),
+            eri_dividends=(
+                round_decimal(eri_dividends, 2) if eri_dividends > 0 else None
+            ),
+            treaty_allowance=round_decimal(
+                report.total_dividend_taxes_in_tax_treaties_amount(), 2
+            ),
+            dividend_allowance=round_decimal(report.dividend_allowance or Decimal(), 2),
+            taxable_dividends=round_decimal(report.total_dividend_taxable_gain(), 2),
+            uk_interest=report.total_uk_interest,
+            foreign_interest=report.total_foreign_interest,
+            eri_interest=(round_decimal(eri_interest, 2) if eri_interest > 0 else None),
+            interest_tax=report.total_interest_tax,
+        ),
+    )

--- a/cgt_calc/report_view.py
+++ b/cgt_calc/report_view.py
@@ -2,10 +2,11 @@
 
 The calculation log names each event with a string key (``sell$FOO``,
 ``excess-reported-income-distribution$FOO``), and the report's figures need
-rounding, counting and adding up before they can be printed. This module is
-the only place that does any of it: it decodes the keys, counts the events,
-keeps the running totals and rounds every figure exactly where the report
-shows it rounded.
+rounding, counting and adding up before they can be printed. This module makes
+every one of those decisions for the detailed report: it decodes the keys,
+counts the events, keeps the running totals and rounds every figure exactly
+where the report shows it rounded. (The terminal summary in ``render_text``
+still reads the gift and spouse-transfer keys for itself.)
 
 A template over the result is loops and substitutions. Every number here is a
 ``Decimal`` already rounded the way the report prints it, so formatting

--- a/cgt_calc/resources/template.tex.j2
+++ b/cgt_calc/resources/template.tex.j2
@@ -3,261 +3,208 @@
 \usepackage[a4paper, margin=3cm]{geometry}
 \setlength{\parindent}{0pt} %--don't indent paragraphs
 \begin{document}
-\centerline{\Large\bfseries Capital Gains Tax Calculations for \VAR{ report.title_period }}
+\centerline{\Large\bfseries Capital Gains Tax Calculations for \VAR{ view.title_period }}
 
-\BLOCK{ set total_gain = namespace(value=Decimal(0)) }
-\BLOCK{ set total_loss = namespace(value=Decimal(0)) }
-\BLOCK{ set gift_loss = namespace(value=Decimal(0)) }
-\BLOCK{ set acquisition_count = namespace(value=0) }
-\BLOCK{ set disposal_count = namespace(value=0) }
-\BLOCK{ set dividend_count = namespace(value=0) }
-\BLOCK{ set interest_count = namespace(value=0) }
-\BLOCK{ set interest_tax_count = namespace(value=0) }
-\BLOCK{ set eri_count = namespace(value=0) }
 
 \section*{Capital Gains Events}
 
-\BLOCK{ for date_index, symbol_dict in report.calculation_log.items() }
+\BLOCK{ for day in view.days }
 
-\subsection*{\VAR{ date_index.strftime("%d %B %Y") }}
-\BLOCK{ for symbol, entries in symbol_dict.items() }
-\BLOCK{ if symbol.startswith("sell$") }
-    \BLOCK{ set symbol = symbol[5:] }
-    \BLOCK{ set is_disposal = True }
-\BLOCK{ elif symbol.startswith("buy$") }
-    \BLOCK{ set symbol = symbol[4:] }
-    \BLOCK{ set is_aquisition = True }
-\BLOCK{ elif symbol.startswith("spin-off$") }
-    \BLOCK{ set symbol = symbol[9:] }
-    \BLOCK{ set is_spin_off = True }
-\BLOCK{ elif symbol.startswith("excess-reported-income$") }
-    \BLOCK{ set symbol = symbol[23:] }
-    \BLOCK{ set is_eri = True }
-\BLOCK{ elif symbol.startswith("rename$") }
-    \BLOCK{ set symbol = symbol[7:] }
-    \BLOCK{ set is_rename = True }
-\BLOCK{ elif symbol.startswith("split$") }
-    \BLOCK{ set symbol = symbol[6:] }
-    \BLOCK{ set is_split = True }
-\BLOCK{ elif symbol.startswith("transfer-to-spouse$") }
-    \BLOCK{ set symbol = symbol[19:] }
-    \BLOCK{ set is_transfer_to_spouse = True }
-\BLOCK{ elif symbol.startswith("gift$") }
-    \BLOCK{ set symbol = symbol[5:] }
-    \BLOCK{ set is_disposal = True }
-    \BLOCK{ set is_gift = True }
-    \BLOCK{ set is_clogged = True }
-\BLOCK{ elif symbol.startswith("gift-unconnected$") }
-    \BLOCK{ set symbol = symbol[17:] }
-    \BLOCK{ set is_disposal = True }
-    \BLOCK{ set is_gift = True }
-\BLOCK{ elif symbol.startswith("exempt$") }
-    \BLOCK{ set symbol = symbol[7:] }
-    \BLOCK{ set is_exempt = True }
-\BLOCK{ elif symbol.startswith("option$") }
-    \BLOCK{ set symbol = symbol[7:] }
-    \BLOCK{ set is_disposal = True }
-    \BLOCK{ set is_option = True }
-\BLOCK{ endif }
-\BLOCK{ set overall_quantity = entries|sum(attribute="quantity") }
-\BLOCK{ set overall_fees = round_decimal(entries|sum(attribute="fees"), 2) }
-\BLOCK{ if is_disposal }
-    \BLOCK{ set overall_disposed = round_decimal(entries|sum(attribute="amount") + entries|sum(attribute="fees"), 2) }
-    \BLOCK{ set overall_gain = round_decimal(entries|sum(attribute="gain"), 2) }
-    \BLOCK{ set disposal_count.value = disposal_count.value + 1 }
-    \BLOCK{ if is_option }
-        \subsubsection*{
-            Disposal \VAR{ disposal_count.value }: grant of \VAR{ strip_zeros(overall_quantity) }
-            contract\BLOCK{ if overall_quantity != 1 }s\BLOCK{ endif } of the \VAR{ symbol }
-            for £\VAR{ "{:,}".format(overall_disposed) }
+\subsection*{\VAR{ day.date.strftime("%d %B %Y") }}
+\BLOCK{ for event in day.events }
+\#{ A tag's own indentation reaches the output, so the layout below is part
+    of the report and the .tex goldens pin it. }
+        \BLOCK{ if event.is_disposal }
+                \BLOCK{ if event.kind == "option_grant" }
+            \subsubsection*{
+            Disposal \VAR{ event.number }: grant of \VAR{ strip_zeros(event.quantity) }
+            contract\BLOCK{ if event.quantity != 1 }s\BLOCK{ endif } of the \VAR{ event.symbol }
+            for £\VAR{ event.proceeds|money }
         }
     \BLOCK{ else }
+\#{ A gift's heading is indented further than a sale's, a connected
+    person's further still. }
+\BLOCK{ if event.is_gift }    \BLOCK{ if event.kind == "gift_connected" }    \BLOCK{ endif }\BLOCK{ endif }
         \subsubsection*{
-            Disposal \VAR{ disposal_count.value }: \VAR{ strip_zeros(overall_quantity) } units of \VAR{ symbol }
-            \BLOCK{ if is_gift }given away at a market value of\BLOCK{ else }for\BLOCK{ endif } £\VAR{ "{:,}".format(overall_disposed) }
-            (£\VAR{ "{:,}".format(round_decimal(overall_disposed/overall_quantity, 2)) }/unit)%
-            \BLOCK{ if overall_fees > 0 }
-                , £\VAR{ "{:,}".format(overall_fees) } fees allowed as cost
+            Disposal \VAR{ event.number }: \VAR{ strip_zeros(event.quantity) } units of \VAR{ event.symbol }
+            \BLOCK{ if event.is_gift }given away at a market value of\BLOCK{ else }for\BLOCK{ endif } £\VAR{ event.proceeds|money }
+            (£\VAR{ event.per_unit|money }/unit)%
+            \BLOCK{ if event.fees > 0 }
+                , £\VAR{ event.fees|money } fees allowed as cost
             \BLOCK{ endif }
         }
     \BLOCK{ endif }
-    \BLOCK{ if overall_gain > 0 -}
-        Chargeable \textbf{gain} is £\VAR{ "{:,}".format(overall_gain) }\BLOCK{ if is_gift }, before any relief:
+    \BLOCK{ if event.outcome == "gain" -}
+        Chargeable \textbf{gain} is £\VAR{ event.gain|money }\BLOCK{ if event.is_gift }, before any relief:
         a gift of shares that qualify for Gift Hold-over Relief has the gain deferred by a joint claim on your returns\BLOCK{ endif }
 
-        \BLOCK{ set total_gain.value = total_gain.value + overall_gain }
-        Capital gain to date is £\VAR{ "{:,}".format(total_gain.value) }
-    \BLOCK{ elif overall_gain == 0 }
+                Capital gain to date is £\VAR{ event.gain_to_date|money }
+    \BLOCK{ elif event.outcome == "nil" }
         Neither a gain nor a loss.
-    \BLOCK{ elif is_clogged }
-        \textbf{Clogged loss} of £\VAR{ "{:,}".format(-overall_gain) } on a gift, kept out of the loss total:
+    \BLOCK{ elif event.outcome == "clogged_loss" }
+        \textbf{Clogged loss} of £\VAR{ (-event.gain)|money } on a gift, kept out of the loss total:
         a loss on a gift to a connected person can only be set against gains on disposals to the same person while still connected (TCGA 1992 s18(3)).
 
-        \BLOCK{ set gift_loss.value = gift_loss.value - overall_gain }
-        Losses on gifts to date are £\VAR{ "{:,}".format(gift_loss.value) }
+                Losses on gifts to date are £\VAR{ event.gift_loss_to_date|money }
     \BLOCK{ else }
-        Chargeable \textbf{loss} is £\VAR{ "{:,}".format(-overall_gain) }
+        Chargeable \textbf{loss} is £\VAR{ (-event.gain)|money }
 
-        \BLOCK{ set total_loss.value = total_loss.value - overall_gain }
-        Capital loss to date is £\VAR{ "{:,}".format(total_loss.value) }
+                Capital loss to date is £\VAR{ event.loss_to_date|money }
     \BLOCK{ endif }
-\BLOCK{ elif is_aquisition } % if is_aquisition
-    \BLOCK{ set acquisition_cost = round_decimal(entries[0].allowable_cost, 2) }
-    \BLOCK{ if overall_quantity > 0 }
-        \BLOCK{ set acquisition_count.value = acquisition_count.value + 1 }
-        \subsubsection*{
-            Acquisition \VAR{ acquisition_count.value }: \VAR{ strip_zeros(overall_quantity) } units of \VAR{ symbol } for £\VAR{ "{:,}".format(acquisition_cost) }
-            (£\VAR{ "{:,}".format(round_decimal(acquisition_cost/overall_quantity, 2)) }/unit)%
-            \BLOCK{ if overall_fees > 0 }
-                , including £\VAR{ "{:,}".format(overall_fees) } fees
+\BLOCK{ elif event.kind == "acquisition" }
+ % if is_aquisition
+                        \subsubsection*{
+            Acquisition \VAR{ event.number }: \VAR{ strip_zeros(event.quantity) } units of \VAR{ event.symbol } for £\VAR{ event.cost|money }
+            (£\VAR{ event.per_unit|money }/unit)%
+            \BLOCK{ if event.fees > 0 }
+                , including £\VAR{ event.fees|money } fees
             \BLOCK{ endif }
         }
-    \BLOCK{ else }
-        \subsubsection*{Management fee for \VAR{ symbol } of £\VAR{ "{:,}".format(acquisition_cost) }}
-    \BLOCK{ endif}
-\BLOCK{ elif is_spin_off } % if is_spin_off
-    \BLOCK{ set acquisition_cost = round_decimal(entries[0].allowable_cost, 2) }
-    \BLOCK{ if overall_quantity > 0 }
-        \BLOCK{ set acquisition_count.value = acquisition_count.value + 1 }
-        \subsubsection*{
-            Spin-off adjustment \VAR{ acquisition_count.value }: \VAR{ entries[0].spin_off.source } cost adjusted because of \VAR{ entries[0].spin_off.dest } shares spinned off
+    \BLOCK{ elif event.kind == "management_fee" }
+ % if is_aquisition
+                \subsubsection*{Management fee for \VAR{ event.symbol } of £\VAR{ event.cost|money }}
+    \BLOCK{ elif event.kind == "spin_off" }
+ % if is_spin_off
+    \BLOCK{ if event.quantity > 0 }
+                    \subsubsection*{
+            Spin-off adjustment \VAR{ event.number }: \VAR{ event.spin_off_source } cost adjusted because of \VAR{ event.spin_off_dest } shares spinned off
         }
     \BLOCK{ endif }
-\BLOCK{ elif is_eri } % if is_eri
-    \BLOCK{ set acquisition_cost = round_decimal(entries[0].allowable_cost, 2) }
-    \BLOCK{ if overall_quantity > 0 }
-        \subsubsection*{
-            Excess Reported Income: \VAR{ symbol } cost increased by £\VAR{ "{:,}".format(acquisition_cost) }
-            (£\VAR{ "{:,}".format(round_decimal(entries[0].eris[0].price, 4)) }/unit)%
+\BLOCK{ elif event.kind == "eri" }
+ % if is_eri
+    \BLOCK{ if event.quantity > 0 }
+            \subsubsection*{
+            Excess Reported Income: \VAR{ event.symbol } cost increased by £\VAR{ event.cost|money }
+            (£\VAR{ event.eri_unit_price|money }/unit)%
         }
     \BLOCK{ endif }
-\BLOCK{ elif is_rename } % if is_rename
+\BLOCK{ elif event.kind == "rename" }
+ % if is_rename
     \subsubsection*{
-        \VAR{ symbol } was renamed to \VAR{ entries[0].renamed_to }%
-        \BLOCK{ if entries[0].quantity > 0 }
-            : \VAR{ strip_zeros(entries[0].quantity) } units with pool cost £\VAR{ "{:,}".format(round_decimal(entries[0].allowable_cost, 2)) } transferred
+        \VAR{ event.symbol } was renamed to \VAR{ event.renamed_to }%
+        \BLOCK{ if event.quantity > 0 }
+            : \VAR{ strip_zeros(event.quantity) } units with pool cost £\VAR{ event.cost|money } transferred
         \BLOCK{ endif }
     }
-\BLOCK{ elif is_split } % if is_split
-    \BLOCK{ set split = entries[0].stock_split }
-    \subsubsection*{
-        Share reorganisation: \VAR{ strip_zeros(split.day_open_quantity) } units of \VAR{ symbol } restated as \VAR{ strip_zeros(split.scaled_day_open_quantity) } (ratio \VAR{ split.ratio_description })
+\BLOCK{ elif event.kind == "split" }
+ % if is_split
+        \subsubsection*{
+        Share reorganisation: \VAR{ strip_zeros(event.split.day_open_quantity) } units of \VAR{ event.symbol } restated as \VAR{ strip_zeros(event.split.scaled_day_open_quantity) } (ratio \VAR{ event.split.ratio_description })
     }
     Neither a disposal nor an acquisition: the new holding is the same asset, held from the same dates, with the same pooled cost (TCGA 1992 s127).
 
-    Stated as \VAR{ strip_zeros(split.broker_before_quantity) } units before the event and \VAR{ strip_zeros(split.broker_after_quantity) } after.
-    \BLOCK{ if split.reconciliation_delta != 0 }
+    Stated as \VAR{ strip_zeros(event.split.broker_before_quantity) } units before the event and \VAR{ strip_zeros(event.split.broker_after_quantity) } after.
+    \BLOCK{ if event.split.reconciliation_delta != 0 }
 
-        Reconciled to that count by \VAR{ strip_zeros(split.reconciliation_delta) } units, from \VAR{ strip_zeros(split.quantity_before_reconciliation) } to \VAR{ strip_zeros(split.quantity_after_reconciliation) }.
+        Reconciled to that count by \VAR{ strip_zeros(event.split.reconciliation_delta) } units, from \VAR{ strip_zeros(event.split.quantity_before_reconciliation) } to \VAR{ strip_zeros(event.split.quantity_after_reconciliation) }.
     \BLOCK{ endif }
 
-    Units in the pool at this point in the day: \VAR{ strip_zeros(entries[0].new_quantity) }%
-    \BLOCK{ if entries[0].new_quantity > 0 },
-        pool cost: £\VAR{ "{:,}".format(round_decimal(entries[0].new_pool_cost, 2)) }
-        (£\VAR{ "{:,}".format(round_decimal(entries[0].new_pool_cost/entries[0].new_quantity, 2)) }/unit)%
+    Units in the pool at this point in the day: \VAR{ strip_zeros(event.pool_quantity) }%
+    \BLOCK{ if event.pool_quantity > 0 },
+        pool cost: £\VAR{ event.pool_cost|money }
+        (£\VAR{ event.pool_per_unit|money }/unit)%
     \BLOCK{ endif }.
-\BLOCK{ elif is_transfer_to_spouse } % if is_transfer_to_spouse
+\BLOCK{ elif event.kind == "transfer_to_spouse" }
+ % if is_transfer_to_spouse
     \subsubsection*{
-        Transferred to spouse: \VAR{ strip_zeros(overall_quantity) } units of \VAR{ symbol } (no gain/no loss)
+        Transferred to spouse: \VAR{ strip_zeros(event.quantity) } units of \VAR{ event.symbol } (no gain/no loss)
     }
-    Base cost of £\VAR{ "{:,}".format(round_decimal(entries|sum(attribute="allowable_cost"), 2)) } passes to the recipient.
+    Base cost of £\VAR{ event.base_cost_passed|money } passes to the recipient.
 
-    \BLOCK{ set pool = entries[-1] }
-    Number of units left in the pool: \VAR{ strip_zeros(pool.new_quantity) }%
-    \BLOCK{ if pool.new_quantity > 0 },
-        new pool cost: £\VAR{ "{:,}".format(round_decimal(pool.new_pool_cost, 2)) }
-        (£\VAR{ "{:,}".format(round_decimal(pool.new_pool_cost/pool.new_quantity, 2)) }/unit)%
+        Number of units left in the pool: \VAR{ strip_zeros(event.pool_quantity) }%
+    \BLOCK{ if event.pool_quantity > 0 },
+        new pool cost: £\VAR{ event.pool_cost|money }
+        (£\VAR{ event.pool_per_unit|money }/unit)%
     \BLOCK{ endif }.
-\BLOCK{ elif is_exempt } % if is_exempt
-    \BLOCK{ set overall_disposed = round_decimal(entries|sum(attribute="amount") + entries|sum(attribute="fees"), 2) }
-    \BLOCK{ set overall_gain = round_decimal(entries|sum(attribute="gain"), 2) }
-    \subsubsection*{
-        Exempt disposal: \VAR{ strip_zeros(overall_quantity) } units of \VAR{ symbol } valued at £\VAR{ "{:,}".format(overall_disposed) }
-        (£\VAR{ "{:,}".format(round_decimal(overall_disposed/overall_quantity, 2)) }/unit)%
-        \BLOCK{ if overall_fees > 0 }
-            , £\VAR{ "{:,}".format(overall_fees) } disposal expenses included in the illustrative calculation
+\BLOCK{ elif event.kind == "exempt" }
+ % if is_exempt
+            \subsubsection*{
+        Exempt disposal: \VAR{ strip_zeros(event.quantity) } units of \VAR{ event.symbol } valued at £\VAR{ event.proceeds|money }
+        (£\VAR{ event.per_unit|money }/unit)%
+        \BLOCK{ if event.fees > 0 }
+            , £\VAR{ event.fees|money } disposal expenses included in the illustrative calculation
         \BLOCK{ endif }
     }
     The cost and disposal expenses shown below are used for this illustrative calculation only;
     they are not allowable deductions against other gains.
 
-    \BLOCK{ if overall_gain > 0 -}
-        Gain is £\VAR{ "{:,}".format(overall_gain) }; the gain or loss is disregarded (exempt asset).
-    \BLOCK{ elif overall_gain == 0 }
+    \BLOCK{ if event.outcome == "gain" -}
+        Gain is £\VAR{ event.gain|money }; the gain or loss is disregarded (exempt asset).
+    \BLOCK{ elif event.outcome == "nil" }
         Neither a gain nor a loss; the gain or loss is disregarded (exempt asset).
     \BLOCK{ else }
-        Loss is £\VAR{ "{:,}".format(-overall_gain) }; the gain or loss is disregarded (exempt asset).
+        Loss is £\VAR{ (-event.gain)|money }; the gain or loss is disregarded (exempt asset).
     \BLOCK{ endif }
 \BLOCK{ endif }
 
-\BLOCK{ if not is_rename and not is_transfer_to_spouse and not is_split }
+\BLOCK{ if event.lines }
 \begin{enumerate}
-\BLOCK{ for entry in entries }
-\item \textbf{\VAR{ entry.rule_type.name.replace("_", " ") }}. Quantity: \VAR{ strip_zeros(entry.quantity) },
-\BLOCK{ if is_disposal }
-    \BLOCK{ if entry.quantity < overall_quantity }
-        disposal proceeds: £\VAR{ "{:,}".format(round_decimal(entry.amount + entry.fees, 2)) },
+\BLOCK{ for line in event.lines }
+\item \textbf{\VAR{ line.rule }}. Quantity: \VAR{ strip_zeros(line.quantity) },
+\BLOCK{ if event.is_disposal }
+    \BLOCK{ if line.shows_proceeds }
+        disposal proceeds: £\VAR{ line.proceeds|money },
     \BLOCK{ endif }
     allowable
-    \BLOCK{ if entry.rule_type.name == "BED_AND_BREAKFAST" }
-        cost on \mbox{\VAR{ entry.bed_and_breakfast_date_index.strftime("%d %b %Y") }:}
+    \BLOCK{ if line.bnb_date }
+        cost on \mbox{\VAR{ line.bnb_date.strftime("%d %b %Y") }:}
     \BLOCK{ else }
         cost:
     \BLOCK{ endif }
-    £\VAR{ "{:,}".format(round_decimal(entry.allowable_cost, 2)) },
-    \BLOCK{ if entry.gain > 0}
-        \mbox{gain: £\VAR{ "{:,}".format(round_decimal(entry.gain, 2)) }.}
+    £\VAR{ line.cost|money },
+    \BLOCK{ if line.is_gain }
+        \mbox{gain: £\VAR{ line.gain|money }.}
     \BLOCK{ else }
-        \mbox{loss: £\VAR{ "{:,}".format(round_decimal(-entry.gain, 2)) }.}
+        \mbox{loss: £\VAR{ (-line.gain)|money }.}
     \BLOCK{ endif }
-\BLOCK{ elif is_exempt }
-    \BLOCK{ if entry.quantity < overall_quantity }
-        disposal proceeds: £\VAR{ "{:,}".format(round_decimal(entry.amount + entry.fees, 2)) },
+\BLOCK{ elif event.kind == "exempt" }
+    \BLOCK{ if line.shows_proceeds }
+        disposal proceeds: £\VAR{ line.proceeds|money },
     \BLOCK{ endif }
     cost used for this illustrative
-    \BLOCK{ if entry.rule_type.name == "BED_AND_BREAKFAST" }
-        calculation on \mbox{\VAR{ entry.bed_and_breakfast_date_index.strftime("%d %b %Y") }:}
+    \BLOCK{ if line.bnb_date }
+        calculation on \mbox{\VAR{ line.bnb_date.strftime("%d %b %Y") }:}
     \BLOCK{ else }
         calculation:
     \BLOCK{ endif }
-    £\VAR{ "{:,}".format(round_decimal(entry.allowable_cost, 2)) },
-    \BLOCK{ if entry.gain > 0}
-        \mbox{disregarded gain: £\VAR{ "{:,}".format(round_decimal(entry.gain, 2)) }.}
+    £\VAR{ line.cost|money },
+    \BLOCK{ if line.is_gain }
+        \mbox{disregarded gain: £\VAR{ line.gain|money }.}
     \BLOCK{ else }
-        \mbox{disregarded loss: £\VAR{ "{:,}".format(round_decimal(-entry.gain, 2)) }.}
+        \mbox{disregarded loss: £\VAR{ (-line.gain)|money }.}
     \BLOCK{ endif }
-\BLOCK{ elif is_spin_off }
-    original cost of \VAR{ entry.spin_off.source }: £\VAR{ "{:,}".format(round_decimal(-entry.amount, 2))}, after spin-off: £\VAR{ "{:,}".format(round_decimal(entry.new_pool_cost, 2))}
-\BLOCK{ elif is_eri }
-    original cost of \VAR{ symbol }: £\VAR{ "{:,}".format(round_decimal(-entry.amount, 2))}, after income distribution: £\VAR{ "{:,}".format(round_decimal(entry.new_pool_cost, 2))}%
-\BLOCK{ else } % if is_aquisition
-    actual cost: £\VAR{ "{:,}".format(round_decimal(-entry.amount, 2)) }.
+\BLOCK{ elif event.kind == "spin_off" }
+    original cost of \VAR{ line.spin_off_source }: £\VAR{ line.amount|money }, after spin-off: £\VAR{ line.new_pool_cost|money }
+\BLOCK{ elif event.kind == "eri" }
+    original cost of \VAR{ event.symbol }: £\VAR{ line.amount|money }, after income distribution: £\VAR{ line.new_pool_cost|money }%
+\BLOCK{ else }
+ % if is_aquisition
+    actual cost: £\VAR{ line.amount|money }.
 \BLOCK{ endif}
 
-\BLOCK{ if is_option }
+\BLOCK{ if event.kind == "option_grant" }
     The option grant does not change the Section 104 holding of the underlying shares.
 \BLOCK{ else }
-\BLOCK{ if is_disposal or is_exempt }
+\BLOCK{ if event.pool_units_left }
     Number of units left in the pool:
 \BLOCK{ else }
     Number of units in the pool:
 \BLOCK{ endif }
-\VAR{ strip_zeros(entry.new_quantity) }%
-\BLOCK{ if entry.new_quantity > 0 },
-    new pool cost: £\VAR{ "{:,}".format(round_decimal(entry.new_pool_cost, 2)) }
-    (£\VAR{ "{:,}".format(round_decimal(entry.new_pool_cost/entry.new_quantity, 2)) }/unit)%
-    \BLOCK{ if is_aquisition and entry.spin_off}
+\VAR{ strip_zeros(line.new_quantity) }%
+\BLOCK{ if line.new_quantity > 0 },
+    new pool cost: £\VAR{ line.new_pool_cost|money }
+    (£\VAR{ line.pool_per_unit|money }/unit)%
+    \BLOCK{ if event.is_acquisition and line.spin_off_source }
 
-    Cost basis calculated based on cost of \VAR{entry.spin_off.source} share pool from which \VAR{ symbol } shares were spinned off%
+    Cost basis calculated based on cost of \VAR{ line.spin_off_source } share pool from which \VAR{ event.symbol } shares were spinned off%
     \BLOCK{ endif }
-    \BLOCK{ if is_aquisition }
-        \BLOCK{ for eri in entry.eris }
-            \BLOCK{ set eri_cost = round_decimal(eri.price * entry.quantity, 2) }
-            \BLOCK{ set eri_date = eri.date.strftime("%d %b %Y") }
+    \BLOCK{ if event.is_acquisition }
+        \BLOCK{ for eri in line.eris }
+                        \#{ padding this line has always carried }
 
-    Cost basis increased by £\VAR{ "{:,}".format(eri_cost)}
-    (£\VAR{ "{:,}".format(round_decimal(eri.price, 4)) }/unit)%
-    , due to exccess reported income on \mbox{\VAR{ eri_date }}%
+    Cost basis increased by £\VAR{ eri.cost|money }
+    (£\VAR{ eri.unit_price|money }/unit)%
+    , due to exccess reported income on \mbox{\VAR{ eri.date.strftime("%d %b %Y") }}%
         \BLOCK{ endfor }
     \BLOCK{ endif }
 \BLOCK{ endif }.
@@ -271,66 +218,34 @@
 
 \BLOCK{ endfor }
 
-\BLOCK{ if report.calculation_log_yields }
+\BLOCK{ if view.income_days }
     \clearpage
     \section*{Interest and Dividends Events}
 
-    \BLOCK{ for date_index, symbol_dict in report.calculation_log_yields.items() }
+    \BLOCK{ for day in view.income_days }
 
-    \subsection*{\VAR{ date_index.strftime("%d %B %Y") }}
-    \BLOCK{ for symbol, entries in symbol_dict.items() }
-    \BLOCK{ if symbol.startswith("dividend$") }
-        \BLOCK{ set symbol = symbol[9:] }
-        \BLOCK{ set is_dividend = True }
-    \BLOCK{ elif symbol.startswith("interestTax") }
-        \BLOCK{ set symbol = symbol.split('$')[0][11:] }
-        \BLOCK{ set is_interest_tax = True }
-        \BLOCK{ if symbol == "GBP" }
-            \BLOCK{ set interest_tax_str = "UK" }
-        \BLOCK{ else }
-            \BLOCK{ set interest_tax_str = "Foreign" }
+    \subsection*{\VAR{ day.date.strftime("%d %B %Y") }}
+    \BLOCK{ for event in day.events }
+        \BLOCK{ if event.kind == "dividend" }
+\#{ A dividend paid as interest has always been indented further. }
+\BLOCK{ if event.is_interest }                    \BLOCK{ endif }
+                                                    \textbf{Dividend \VAR{ event.number }:} \VAR{ event.symbol }\BLOCK{ if event.is_interest } (interest)\BLOCK{ endif } for £\VAR{ event.amount|money }
+        \BLOCK{ if not event.is_interest }
+            (tax paid at source: £\VAR{ event.tax_at_source|money })
         \BLOCK{ endif }
-    \BLOCK{ elif symbol.startswith("interestUK$") }
-        \BLOCK{ set symbol = symbol[11:] }
-        \BLOCK{ set is_interest = True }
-        \BLOCK{ set interest_str = "UK" }
-    \BLOCK{ elif symbol.startswith("interest") }
-        \BLOCK{ set symbol = symbol.split('$')[0][8:] }
-        \BLOCK{ set is_interest = True }
-        \BLOCK{ set interest_str = "Foreign" }
-    \BLOCK{ elif symbol.startswith("excess-reported-income-distribution$") }
-        \BLOCK{ set symbol = symbol[36:] }
-        \BLOCK{ set is_eri_tax = True }
-    \BLOCK{ endif }
-    \BLOCK{ if is_dividend }
-        \BLOCK{ set type_str = "" }
-        \BLOCK{ set dividend_count.value = dividend_count.value + 1 }
-        \BLOCK{ if entries[0].dividend.is_interest }
-            \BLOCK{ set type_str = " (interest)" }
+        \BLOCK{ if event.treaty_country is not none }
+            , tax treaty amount: £\VAR{ event.treaty_amount|money } (treaty rate for \VAR{ event.treaty_country }: \VAR{ event.treaty_rate }\%)
         \BLOCK{ endif }
-        \textbf{Dividend \VAR{ dividend_count.value }:} \VAR{ symbol + type_str } for £\VAR{ "{:,}".format(round_decimal(entries[0].amount, 2)) }
-        \BLOCK{ if not entries[0].dividend.is_interest }
-            (tax paid at source: £\VAR{ "{:,}".format(round_decimal(-entries[0].dividend.tax_at_source, 2)) })
-        \BLOCK{ endif }
-        \BLOCK{ if entries[0].dividend.tax_treaty }
-            , tax treaty amount: £\VAR{ "{:,}".format(round_decimal(entries[0].dividend.tax_treaty_amount, 2)) } (treaty rate for \VAR{ entries[0].dividend.tax_treaty.country }: \VAR{ round_decimal(100 * entries[0].dividend.tax_treaty.treaty_rate, 2) }\%)
-        \BLOCK{ endif }
-    \BLOCK{ elif is_interest } % if is_interest
-        \BLOCK{ set interest_count.value = interest_count.value + 1 }
-        \textbf{Interest \VAR{ interest_str } \VAR{ interest_count.value }:} \VAR{ symbol } for £\VAR{ "{:,}".format(round_decimal(entries[0].amount, 2)) }
-    \BLOCK{ elif is_interest_tax } % if is_interest_tax
-        \BLOCK{ set interest_tax_count.value = interest_tax_count.value + 1 }
-        \textbf{Interest tax \VAR{ interest_tax_str } \VAR{ interest_tax_count.value }:} \VAR{ symbol } for £\VAR{ "{:,}".format(round_decimal(entries[0].amount, 2)) }
-    \BLOCK{ elif is_eri_tax } % if is_eri_tax
-        \BLOCK{ if entries[0].eris[0].is_interest }
-            \BLOCK{ set type_str = " (interest)" }
-        \BLOCK{ else }
-            \BLOCK{ set type_str = " (dividend)" }
-        \BLOCK{ endif }
-        \BLOCK{ set eri_income = round_decimal(entries[0].amount, 2) }
-        \BLOCK{ set eri_count.value = eri_count.value + 1 }
-        \textbf{Excess Reported Income Distribution \VAR{ eri_count.value }}: \VAR{ symbol + type_str } for £\VAR{ "{:,}".format(eri_income) }
-        (£\VAR{ "{:,}".format(round_decimal(entries[0].eris[0].price, 4)) }/unit)%
+    \BLOCK{ elif event.kind == "interest" }
+                             % if is_interest
+                \textbf{Interest \VAR{ event.origin } \VAR{ event.number }:} \VAR{ event.symbol } for £\VAR{ event.amount|money }
+    \BLOCK{ elif event.kind == "interest_tax" }
+                                                 % if is_interest_tax
+                \textbf{Interest tax \VAR{ event.origin } \VAR{ event.number }:} \VAR{ event.symbol } for £\VAR{ event.amount|money }
+    \BLOCK{ elif event.kind == "eri_distribution" }
+                     % if is_eri_tax
+                                                    \textbf{Excess Reported Income Distribution \VAR{ event.number }}: \VAR{ event.symbol }\BLOCK{ if event.is_interest } (interest)\BLOCK{ else } (dividend)\BLOCK{ endif } for £\VAR{ event.amount|money }
+        (£\VAR{ event.unit_price|money }/unit)%
     \BLOCK{ endif }
 
     \BLOCK{ endfor }
@@ -340,38 +255,38 @@
 
 \clearpage
 \section*{Overall - Capital Gains}
-\subsection*{Number of acquisitions: \VAR{ acquisition_count.value }}
-\subsection*{Number of disposals: \VAR{ disposal_count.value }}
-\subsection*{Total disposal proceeds: £\VAR{ "{:,}".format(report.disposal_proceeds) }}
-\subsection*{Total capital gain before loss: £\VAR{ "{:,}".format(total_gain.value) }}
-\subsection*{Total capital loss: £\VAR{ "{:,}".format(total_loss.value) }}
-\BLOCK{ if gift_loss.value > 0 }
-\subsection*{Losses on gifts, kept separate: £\VAR{ "{:,}".format(gift_loss.value) }}
+\subsection*{Number of acquisitions: \VAR{ view.summary.acquisition_count }}
+\subsection*{Number of disposals: \VAR{ view.summary.disposal_count }}
+\subsection*{Total disposal proceeds: £\VAR{ view.summary.disposal_proceeds|money }}
+\subsection*{Total capital gain before loss: £\VAR{ view.summary.total_gain|money }}
+\subsection*{Total capital loss: £\VAR{ view.summary.total_loss|money }}
+\BLOCK{ if view.summary.gift_loss > 0 }
+\subsection*{Losses on gifts, kept separate: £\VAR{ view.summary.gift_loss|money }}
 \BLOCK{ endif }
-\BLOCK{ if report.exempt_disposal_count > 0 }
-\subsection*{Number of exempt disposals: \VAR{ report.exempt_disposal_count }}
-\subsection*{Total exempt disposal proceeds: £\VAR{ "{:,}".format(report.exempt_disposal_proceeds) }}
+\BLOCK{ if view.summary.exempt_disposal_count > 0 }
+\subsection*{Number of exempt disposals: \VAR{ view.summary.exempt_disposal_count }}
+\subsection*{Total exempt disposal proceeds: £\VAR{ view.summary.exempt_disposal_proceeds|money }}
 \BLOCK{ endif }
-\subsection*{Total capital gain after loss: £\VAR{ "{:,}".format(total_gain.value - total_loss.value) }}
+\subsection*{Total capital gain after loss: £\VAR{ view.summary.net_gain|money }}
 \vspace{1em}
 Amounts are rounded to the nearest penny individually, so a line may differ from its components by a penny.
 \vspace{2em}
 \section*{Overall - Dividends and Interests}
-\subsection*{Number of dividend distributions: \VAR{ dividend_count.value }}
-\subsection*{Number of interest transactions: \VAR{ interest_count.value }}
-\subsection*{Number of interest tax transactions: \VAR{ interest_tax_count.value }}
-\subsection*{Number of excess reported income distributions: \VAR{ eri_count.value }}
-\subsection*{Total amount of dividends proceeds: £\VAR{ "{:,}".format(round_decimal(report.total_dividends_amount(), 2)) }}
-\BLOCK{ if report.total_eri_amount(is_interest=False) > 0 }
-\subsubsection*{   (including £\VAR{ "{:,}".format(round_decimal(report.total_eri_amount(is_interest=False), 2))} from excess reported income distributions)}
+\subsection*{Number of dividend distributions: \VAR{ view.income_summary.dividend_count }}
+\subsection*{Number of interest transactions: \VAR{ view.income_summary.interest_count }}
+\subsection*{Number of interest tax transactions: \VAR{ view.income_summary.interest_tax_count }}
+\subsection*{Number of excess reported income distributions: \VAR{ view.income_summary.eri_count }}
+\subsection*{Total amount of dividends proceeds: £\VAR{ view.income_summary.total_dividends|money }}
+\BLOCK{ if view.income_summary.eri_dividends is not none }
+\subsubsection*{   (including £\VAR{ view.income_summary.eri_dividends|money } from excess reported income distributions)}
 \BLOCK{ endif }
-\subsection*{Total amount of dividends tax allowance due to double taxation treaties: £\VAR{ "{:,}".format(round_decimal(report.total_dividend_taxes_in_tax_treaties_amount(), 2)) }}
-\subsection*{Total amount of dividends tax yearly allowance: £\VAR{ "{:,}".format(round_decimal(report.dividend_allowance or Decimal(), 2)) }}
-\subsection*{Total amount of taxable dividends proceeds: £\VAR{ "{:,}".format(round_decimal(report.total_dividend_taxable_gain(), 2)) }}
-\subsection*{Total amount of UK interests proceeds: £\VAR{ "{:,}".format(report.total_uk_interest) }}
-\subsection*{Total amount of foreign interests proceeds: £\VAR{ "{:,}".format(report.total_foreign_interest) }}
-\BLOCK{ if report.total_eri_amount(is_interest=True) > 0 }
-\subsubsection*{   (including £\VAR{ "{:,}".format(round_decimal(report.total_eri_amount(is_interest=True), 2))} from excess reported income distributions)}
+\subsection*{Total amount of dividends tax allowance due to double taxation treaties: £\VAR{ view.income_summary.treaty_allowance|money }}
+\subsection*{Total amount of dividends tax yearly allowance: £\VAR{ view.income_summary.dividend_allowance|money }}
+\subsection*{Total amount of taxable dividends proceeds: £\VAR{ view.income_summary.taxable_dividends|money }}
+\subsection*{Total amount of UK interests proceeds: £\VAR{ view.income_summary.uk_interest|money }}
+\subsection*{Total amount of foreign interests proceeds: £\VAR{ view.income_summary.foreign_interest|money }}
+\BLOCK{ if view.income_summary.eri_interest is not none }
+\subsubsection*{   (including £\VAR{ view.income_summary.eri_interest|money } from excess reported income distributions)}
 \BLOCK{ endif }
-\subsection*{Total amount of interest tax paid: £\VAR{ "{:,}".format(report.total_interest_tax) }}
+\subsection*{Total amount of interest tax paid: £\VAR{ view.income_summary.interest_tax|money }}
 \end{document}

--- a/cgt_calc/resources/template.tex.j2
+++ b/cgt_calc/resources/template.tex.j2
@@ -5,135 +5,121 @@
 \begin{document}
 \centerline{\Large\bfseries Capital Gains Tax Calculations for \VAR{ view.title_period }}
 
-
 \section*{Capital Gains Events}
 
 \BLOCK{ for day in view.days }
 
 \subsection*{\VAR{ day.date.strftime("%d %B %Y") }}
 \BLOCK{ for event in day.events }
-\#{ A tag's own indentation reaches the output, so the layout below is part
-    of the report and the .tex goldens pin it. }
-        \BLOCK{ if event.is_disposal }
-                \BLOCK{ if event.kind == "option_grant" }
-            \subsubsection*{
-            Disposal \VAR{ event.number }: grant of \VAR{ strip_zeros(event.quantity) }
-            contract\BLOCK{ if event.quantity != 1 }s\BLOCK{ endif } of the \VAR{ event.symbol }
-            for £\VAR{ event.proceeds|money }
-        }
+\BLOCK{ if event.is_disposal }
+    \BLOCK{ if event.kind == "option_grant" }
+\subsubsection*{
+    Disposal \VAR{ event.number }: grant of \VAR{ strip_zeros(event.quantity) }
+    contract\BLOCK{ if event.quantity != 1 }s\BLOCK{ endif } of the \VAR{ event.symbol }
+    for £\VAR{ event.proceeds|money }
+}
     \BLOCK{ else }
-\#{ A gift's heading is indented further than a sale's, a connected
-    person's further still. }
-\BLOCK{ if event.is_gift }    \BLOCK{ if event.kind == "gift_connected" }    \BLOCK{ endif }\BLOCK{ endif }
-        \subsubsection*{
-            Disposal \VAR{ event.number }: \VAR{ strip_zeros(event.quantity) } units of \VAR{ event.symbol }
-            \BLOCK{ if event.is_gift }given away at a market value of\BLOCK{ else }for\BLOCK{ endif } £\VAR{ event.proceeds|money }
-            (£\VAR{ event.per_unit|money }/unit)%
-            \BLOCK{ if event.fees > 0 }
-                , £\VAR{ event.fees|money } fees allowed as cost
-            \BLOCK{ endif }
-        }
+\subsubsection*{
+    Disposal \VAR{ event.number }: \VAR{ strip_zeros(event.quantity) } units of \VAR{ event.symbol }
+    \BLOCK{ if event.is_gift }given away at a market value of\BLOCK{ else }for\BLOCK{ endif } £\VAR{ event.proceeds|money }
+    (£\VAR{ event.per_unit|money }/unit)%
+    \BLOCK{ if event.fees > 0 }
+    , £\VAR{ event.fees|money } fees allowed as cost
     \BLOCK{ endif }
-    \BLOCK{ if event.outcome == "gain" -}
-        Chargeable \textbf{gain} is £\VAR{ event.gain|money }\BLOCK{ if event.is_gift }, before any relief:
-        a gift of shares that qualify for Gift Hold-over Relief has the gain deferred by a joint claim on your returns\BLOCK{ endif }
+}
+    \BLOCK{ endif }
+    \BLOCK{ if event.outcome == "gain" }
+Chargeable \textbf{gain} is £\VAR{ event.gain|money }\BLOCK{ if event.is_gift }, before any relief:
+a gift of shares that qualify for Gift Hold-over Relief has the gain deferred by a joint claim on your returns\BLOCK{ endif }
 
-                Capital gain to date is £\VAR{ event.gain_to_date|money }
+Capital gain to date is £\VAR{ event.gain_to_date|money }
     \BLOCK{ elif event.outcome == "nil" }
-        Neither a gain nor a loss.
+Neither a gain nor a loss.
     \BLOCK{ elif event.outcome == "clogged_loss" }
-        \textbf{Clogged loss} of £\VAR{ (-event.gain)|money } on a gift, kept out of the loss total:
-        a loss on a gift to a connected person can only be set against gains on disposals to the same person while still connected (TCGA 1992 s18(3)).
+\textbf{Clogged loss} of £\VAR{ (-event.gain)|money } on a gift, kept out of the loss total:
+a loss on a gift to a connected person can only be set against gains on disposals to the same person while still connected (TCGA 1992 s18(3)).
 
-                Losses on gifts to date are £\VAR{ event.gift_loss_to_date|money }
+Losses on gifts to date are £\VAR{ event.gift_loss_to_date|money }
     \BLOCK{ else }
-        Chargeable \textbf{loss} is £\VAR{ (-event.gain)|money }
+Chargeable \textbf{loss} is £\VAR{ (-event.gain)|money }
 
-                Capital loss to date is £\VAR{ event.loss_to_date|money }
+Capital loss to date is £\VAR{ event.loss_to_date|money }
     \BLOCK{ endif }
 \BLOCK{ elif event.kind == "acquisition" }
- % if is_aquisition
-                        \subsubsection*{
-            Acquisition \VAR{ event.number }: \VAR{ strip_zeros(event.quantity) } units of \VAR{ event.symbol } for £\VAR{ event.cost|money }
-            (£\VAR{ event.per_unit|money }/unit)%
-            \BLOCK{ if event.fees > 0 }
-                , including £\VAR{ event.fees|money } fees
-            \BLOCK{ endif }
-        }
-    \BLOCK{ elif event.kind == "management_fee" }
- % if is_aquisition
-                \subsubsection*{Management fee for \VAR{ event.symbol } of £\VAR{ event.cost|money }}
-    \BLOCK{ elif event.kind == "spin_off" }
- % if is_spin_off
+\subsubsection*{
+    Acquisition \VAR{ event.number }: \VAR{ strip_zeros(event.quantity) } units of \VAR{ event.symbol } for £\VAR{ event.cost|money }
+    (£\VAR{ event.per_unit|money }/unit)%
+    \BLOCK{ if event.fees > 0 }
+    , including £\VAR{ event.fees|money } fees
+    \BLOCK{ endif }
+}
+\BLOCK{ elif event.kind == "management_fee" }
+\subsubsection*{Management fee for \VAR{ event.symbol } of £\VAR{ event.cost|money }}
+\BLOCK{ elif event.kind == "spin_off" }
     \BLOCK{ if event.quantity > 0 }
-                    \subsubsection*{
-            Spin-off adjustment \VAR{ event.number }: \VAR{ event.spin_off_source } cost adjusted because of \VAR{ event.spin_off_dest } shares spinned off
-        }
+\subsubsection*{
+    Spin-off adjustment \VAR{ event.number }: \VAR{ event.spin_off_source } cost adjusted because of \VAR{ event.spin_off_dest } shares spinned off
+}
     \BLOCK{ endif }
 \BLOCK{ elif event.kind == "eri" }
- % if is_eri
     \BLOCK{ if event.quantity > 0 }
-            \subsubsection*{
-            Excess Reported Income: \VAR{ event.symbol } cost increased by £\VAR{ event.cost|money }
-            (£\VAR{ event.eri_unit_price|money }/unit)%
-        }
+\subsubsection*{
+    Excess Reported Income: \VAR{ event.symbol } cost increased by £\VAR{ event.cost|money }
+    (£\VAR{ event.eri_unit_price|money }/unit)%
+}
     \BLOCK{ endif }
 \BLOCK{ elif event.kind == "rename" }
- % if is_rename
-    \subsubsection*{
-        \VAR{ event.symbol } was renamed to \VAR{ event.renamed_to }%
-        \BLOCK{ if event.quantity > 0 }
-            : \VAR{ strip_zeros(event.quantity) } units with pool cost £\VAR{ event.cost|money } transferred
-        \BLOCK{ endif }
-    }
+\subsubsection*{
+    \VAR{ event.symbol } was renamed to \VAR{ event.renamed_to }%
+    \BLOCK{ if event.quantity > 0 }
+    : \VAR{ strip_zeros(event.quantity) } units with pool cost £\VAR{ event.cost|money } transferred
+    \BLOCK{ endif }
+}
 \BLOCK{ elif event.kind == "split" }
- % if is_split
-        \subsubsection*{
-        Share reorganisation: \VAR{ strip_zeros(event.split.day_open_quantity) } units of \VAR{ event.symbol } restated as \VAR{ strip_zeros(event.split.scaled_day_open_quantity) } (ratio \VAR{ event.split.ratio_description })
-    }
-    Neither a disposal nor an acquisition: the new holding is the same asset, held from the same dates, with the same pooled cost (TCGA 1992 s127).
+\subsubsection*{
+    Share reorganisation: \VAR{ strip_zeros(event.split.day_open_quantity) } units of \VAR{ event.symbol } restated as \VAR{ strip_zeros(event.split.scaled_day_open_quantity) } (ratio \VAR{ event.split.ratio_description })
+}
+Neither a disposal nor an acquisition: the new holding is the same asset, held from the same dates, with the same pooled cost (TCGA 1992 s127).
 
-    Stated as \VAR{ strip_zeros(event.split.broker_before_quantity) } units before the event and \VAR{ strip_zeros(event.split.broker_after_quantity) } after.
+Stated as \VAR{ strip_zeros(event.split.broker_before_quantity) } units before the event and \VAR{ strip_zeros(event.split.broker_after_quantity) } after.
     \BLOCK{ if event.split.reconciliation_delta != 0 }
 
-        Reconciled to that count by \VAR{ strip_zeros(event.split.reconciliation_delta) } units, from \VAR{ strip_zeros(event.split.quantity_before_reconciliation) } to \VAR{ strip_zeros(event.split.quantity_after_reconciliation) }.
+Reconciled to that count by \VAR{ strip_zeros(event.split.reconciliation_delta) } units, from \VAR{ strip_zeros(event.split.quantity_before_reconciliation) } to \VAR{ strip_zeros(event.split.quantity_after_reconciliation) }.
     \BLOCK{ endif }
 
-    Units in the pool at this point in the day: \VAR{ strip_zeros(event.pool_quantity) }%
+Units in the pool at this point in the day: \VAR{ strip_zeros(event.pool_quantity) }%
     \BLOCK{ if event.pool_quantity > 0 },
-        pool cost: £\VAR{ event.pool_cost|money }
-        (£\VAR{ event.pool_per_unit|money }/unit)%
+    pool cost: £\VAR{ event.pool_cost|money }
+    (£\VAR{ event.pool_per_unit|money }/unit)%
     \BLOCK{ endif }.
 \BLOCK{ elif event.kind == "transfer_to_spouse" }
- % if is_transfer_to_spouse
-    \subsubsection*{
-        Transferred to spouse: \VAR{ strip_zeros(event.quantity) } units of \VAR{ event.symbol } (no gain/no loss)
-    }
-    Base cost of £\VAR{ event.base_cost_passed|money } passes to the recipient.
+\subsubsection*{
+    Transferred to spouse: \VAR{ strip_zeros(event.quantity) } units of \VAR{ event.symbol } (no gain/no loss)
+}
+Base cost of £\VAR{ event.base_cost_passed|money } passes to the recipient.
 
-        Number of units left in the pool: \VAR{ strip_zeros(event.pool_quantity) }%
+Number of units left in the pool: \VAR{ strip_zeros(event.pool_quantity) }%
     \BLOCK{ if event.pool_quantity > 0 },
-        new pool cost: £\VAR{ event.pool_cost|money }
-        (£\VAR{ event.pool_per_unit|money }/unit)%
+    new pool cost: £\VAR{ event.pool_cost|money }
+    (£\VAR{ event.pool_per_unit|money }/unit)%
     \BLOCK{ endif }.
 \BLOCK{ elif event.kind == "exempt" }
- % if is_exempt
-            \subsubsection*{
-        Exempt disposal: \VAR{ strip_zeros(event.quantity) } units of \VAR{ event.symbol } valued at £\VAR{ event.proceeds|money }
-        (£\VAR{ event.per_unit|money }/unit)%
-        \BLOCK{ if event.fees > 0 }
-            , £\VAR{ event.fees|money } disposal expenses included in the illustrative calculation
-        \BLOCK{ endif }
-    }
-    The cost and disposal expenses shown below are used for this illustrative calculation only;
-    they are not allowable deductions against other gains.
+\subsubsection*{
+    Exempt disposal: \VAR{ strip_zeros(event.quantity) } units of \VAR{ event.symbol } valued at £\VAR{ event.proceeds|money }
+    (£\VAR{ event.per_unit|money }/unit)%
+    \BLOCK{ if event.fees > 0 }
+    , £\VAR{ event.fees|money } disposal expenses included in the illustrative calculation
+    \BLOCK{ endif }
+}
+The cost and disposal expenses shown below are used for this illustrative calculation only;
+they are not allowable deductions against other gains.
 
-    \BLOCK{ if event.outcome == "gain" -}
-        Gain is £\VAR{ event.gain|money }; the gain or loss is disregarded (exempt asset).
+    \BLOCK{ if event.outcome == "gain" }
+Gain is £\VAR{ event.gain|money }; the gain or loss is disregarded (exempt asset).
     \BLOCK{ elif event.outcome == "nil" }
-        Neither a gain nor a loss; the gain or loss is disregarded (exempt asset).
+Neither a gain nor a loss; the gain or loss is disregarded (exempt asset).
     \BLOCK{ else }
-        Loss is £\VAR{ (-event.gain)|money }; the gain or loss is disregarded (exempt asset).
+Loss is £\VAR{ (-event.gain)|money }; the gain or loss is disregarded (exempt asset).
     \BLOCK{ endif }
 \BLOCK{ endif }
 
@@ -141,76 +127,74 @@
 \begin{enumerate}
 \BLOCK{ for line in event.lines }
 \item \textbf{\VAR{ line.rule }}. Quantity: \VAR{ strip_zeros(line.quantity) },
-\BLOCK{ if event.is_disposal }
-    \BLOCK{ if line.shows_proceeds }
-        disposal proceeds: £\VAR{ line.proceeds|money },
-    \BLOCK{ endif }
+    \BLOCK{ if event.is_disposal }
+        \BLOCK{ if line.shows_proceeds }
+    disposal proceeds: £\VAR{ line.proceeds|money },
+        \BLOCK{ endif }
     allowable
-    \BLOCK{ if line.bnb_date }
-        cost on \mbox{\VAR{ line.bnb_date.strftime("%d %b %Y") }:}
-    \BLOCK{ else }
-        cost:
-    \BLOCK{ endif }
+        \BLOCK{ if line.bnb_date }
+    cost on \mbox{\VAR{ line.bnb_date.strftime("%d %b %Y") }:}
+        \BLOCK{ else }
+    cost:
+        \BLOCK{ endif }
     £\VAR{ line.cost|money },
-    \BLOCK{ if line.is_gain }
-        \mbox{gain: £\VAR{ line.gain|money }.}
-    \BLOCK{ else }
-        \mbox{loss: £\VAR{ (-line.gain)|money }.}
-    \BLOCK{ endif }
-\BLOCK{ elif event.kind == "exempt" }
-    \BLOCK{ if line.shows_proceeds }
-        disposal proceeds: £\VAR{ line.proceeds|money },
-    \BLOCK{ endif }
+        \BLOCK{ if line.is_gain }
+    \mbox{gain: £\VAR{ line.gain|money }.}
+        \BLOCK{ else }
+    \mbox{loss: £\VAR{ (-line.gain)|money }.}
+        \BLOCK{ endif }
+    \BLOCK{ elif event.kind == "exempt" }
+        \BLOCK{ if line.shows_proceeds }
+    disposal proceeds: £\VAR{ line.proceeds|money },
+        \BLOCK{ endif }
     cost used for this illustrative
-    \BLOCK{ if line.bnb_date }
-        calculation on \mbox{\VAR{ line.bnb_date.strftime("%d %b %Y") }:}
-    \BLOCK{ else }
-        calculation:
-    \BLOCK{ endif }
+        \BLOCK{ if line.bnb_date }
+    calculation on \mbox{\VAR{ line.bnb_date.strftime("%d %b %Y") }:}
+        \BLOCK{ else }
+    calculation:
+        \BLOCK{ endif }
     £\VAR{ line.cost|money },
-    \BLOCK{ if line.is_gain }
-        \mbox{disregarded gain: £\VAR{ line.gain|money }.}
-    \BLOCK{ else }
-        \mbox{disregarded loss: £\VAR{ (-line.gain)|money }.}
-    \BLOCK{ endif }
-\BLOCK{ elif event.kind == "spin_off" }
+        \BLOCK{ if line.is_gain }
+    \mbox{disregarded gain: £\VAR{ line.gain|money }.}
+        \BLOCK{ else }
+    \mbox{disregarded loss: £\VAR{ (-line.gain)|money }.}
+        \BLOCK{ endif }
+    \BLOCK{ elif event.kind == "spin_off" }
     original cost of \VAR{ line.spin_off_source }: £\VAR{ line.amount|money }, after spin-off: £\VAR{ line.new_pool_cost|money }
-\BLOCK{ elif event.kind == "eri" }
+    \BLOCK{ elif event.kind == "eri" }
     original cost of \VAR{ event.symbol }: £\VAR{ line.amount|money }, after income distribution: £\VAR{ line.new_pool_cost|money }%
-\BLOCK{ else }
- % if is_aquisition
+    \BLOCK{ else }
     actual cost: £\VAR{ line.amount|money }.
-\BLOCK{ endif}
+    \BLOCK{ endif }
 
-\BLOCK{ if event.kind == "option_grant" }
+    \BLOCK{ if event.kind == "option_grant" }
     The option grant does not change the Section 104 holding of the underlying shares.
-\BLOCK{ else }
-\BLOCK{ if event.pool_units_left }
+    \BLOCK{ else }
+        \BLOCK{ if event.pool_units_left }
     Number of units left in the pool:
-\BLOCK{ else }
+        \BLOCK{ else }
     Number of units in the pool:
-\BLOCK{ endif }
-\VAR{ strip_zeros(line.new_quantity) }%
-\BLOCK{ if line.new_quantity > 0 },
+        \BLOCK{ endif }
+    \VAR{ strip_zeros(line.new_quantity) }%
+        \BLOCK{ if line.new_quantity > 0 },
     new pool cost: £\VAR{ line.new_pool_cost|money }
     (£\VAR{ line.pool_per_unit|money }/unit)%
-    \BLOCK{ if event.is_acquisition and line.spin_off_source }
+            \BLOCK{ if event.is_acquisition and line.spin_off_source }
 
     Cost basis calculated based on cost of \VAR{ line.spin_off_source } share pool from which \VAR{ event.symbol } shares were spinned off%
-    \BLOCK{ endif }
-    \BLOCK{ if event.is_acquisition }
-        \BLOCK{ for eri in line.eris }
-                        \#{ padding this line has always carried }
+            \BLOCK{ endif }
+            \BLOCK{ if event.is_acquisition }
+                \BLOCK{ for eri in line.eris }
 
     Cost basis increased by £\VAR{ eri.cost|money }
     (£\VAR{ eri.unit_price|money }/unit)%
     , due to exccess reported income on \mbox{\VAR{ eri.date.strftime("%d %b %Y") }}%
-        \BLOCK{ endfor }
+                \BLOCK{ endfor }
+            \BLOCK{ endif }
+        \BLOCK{ endif }.
     \BLOCK{ endif }
-\BLOCK{ endif }.
-\BLOCK{ endif }
 
-\BLOCK{ endfor}
+\BLOCK{ endfor }
 \end{enumerate}
 \BLOCK{ endif }
 
@@ -219,38 +203,33 @@
 \BLOCK{ endfor }
 
 \BLOCK{ if view.income_days }
-    \clearpage
-    \section*{Interest and Dividends Events}
+\clearpage
+\section*{Interest and Dividends Events}
 
-    \BLOCK{ for day in view.income_days }
+\BLOCK{ for day in view.income_days }
 
-    \subsection*{\VAR{ day.date.strftime("%d %B %Y") }}
-    \BLOCK{ for event in day.events }
-        \BLOCK{ if event.kind == "dividend" }
-\#{ A dividend paid as interest has always been indented further. }
-\BLOCK{ if event.is_interest }                    \BLOCK{ endif }
-                                                    \textbf{Dividend \VAR{ event.number }:} \VAR{ event.symbol }\BLOCK{ if event.is_interest } (interest)\BLOCK{ endif } for £\VAR{ event.amount|money }
+\subsection*{\VAR{ day.date.strftime("%d %B %Y") }}
+\BLOCK{ for event in day.events }
+    \BLOCK{ if event.kind == "dividend" }
+\textbf{Dividend \VAR{ event.number }:} \VAR{ event.symbol }\BLOCK{ if event.is_interest } (interest)\BLOCK{ endif } for £\VAR{ event.amount|money }
         \BLOCK{ if not event.is_interest }
-            (tax paid at source: £\VAR{ event.tax_at_source|money })
+(tax paid at source: £\VAR{ event.tax_at_source|money })
         \BLOCK{ endif }
         \BLOCK{ if event.treaty_country is not none }
-            , tax treaty amount: £\VAR{ event.treaty_amount|money } (treaty rate for \VAR{ event.treaty_country }: \VAR{ event.treaty_rate }\%)
+, tax treaty amount: £\VAR{ event.treaty_amount|money } (treaty rate for \VAR{ event.treaty_country }: \VAR{ event.treaty_rate }\%)
         \BLOCK{ endif }
     \BLOCK{ elif event.kind == "interest" }
-                             % if is_interest
-                \textbf{Interest \VAR{ event.origin } \VAR{ event.number }:} \VAR{ event.symbol } for £\VAR{ event.amount|money }
+\textbf{Interest \VAR{ event.origin } \VAR{ event.number }:} \VAR{ event.symbol } for £\VAR{ event.amount|money }
     \BLOCK{ elif event.kind == "interest_tax" }
-                                                 % if is_interest_tax
-                \textbf{Interest tax \VAR{ event.origin } \VAR{ event.number }:} \VAR{ event.symbol } for £\VAR{ event.amount|money }
+\textbf{Interest tax \VAR{ event.origin } \VAR{ event.number }:} \VAR{ event.symbol } for £\VAR{ event.amount|money }
     \BLOCK{ elif event.kind == "eri_distribution" }
-                     % if is_eri_tax
-                                                    \textbf{Excess Reported Income Distribution \VAR{ event.number }}: \VAR{ event.symbol }\BLOCK{ if event.is_interest } (interest)\BLOCK{ else } (dividend)\BLOCK{ endif } for £\VAR{ event.amount|money }
-        (£\VAR{ event.unit_price|money }/unit)%
+\textbf{Excess Reported Income Distribution \VAR{ event.number }}: \VAR{ event.symbol }\BLOCK{ if event.is_interest } (interest)\BLOCK{ else } (dividend)\BLOCK{ endif } for £\VAR{ event.amount|money }
+(£\VAR{ event.unit_price|money }/unit)%
     \BLOCK{ endif }
 
-    \BLOCK{ endfor }
+\BLOCK{ endfor }
 
-    \BLOCK{ endfor }
+\BLOCK{ endfor }
 \BLOCK{ endif }
 
 \clearpage

--- a/tests/general/data/latex/exempt.tex
+++ b/tests/general/data/latex/exempt.tex
@@ -5,111 +5,105 @@
 \begin{document}
 \centerline{\Large\bfseries Capital Gains Tax Calculations for 2024-25}
 
-
 \section*{Capital Gains Events}
 
 
 \subsection*{01 May 2024}
-         % if is_aquisition
-                        \subsubsection*{
-            Acquisition 1: 100 units of T26 for £10,000.00
-            (£100.00/unit)%
-                    }
-    
+\subsubsection*{
+    Acquisition 1: 100 units of T26 for £10,000.00
+    (£100.00/unit)%
+}
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 100,
- % if is_aquisition
     actual cost: £10,000.00.
 
     Number of units in the pool:
-100%
+    100%
 ,
     new pool cost: £10,000.00
     (£100.00/unit)%
-                    .
+.
 
 \end{enumerate}
 
 
 
 \subsection*{01 September 2024}
-         % if is_exempt
-            \subsubsection*{
-        Exempt disposal: 50 units of T26 valued at £6,000.00
-        (£120.00/unit)%
-            }
-    The cost and disposal expenses shown below are used for this illustrative calculation only;
-    they are not allowable deductions against other gains.
+\subsubsection*{
+    Exempt disposal: 50 units of T26 valued at £6,000.00
+    (£120.00/unit)%
+}
+The cost and disposal expenses shown below are used for this illustrative calculation only;
+they are not allowable deductions against other gains.
 
-    Gain is £1,000.00; the gain or loss is disregarded (exempt asset).
-    
+Gain is £1,000.00; the gain or loss is disregarded (exempt asset).
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 50,
-        cost used for this illustrative
-            calculation:
-        £5,000.00,
-            \mbox{disregarded gain: £1,000.00.}
-    
+    cost used for this illustrative
+    calculation:
+    £5,000.00,
+    \mbox{disregarded gain: £1,000.00.}
+
     Number of units left in the pool:
-50%
+    50%
 ,
     new pool cost: £5,000.00
     (£100.00/unit)%
-        .
+.
 
 \end{enumerate}
 
 
 
 \subsection*{02 September 2024}
-         % if is_exempt
-            \subsubsection*{
-        Exempt disposal: 25 units of T26 valued at £2,500.00
-        (£100.00/unit)%
-            }
-    The cost and disposal expenses shown below are used for this illustrative calculation only;
-    they are not allowable deductions against other gains.
+\subsubsection*{
+    Exempt disposal: 25 units of T26 valued at £2,500.00
+    (£100.00/unit)%
+}
+The cost and disposal expenses shown below are used for this illustrative calculation only;
+they are not allowable deductions against other gains.
 
-            Neither a gain nor a loss; the gain or loss is disregarded (exempt asset).
-    
+Neither a gain nor a loss; the gain or loss is disregarded (exempt asset).
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 25,
-        cost used for this illustrative
-            calculation:
-        £2,500.00,
-            \mbox{disregarded loss: £0.00.}
-    
+    cost used for this illustrative
+    calculation:
+    £2,500.00,
+    \mbox{disregarded loss: £0.00.}
+
     Number of units left in the pool:
-25%
+    25%
 ,
     new pool cost: £2,500.00
     (£100.00/unit)%
-        .
+.
 
 \end{enumerate}
 
 
 
 \subsection*{03 September 2024}
-         % if is_exempt
-            \subsubsection*{
-        Exempt disposal: 25 units of T26 valued at £2,000.00
-        (£80.00/unit)%
-            }
-    The cost and disposal expenses shown below are used for this illustrative calculation only;
-    they are not allowable deductions against other gains.
+\subsubsection*{
+    Exempt disposal: 25 units of T26 valued at £2,000.00
+    (£80.00/unit)%
+}
+The cost and disposal expenses shown below are used for this illustrative calculation only;
+they are not allowable deductions against other gains.
 
-            Loss is £500.00; the gain or loss is disregarded (exempt asset).
-    
+Loss is £500.00; the gain or loss is disregarded (exempt asset).
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 25,
-        cost used for this illustrative
-            calculation:
-        £2,500.00,
-            \mbox{disregarded loss: £500.00.}
-    
+    cost used for this illustrative
+    calculation:
+    £2,500.00,
+    \mbox{disregarded loss: £500.00.}
+
     Number of units left in the pool:
-0%
+    0%
 .
 
 \end{enumerate}

--- a/tests/general/data/latex/fee_and_income.tex
+++ b/tests/general/data/latex/fee_and_income.tex
@@ -5,76 +5,69 @@
 \begin{document}
 \centerline{\Large\bfseries Capital Gains Tax Calculations for 2024-25}
 
-
 \section*{Capital Gains Events}
 
 
 \subsection*{01 June 2024}
-         % if is_aquisition
-                        \subsubsection*{
-            Acquisition 1: 10 units of FOO for £100.00
-            (£10.00/unit)%
-                    }
-    
+\subsubsection*{
+    Acquisition 1: 10 units of FOO for £100.00
+    (£10.00/unit)%
+}
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 10,
- % if is_aquisition
     actual cost: £100.00.
 
     Number of units in the pool:
-10%
+    10%
 ,
     new pool cost: £100.00
     (£10.00/unit)%
-                    .
+.
 
 \end{enumerate}
 
 
 
 \subsection*{03 June 2024}
-         % if is_aquisition
-                \subsubsection*{Management fee for FOO of £5.00}
-    
+\subsubsection*{Management fee for FOO of £5.00}
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 0,
- % if is_aquisition
     actual cost: £5.00.
 
     Number of units in the pool:
-10%
+    10%
 ,
     new pool cost: £105.00
     (£10.50/unit)%
-                    .
+.
 
 \end{enumerate}
 
 
 
-    \clearpage
-    \section*{Interest and Dividends Events}
+\clearpage
+\section*{Interest and Dividends Events}
 
-    
-    \subsection*{03 June 2024}
-                                                                \textbf{Dividend 1:} BAR for £100.00
-                    (tax paid at source: £15.00)
-                            , tax treaty amount: £15.00 (treaty rate for USA: 15.00\%)
-            
-    
-    
-    \subsection*{02 July 2024}
-                                         % if is_interest
-                \textbf{Interest UK 1:} Testing for £3.00
-    
-    
-    
-    \subsection*{03 July 2024}
-                                                             % if is_interest_tax
-                \textbf{Interest tax UK 1:} GBP for £2.00
-    
-    
-    
+
+\subsection*{03 June 2024}
+\textbf{Dividend 1:} BAR for £100.00
+(tax paid at source: £15.00)
+, tax treaty amount: £15.00 (treaty rate for USA: 15.00\%)
+
+
+
+\subsection*{02 July 2024}
+\textbf{Interest UK 1:} Testing for £3.00
+
+
+
+\subsection*{03 July 2024}
+\textbf{Interest tax UK 1:} GBP for £2.00
+
+
+
 \clearpage
 \section*{Overall - Capital Gains}
 \subsection*{Number of acquisitions: 1}

--- a/tests/general/data/latex/gifts.tex
+++ b/tests/general/data/latex/gifts.tex
@@ -5,139 +5,136 @@
 \begin{document}
 \centerline{\Large\bfseries Capital Gains Tax Calculations for 2024-25}
 
-
 \section*{Capital Gains Events}
 
 
 \subsection*{01 June 2024}
-         % if is_aquisition
-                        \subsubsection*{
-            Acquisition 1: 10 units of FOO for £100.00
-            (£10.00/unit)%
-                    }
-    
+\subsubsection*{
+    Acquisition 1: 10 units of FOO for £100.00
+    (£10.00/unit)%
+}
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 10,
- % if is_aquisition
     actual cost: £100.00.
 
     Number of units in the pool:
-10%
+    10%
 ,
     new pool cost: £100.00
     (£10.00/unit)%
-                    .
+.
 
 \end{enumerate}
 
 
 
 \subsection*{10 June 2024}
-                                        \subsubsection*{
-            Disposal 1: 2 units of FOO
-            given away at a market value of £60.00
-            (£30.00/unit)%
-                    }
-        Chargeable \textbf{gain} is £40.00, before any relief:
-        a gift of shares that qualify for Gift Hold-over Relief has the gain deferred by a joint claim on your returns
-                Capital gain to date is £40.00
-    
+\subsubsection*{
+    Disposal 1: 2 units of FOO
+given away at a market value of £60.00
+    (£30.00/unit)%
+}
+Chargeable \textbf{gain} is £40.00, before any relief:
+a gift of shares that qualify for Gift Hold-over Relief has the gain deferred by a joint claim on your returns
+Capital gain to date is £40.00
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 2,
-        allowable
-            cost:
-        £20.00,
-            \mbox{gain: £40.00.}
-    
+    allowable
+    cost:
+    £20.00,
+    \mbox{gain: £40.00.}
+
     Number of units left in the pool:
-8%
+    8%
 ,
     new pool cost: £80.00
     (£10.00/unit)%
-        .
+.
 
 \end{enumerate}
 
 
 
 \subsection*{11 June 2024}
-                                        \subsubsection*{
-            Disposal 2: 2 units of FOO
-            given away at a market value of £10.00
-            (£5.00/unit)%
-                    }
-                \textbf{Clogged loss} of £10.00 on a gift, kept out of the loss total:
-        a loss on a gift to a connected person can only be set against gains on disposals to the same person while still connected (TCGA 1992 s18(3)).
+\subsubsection*{
+    Disposal 2: 2 units of FOO
+given away at a market value of £10.00
+    (£5.00/unit)%
+}
+\textbf{Clogged loss} of £10.00 on a gift, kept out of the loss total:
+a loss on a gift to a connected person can only be set against gains on disposals to the same person while still connected (TCGA 1992 s18(3)).
 
-                Losses on gifts to date are £10.00
-    
+Losses on gifts to date are £10.00
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 2,
-        allowable
-            cost:
-        £20.00,
-            \mbox{loss: £10.00.}
-    
+    allowable
+    cost:
+    £20.00,
+    \mbox{loss: £10.00.}
+
     Number of units left in the pool:
-6%
+    6%
 ,
     new pool cost: £60.00
     (£10.00/unit)%
-        .
+.
 
 \end{enumerate}
 
 
 
 \subsection*{12 June 2024}
-                                    \subsubsection*{
-            Disposal 3: 2 units of FOO
-            given away at a market value of £10.00
-            (£5.00/unit)%
-                    }
-                Chargeable \textbf{loss} is £10.00
+\subsubsection*{
+    Disposal 3: 2 units of FOO
+given away at a market value of £10.00
+    (£5.00/unit)%
+}
+Chargeable \textbf{loss} is £10.00
 
-                Capital loss to date is £10.00
-    
+Capital loss to date is £10.00
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 2,
-        allowable
-            cost:
-        £20.00,
-            \mbox{loss: £10.00.}
-    
+    allowable
+    cost:
+    £20.00,
+    \mbox{loss: £10.00.}
+
     Number of units left in the pool:
-4%
+    4%
 ,
     new pool cost: £40.00
     (£10.00/unit)%
-        .
+.
 
 \end{enumerate}
 
 
 
 \subsection*{13 June 2024}
-                                        \subsubsection*{
-            Disposal 4: 2 units of FOO
-            given away at a market value of £20.00
-            (£10.00/unit)%
-                    }
-                Neither a gain nor a loss.
-    
+\subsubsection*{
+    Disposal 4: 2 units of FOO
+given away at a market value of £20.00
+    (£10.00/unit)%
+}
+Neither a gain nor a loss.
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 2,
-        allowable
-            cost:
-        £20.00,
-            \mbox{loss: £0.00.}
-    
+    allowable
+    cost:
+    £20.00,
+    \mbox{loss: £0.00.}
+
     Number of units left in the pool:
-2%
+    2%
 ,
     new pool cost: £20.00
     (£10.00/unit)%
-        .
+.
 
 \end{enumerate}
 

--- a/tests/general/data/latex/option_grant.tex
+++ b/tests/general/data/latex/option_grant.tex
@@ -5,26 +5,25 @@
 \begin{document}
 \centerline{\Large\bfseries Capital Gains Tax Calculations for 2024-25}
 
-
 \section*{Capital Gains Events}
 
 
 \subsection*{01 May 2024}
-                                    \subsubsection*{
-            Disposal 1: grant of 2
-            contracts of the META call option expiring 2024-05-17 at a strike of 500
-            for £200.00
-        }
-        Chargeable \textbf{gain} is £198.70
-                Capital gain to date is £198.70
-    
+\subsubsection*{
+    Disposal 1: grant of 2
+    contracts of the META call option expiring 2024-05-17 at a strike of 500
+    for £200.00
+}
+Chargeable \textbf{gain} is £198.70
+Capital gain to date is £198.70
+
 \begin{enumerate}
 \item \textbf{OPTION}. Quantity: 2,
-        allowable
-            cost:
-        £1.30,
-            \mbox{gain: £198.70.}
-    
+    allowable
+    cost:
+    £1.30,
+    \mbox{gain: £198.70.}
+
     The option grant does not change the Section 104 holding of the underlying shares.
 
 \end{enumerate}

--- a/tests/general/data/latex/rename.tex
+++ b/tests/general/data/latex/rename.tex
@@ -5,82 +5,76 @@
 \begin{document}
 \centerline{\Large\bfseries Capital Gains Tax Calculations for 2024-25}
 
-
 \section*{Capital Gains Events}
 
 
 \subsection*{01 May 2024}
-         % if is_aquisition
-                        \subsubsection*{
-            Acquisition 1: 100 units of OLD for £1,000.00
-            (£10.00/unit)%
-                    }
-    
+\subsubsection*{
+    Acquisition 1: 100 units of OLD for £1,000.00
+    (£10.00/unit)%
+}
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 100,
- % if is_aquisition
     actual cost: £1,000.00.
 
     Number of units in the pool:
-100%
+    100%
 ,
     new pool cost: £1,000.00
     (£10.00/unit)%
-                    .
+.
 
 \end{enumerate}
 
 
 
 \subsection*{10 May 2024}
-                                \subsubsection*{
-            Disposal 1: 100 units of OLD
-            for £800.00
-            (£8.00/unit)%
-                    }
-                Chargeable \textbf{loss} is £100.00
+\subsubsection*{
+    Disposal 1: 100 units of OLD
+for £800.00
+    (£8.00/unit)%
+}
+Chargeable \textbf{loss} is £100.00
 
-                Capital loss to date is £100.00
-    
+Capital loss to date is £100.00
+
 \begin{enumerate}
 \item \textbf{BED AND BREAKFAST}. Quantity: 100,
-        allowable
-            cost on \mbox{20 May 2024:}
-        £900.00,
-            \mbox{loss: £100.00.}
-    
+    allowable
+    cost on \mbox{20 May 2024:}
+    £900.00,
+    \mbox{loss: £100.00.}
+
     Number of units left in the pool:
-0%
+    0%
 .
 
 \end{enumerate}
 
-         % if is_rename
-    \subsubsection*{
-        OLD was renamed to NEW%
-            }
+\subsubsection*{
+    OLD was renamed to NEW%
+}
 
 
 
 
 \subsection*{20 May 2024}
-         % if is_aquisition
-                        \subsubsection*{
-            Acquisition 2: 100 units of NEW for £900.00
-            (£9.00/unit)%
-                    }
-    
+\subsubsection*{
+    Acquisition 2: 100 units of NEW for £900.00
+    (£9.00/unit)%
+}
+
 \begin{enumerate}
 \item \textbf{BED AND BREAKFAST}. Quantity: 100,
- % if is_aquisition
     actual cost: £1,000.00.
 
     Number of units in the pool:
-100%
+    100%
 ,
     new pool cost: £1,000.00
     (£10.00/unit)%
-                    .
+.
 
 \end{enumerate}
 

--- a/tests/general/data/latex/spin_off.tex
+++ b/tests/general/data/latex/spin_off.tex
@@ -5,71 +5,65 @@
 \begin{document}
 \centerline{\Large\bfseries Capital Gains Tax Calculations for 2024-25}
 
-
 \section*{Capital Gains Events}
 
 
 \subsection*{01 June 2024}
-         % if is_aquisition
-                        \subsubsection*{
-            Acquisition 1: 10 units of FOO for £100.00
-            (£10.00/unit)%
-                    }
-    
+\subsubsection*{
+    Acquisition 1: 10 units of FOO for £100.00
+    (£10.00/unit)%
+}
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 10,
- % if is_aquisition
     actual cost: £100.00.
 
     Number of units in the pool:
-10%
+    10%
 ,
     new pool cost: £100.00
     (£10.00/unit)%
-                    .
+.
 
 \end{enumerate}
 
 
 
 \subsection*{05 July 2024}
-         % if is_aquisition
-                        \subsubsection*{
-            Acquisition 2: 10 units of BAR for £10.00
-            (£1.00/unit)%
-                    }
-    
+\subsubsection*{
+    Acquisition 2: 10 units of BAR for £10.00
+    (£1.00/unit)%
+}
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 10,
- % if is_aquisition
     actual cost: £10.00.
 
     Number of units in the pool:
-10%
+    10%
 ,
     new pool cost: £10.00
     (£1.00/unit)%
-    
+
     Cost basis calculated based on cost of FOO share pool from which BAR shares were spinned off%
-                    .
+.
 
 \end{enumerate}
 
-         % if is_spin_off
-                        \subsubsection*{
-            Spin-off adjustment 3: FOO cost adjusted because of BAR shares spinned off
-        }
-    
+\subsubsection*{
+    Spin-off adjustment 3: FOO cost adjusted because of BAR shares spinned off
+}
+
 \begin{enumerate}
 \item \textbf{SPIN OFF}. Quantity: 10,
     original cost of FOO: £100.00, after spin-off: £90.00
 
     Number of units in the pool:
-10%
+    10%
 ,
     new pool cost: £90.00
     (£9.00/unit)%
-        .
+.
 
 \end{enumerate}
 

--- a/tests/general/data/latex/split.tex
+++ b/tests/general/data/latex/split.tex
@@ -5,69 +5,63 @@
 \begin{document}
 \centerline{\Large\bfseries Capital Gains Tax Calculations for 2023-24}
 
-
 \section*{Capital Gains Events}
 
 
 \subsection*{02 May 2023}
-         % if is_aquisition
-                        \subsubsection*{
-            Acquisition 1: 0.9 units of FOO for £90.00
-            (£100.00/unit)%
-                    }
-    
+\subsubsection*{
+    Acquisition 1: 0.9 units of FOO for £90.00
+    (£100.00/unit)%
+}
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 0.9,
- % if is_aquisition
     actual cost: £90.00.
 
     Number of units in the pool:
-0.9%
+    0.9%
 ,
     new pool cost: £90.00
     (£100.00/unit)%
-                    .
+.
 
 \end{enumerate}
 
 
 
 \subsection*{15 May 2023}
-         % if is_aquisition
-                        \subsubsection*{
-            Acquisition 2: 0.0111111111 units of FOO for £10.00
-            (£900.00/unit)%
-                    }
-    
+\subsubsection*{
+    Acquisition 2: 0.0111111111 units of FOO for £10.00
+    (£900.00/unit)%
+}
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 0.0111111111,
- % if is_aquisition
     actual cost: £10.00.
 
     Number of units in the pool:
-0.1111111111%
+    0.1111111111%
 ,
     new pool cost: £100.00
     (£900.00/unit)%
-                    .
+.
 
 \end{enumerate}
 
-         % if is_split
-        \subsubsection*{
-        Share reorganisation: 0.9 units of FOO restated as 0.1 (ratio 1/9)
-    }
-    Neither a disposal nor an acquisition: the new holding is the same asset, held from the same dates, with the same pooled cost (TCGA 1992 s127).
+\subsubsection*{
+    Share reorganisation: 0.9 units of FOO restated as 0.1 (ratio 1/9)
+}
+Neither a disposal nor an acquisition: the new holding is the same asset, held from the same dates, with the same pooled cost (TCGA 1992 s127).
 
-    Stated as 1 units before the event and 0.11111111 after.
-    
-        Reconciled to that count by -0.0000000011 units, from 0.1111111111 to 0.11111111.
-    
-    Units in the pool at this point in the day: 0.11111111%
-    ,
-        pool cost: £100.00
-        (£900.00/unit)%
-    .
+Stated as 1 units before the event and 0.11111111 after.
+
+Reconciled to that count by -0.0000000011 units, from 0.1111111111 to 0.11111111.
+
+Units in the pool at this point in the day: 0.11111111%
+,
+    pool cost: £100.00
+    (£900.00/unit)%
+.
 
 
 

--- a/tests/general/data/latex/spouse_transfer.tex
+++ b/tests/general/data/latex/spouse_transfer.tex
@@ -5,45 +5,41 @@
 \begin{document}
 \centerline{\Large\bfseries Capital Gains Tax Calculations for 2024-25}
 
-
 \section*{Capital Gains Events}
 
 
 \subsection*{01 June 2024}
-         % if is_aquisition
-                        \subsubsection*{
-            Acquisition 1: 10 units of FOO for £100.00
-            (£10.00/unit)%
-                    }
-    
+\subsubsection*{
+    Acquisition 1: 10 units of FOO for £100.00
+    (£10.00/unit)%
+}
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 10,
- % if is_aquisition
     actual cost: £100.00.
 
     Number of units in the pool:
-10%
+    10%
 ,
     new pool cost: £100.00
     (£10.00/unit)%
-                    .
+.
 
 \end{enumerate}
 
 
 
 \subsection*{10 June 2024}
-         % if is_transfer_to_spouse
-    \subsubsection*{
-        Transferred to spouse: 4 units of FOO (no gain/no loss)
-    }
-    Base cost of £40.00 passes to the recipient.
+\subsubsection*{
+    Transferred to spouse: 4 units of FOO (no gain/no loss)
+}
+Base cost of £40.00 passes to the recipient.
 
-        Number of units left in the pool: 6%
-    ,
-        new pool cost: £60.00
-        (£10.00/unit)%
-    .
+Number of units left in the pool: 6%
+,
+    new pool cost: £60.00
+    (£10.00/unit)%
+.
 
 
 

--- a/tests/general/data/test_run_with_example_files_report.tex
+++ b/tests/general/data/test_run_with_example_files_report.tex
@@ -5,103 +5,98 @@
 \begin{document}
 \centerline{\Large\bfseries Capital Gains Tax Calculations for 2020-21}
 
-
 \section*{Capital Gains Events}
 
 
 \subsection*{02 June 2020}
-         % if is_aquisition
-                        \subsubsection*{
-            Acquisition 1: 100 units of VUAG for £2,042.38
-            (£20.42/unit)%
-                            , including £4.89 fees
-                    }
-    
+\subsubsection*{
+    Acquisition 1: 100 units of VUAG for £2,042.38
+    (£20.42/unit)%
+    , including £4.89 fees
+}
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 100,
- % if is_aquisition
     actual cost: £2,042.38.
 
     Number of units in the pool:
-100%
+    100%
 ,
     new pool cost: £2,042.38
     (£20.42/unit)%
-                    .
+.
 
 \end{enumerate}
 
 
 
 \subsection*{03 June 2020}
-         % if is_aquisition
-                        \subsubsection*{
-            Acquisition 2: 154 units of VUAG for £3,569.68
-            (£23.18/unit)%
-                            , including £8.15 fees
-                    }
-    
+\subsubsection*{
+    Acquisition 2: 154 units of VUAG for £3,569.68
+    (£23.18/unit)%
+    , including £8.15 fees
+}
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 154,
- % if is_aquisition
     actual cost: £3,569.68.
 
     Number of units in the pool:
-254%
+    254%
 ,
     new pool cost: £5,612.06
     (£22.09/unit)%
-                    .
+.
 
 \end{enumerate}
 
-                                \subsubsection*{
-            Disposal 1: 254 units of VUAG
-            for £5,887.53
-            (£23.18/unit)%
-                            , £12.22 fees allowed as cost
-                    }
-        Chargeable \textbf{gain} is £148.45
-                Capital gain to date is £148.45
-    
+\subsubsection*{
+    Disposal 1: 254 units of VUAG
+for £5,887.53
+    (£23.18/unit)%
+    , £12.22 fees allowed as cost
+}
+Chargeable \textbf{gain} is £148.45
+Capital gain to date is £148.45
+
 \begin{enumerate}
 \item \textbf{SAME DAY}. Quantity: 154,
-            disposal proceeds: £3,569.61,
-        allowable
-            cost:
-        £3,577.09,
-            \mbox{loss: £7.49.}
-    
+    disposal proceeds: £3,569.61,
+    allowable
+    cost:
+    £3,577.09,
+    \mbox{loss: £7.49.}
+
     Number of units left in the pool:
-100%
+    100%
 ,
     new pool cost: £2,042.38
     (£20.42/unit)%
-        .
+.
 
 \item \textbf{BED AND BREAKFAST}. Quantity: 30.5,
-            disposal proceeds: £706.97,
-        allowable
-            cost on \mbox{02 Jul 2020:}
-        £739.19,
-            \mbox{loss: £32.22.}
-    
+    disposal proceeds: £706.97,
+    allowable
+    cost on \mbox{02 Jul 2020:}
+    £739.19,
+    \mbox{loss: £32.22.}
+
     Number of units left in the pool:
-69.5%
+    69.5%
 ,
     new pool cost: £1,419.45
     (£20.42/unit)%
-        .
+.
 
 \item \textbf{SECTION 104}. Quantity: 69.5,
-            disposal proceeds: £1,610.96,
-        allowable
-            cost:
-        £1,422.80,
-            \mbox{gain: £188.16.}
-    
+    disposal proceeds: £1,610.96,
+    allowable
+    cost:
+    £1,422.80,
+    \mbox{gain: £188.16.}
+
     Number of units left in the pool:
-0%
+    0%
 .
 
 \end{enumerate}
@@ -109,45 +104,43 @@
 
 
 \subsection*{06 June 2020}
-         % if is_aquisition
-                        \subsubsection*{
-            Acquisition 3: 90 units of VUAG for £2,351.26
-            (£26.13/unit)%
-                            , including £4.07 fees
-                    }
-    
+\subsubsection*{
+    Acquisition 3: 90 units of VUAG for £2,351.26
+    (£26.13/unit)%
+    , including £4.07 fees
+}
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 90,
- % if is_aquisition
     actual cost: £2,351.26.
 
     Number of units in the pool:
-90%
+    90%
 ,
     new pool cost: £2,351.26
     (£26.13/unit)%
-                    .
+.
 
 \end{enumerate}
 
-                                \subsubsection*{
-            Disposal 2: 90 units of VUAG
-            for £2,420.54
-            (£26.89/unit)%
-                            , £4.07 fees allowed as cost
-                    }
-        Chargeable \textbf{gain} is £65.20
-                Capital gain to date is £213.65
-    
+\subsubsection*{
+    Disposal 2: 90 units of VUAG
+for £2,420.54
+    (£26.89/unit)%
+    , £4.07 fees allowed as cost
+}
+Chargeable \textbf{gain} is £65.20
+Capital gain to date is £213.65
+
 \begin{enumerate}
 \item \textbf{SAME DAY}. Quantity: 90,
-        allowable
-            cost:
-        £2,355.34,
-            \mbox{gain: £65.20.}
-    
+    allowable
+    cost:
+    £2,355.34,
+    \mbox{gain: £65.20.}
+
     Number of units left in the pool:
-0%
+    0%
 .
 
 \end{enumerate}
@@ -155,165 +148,154 @@
 
 
 \subsection*{24 June 2020}
-         % if is_aquisition
-                        \subsubsection*{
-            Acquisition 4: 1 units of VNRG for £8.07
-            (£8.07/unit)%
-                    }
-    
+\subsubsection*{
+    Acquisition 4: 1 units of VNRG for £8.07
+    (£8.07/unit)%
+}
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 1,
- % if is_aquisition
     actual cost: £8.07.
 
     Number of units in the pool:
-1%
+    1%
 ,
     new pool cost: £8.07
     (£8.07/unit)%
-                    .
+.
 
 \end{enumerate}
 
 
 
 \subsection*{30 June 2020}
-         % if is_eri
-                \subsubsection*{
-            Excess Reported Income: VNRG cost increased by £0.91
-            (£0.9061/unit)%
-        }
-    
+\subsubsection*{
+    Excess Reported Income: VNRG cost increased by £0.91
+    (£0.9061/unit)%
+}
+
 \begin{enumerate}
 \item \textbf{EXCESS REPORTED INCOME}. Quantity: 1,
     original cost of VNRG: £8.07, after income distribution: £8.98%
 
     Number of units in the pool:
-1%
+    1%
 ,
     new pool cost: £8.98
     (£8.98/unit)%
-        .
+.
 
 \end{enumerate}
 
 
 
 \subsection*{02 July 2020}
-         % if is_aquisition
-                        \subsubsection*{
-            Acquisition 5: 30.5 units of VUAG for £737.72
-            (£24.19/unit)%
-                            , including £3.19 fees
-                    }
-    
+\subsubsection*{
+    Acquisition 5: 30.5 units of VUAG for £737.72
+    (£24.19/unit)%
+    , including £3.19 fees
+}
+
 \begin{enumerate}
 \item \textbf{BED AND BREAKFAST}. Quantity: 30.5,
- % if is_aquisition
     actual cost: £645.19.
 
     Number of units in the pool:
-30.5%
+    30.5%
 ,
     new pool cost: £645.19
     (£21.15/unit)%
-                                        
+
     Cost basis increased by £22.26
     (£0.7300/unit)%
     , due to exccess reported income on \mbox{30 Jun 2020}%
-            .
+.
 
 \end{enumerate}
 
 
 
 \subsection*{25 November 2020}
-         % if is_aquisition
-                        \subsubsection*{
-            Acquisition 6: 100 units of GME for £1,106.25
-            (£11.06/unit)%
-                    }
-    
+\subsubsection*{
+    Acquisition 6: 100 units of GME for £1,106.25
+    (£11.06/unit)%
+}
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 100,
- % if is_aquisition
     actual cost: £1,106.25.
 
     Number of units in the pool:
-100%
+    100%
 ,
     new pool cost: £1,106.25
     (£11.06/unit)%
-                    .
+.
 
 \end{enumerate}
 
 
 
 \subsection*{27 November 2020}
-         % if is_aquisition
-                        \subsubsection*{
-            Acquisition 7: 1 units of NVDA for £401.01
-            (£401.01/unit)%
-                    }
-    
+\subsubsection*{
+    Acquisition 7: 1 units of NVDA for £401.01
+    (£401.01/unit)%
+}
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 1,
- % if is_aquisition
     actual cost: £401.01.
 
     Number of units in the pool:
-1%
+    1%
 ,
     new pool cost: £401.01
     (£401.01/unit)%
-                    .
+.
 
 \end{enumerate}
 
 
 
 \subsection*{26 January 2021}
-         % if is_aquisition
-                        \subsubsection*{
-            Acquisition 8: 100 units of GME for £6,554.80
-            (£65.55/unit)%
-                    }
-    
+\subsubsection*{
+    Acquisition 8: 100 units of GME for £6,554.80
+    (£65.55/unit)%
+}
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 100,
- % if is_aquisition
     actual cost: £6,554.80.
 
     Number of units in the pool:
-200%
+    200%
 ,
     new pool cost: £7,661.05
     (£38.31/unit)%
-                    .
+.
 
 \end{enumerate}
 
 
 
 \subsection*{01 February 2021}
-                                \subsubsection*{
-            Disposal 3: 200 units of GME
-            for £32,453.25
-            (£162.27/unit)%
-                    }
-        Chargeable \textbf{gain} is £24,792.20
-                Capital gain to date is £25,005.85
-    
+\subsubsection*{
+    Disposal 3: 200 units of GME
+for £32,453.25
+    (£162.27/unit)%
+}
+Chargeable \textbf{gain} is £24,792.20
+Capital gain to date is £25,005.85
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 200,
-        allowable
-            cost:
-        £7,661.05,
-            \mbox{gain: £24,792.20.}
-    
+    allowable
+    cost:
+    £7,661.05,
+    \mbox{gain: £24,792.20.}
+
     Number of units left in the pool:
-0%
+    0%
 .
 
 \end{enumerate}
@@ -321,83 +303,78 @@
 
 
 \subsection*{25 March 2021}
-         % if is_aquisition
-                        \subsubsection*{
-            Acquisition 9: 212 units of GOOG for £15,427.37
-            (£72.77/unit)%
-                    }
-    
+\subsubsection*{
+    Acquisition 9: 212 units of GOOG for £15,427.37
+    (£72.77/unit)%
+}
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 212,
- % if is_aquisition
     actual cost: £15,427.37.
 
     Number of units in the pool:
-212%
+    212%
 ,
     new pool cost: £15,427.37
     (£72.77/unit)%
-                    .
+.
 
 \end{enumerate}
 
 
 
 \subsection*{01 April 2021}
-                                \subsubsection*{
-            Disposal 4: 40 units of GOOG
-            for £3,075.58
-            (£76.89/unit)%
-                            , £0.04 fees allowed as cost
-                    }
-        Chargeable \textbf{gain} is £164.72
-                Capital gain to date is £25,170.57
-    
+\subsubsection*{
+    Disposal 4: 40 units of GOOG
+for £3,075.58
+    (£76.89/unit)%
+    , £0.04 fees allowed as cost
+}
+Chargeable \textbf{gain} is £164.72
+Capital gain to date is £25,170.57
+
 \begin{enumerate}
 \item \textbf{SECTION 104}. Quantity: 40,
-        allowable
-            cost:
-        £2,910.86,
-            \mbox{gain: £164.72.}
-    
+    allowable
+    cost:
+    £2,910.86,
+    \mbox{gain: £164.72.}
+
     Number of units left in the pool:
-172%
+    172%
 ,
     new pool cost: £12,516.55
     (£72.77/unit)%
-        .
+.
 
 \end{enumerate}
 
 
 
-    \clearpage
-    \section*{Interest and Dividends Events}
+\clearpage
+\section*{Interest and Dividends Events}
 
-    
-    \subsection*{30 December 2020}
-                                 % if is_eri_tax
-                                                    \textbf{Excess Reported Income Distribution 1}: VUAG (dividend) for £22.26
-        (£0.7300/unit)%
-    
-                                 % if is_eri_tax
-                                                    \textbf{Excess Reported Income Distribution 2}: VNRG (dividend) for £0.91
-        (£0.9061/unit)%
-    
-    
-    
-    \subsection*{03 February 2021}
-                                         % if is_interest
-                \textbf{Interest Foreign 1:} USD for £1.03
-    
-    
-    
-    \subsection*{02 April 2021}
-                                                                \textbf{Dividend 1:} NVDA for £0.10
-                    (tax paid at source: £0.00)
-                    
-    
-    
+
+\subsection*{30 December 2020}
+\textbf{Excess Reported Income Distribution 1}: VUAG (dividend) for £22.26
+(£0.7300/unit)%
+
+\textbf{Excess Reported Income Distribution 2}: VNRG (dividend) for £0.91
+(£0.9061/unit)%
+
+
+
+\subsection*{03 February 2021}
+\textbf{Interest Foreign 1:} USD for £1.03
+
+
+
+\subsection*{02 April 2021}
+\textbf{Dividend 1:} NVDA for £0.10
+(tax paid at source: £0.00)
+
+
+
 \clearpage
 \section*{Overall - Capital Gains}
 \subsection*{Number of acquisitions: 9}

--- a/tests/general/test_report_view.py
+++ b/tests/general/test_report_view.py
@@ -1,0 +1,523 @@
+"""Tests for the printable view of a capital gains report.
+
+The golden `.tex` files prove the template and the view agree with what the
+report used to say. These prove the numbers the view carries: which log key
+means which event, what is counted, what the running totals come to.
+"""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+
+from cgt_calc.exceptions import CalculationError
+from cgt_calc.model import (
+    CalculationEntry,
+    CapitalGainsReport,
+    Dividend,
+    ExcessReportedIncome,
+    RuleType,
+    SpinOff,
+    TaxTreaty,
+)
+from cgt_calc.report_view import (
+    EventKind,
+    EventView,
+    IncomeEventView,
+    IncomeKind,
+    Outcome,
+    build_report_view,
+)
+
+DAY = datetime.date(2024, 6, 10)
+OTHER_DAY = datetime.date(2024, 6, 11)
+
+
+def _entry(
+    rule_type: RuleType = RuleType.SECTION_104,
+    *,
+    quantity: str = "1",
+    amount: str = "0",
+    fees: str = "0",
+    gain: str | None = None,
+    allowable_cost: str = "0",
+    new_quantity: str = "0",
+    new_pool_cost: str = "0",
+    bed_and_breakfast_date_index: datetime.date | None = None,
+    spin_off: SpinOff | None = None,
+    dividend: Dividend | None = None,
+    eris: list[ExcessReportedIncome] | None = None,
+    renamed_to: str | None = None,
+) -> CalculationEntry:
+    """Build a calculation entry from strings, so the decimals stay exact."""
+    return CalculationEntry(
+        rule_type=rule_type,
+        quantity=Decimal(quantity),
+        amount=Decimal(amount),
+        fees=Decimal(fees),
+        gain=Decimal(gain) if gain is not None else None,
+        allowable_cost=Decimal(allowable_cost),
+        new_quantity=Decimal(new_quantity),
+        new_pool_cost=Decimal(new_pool_cost),
+        bed_and_breakfast_date_index=bed_and_breakfast_date_index,
+        spin_off=spin_off,
+        dividend=dividend,
+        eris=eris,
+        renamed_to=renamed_to,
+    )
+
+
+def _disposal(gain: str, *, quantity: str = "1") -> CalculationEntry:
+    """Build a disposal whose proceeds are its cost plus the gain asked for."""
+    cost = Decimal(100)
+    return _entry(
+        quantity=quantity,
+        amount=str(cost + Decimal(gain)),
+        allowable_cost=str(cost),
+        gain=gain,
+    )
+
+
+def _report(
+    log: dict[datetime.date, dict[str, list[CalculationEntry]]] | None = None,
+    yields: dict[datetime.date, dict[str, list[CalculationEntry]]] | None = None,
+) -> CapitalGainsReport:
+    """Build a report carrying nothing but the calculation logs under test."""
+    return CapitalGainsReport(
+        tax_year=2024,
+        portfolio=[],
+        disposal_count=0,
+        disposal_proceeds=Decimal(0),
+        allowable_costs=Decimal(0),
+        capital_gain=Decimal(0),
+        capital_loss=Decimal(0),
+        capital_gain_allowance=Decimal(3000),
+        dividend_allowance=Decimal(500),
+        calculation_log=log or {},
+        calculation_log_yields=yields or {},
+        total_uk_interest=Decimal(0),
+        total_foreign_interest=Decimal(0),
+        total_interest_tax=Decimal(0),
+        show_unrealized_gains=False,
+    )
+
+
+def _events(log: dict[str, list[CalculationEntry]]) -> list[EventView]:
+    """Build the view of one day's events."""
+    return list(build_report_view(_report({DAY: log})).days[0].events)
+
+
+SPIN_OFF = SpinOff(source="FOO", dest="BAR", date=DAY)
+ERI = ExcessReportedIncome(
+    price=Decimal("0.5"),
+    symbol="FOO",
+    date=DAY,
+    distribution_date=OTHER_DAY,
+    is_interest=False,
+)
+
+
+@pytest.mark.parametrize(
+    ("key", "entry", "kind"),
+    [
+        ("sell$FOO", _disposal("10"), EventKind.DISPOSAL),
+        ("buy$FOO", _entry(amount="-100", allowable_cost="100"), EventKind.ACQUISITION),
+        (
+            "spin-off$FOO",
+            _entry(rule_type=RuleType.SPIN_OFF, amount="-100", spin_off=SPIN_OFF),
+            EventKind.SPIN_OFF,
+        ),
+        (
+            "excess-reported-income$FOO",
+            _entry(
+                rule_type=RuleType.EXCESS_REPORTED_INCOME,
+                amount="-10",
+                allowable_cost="1",
+                new_pool_cost="11",
+                eris=[ERI],
+            ),
+            EventKind.ERI,
+        ),
+        ("rename$OLD", _entry(rule_type=RuleType.RENAME, renamed_to="NEW"), None),
+        ("split$FOO", _entry(rule_type=RuleType.STOCK_SPLIT), EventKind.SPLIT),
+        (
+            "transfer-to-spouse$FOO",
+            _entry(rule_type=RuleType.TRANSFER_TO_SPOUSE),
+            EventKind.TRANSFER_TO_SPOUSE,
+        ),
+        ("gift$FOO", _disposal("10"), EventKind.GIFT_CONNECTED),
+        ("gift-unconnected$FOO", _disposal("10"), EventKind.GIFT_UNCONNECTED),
+        ("exempt$FOO", _disposal("10"), EventKind.EXEMPT),
+        ("option$META call", _entry(rule_type=RuleType.OPTION), EventKind.OPTION_GRANT),
+    ],
+)
+def test_every_log_key_names_its_event(
+    key: str, entry: CalculationEntry, kind: EventKind | None
+) -> None:
+    """Each prefix decodes to one kind, and the symbol is what follows the $."""
+    (event,) = _events({key: [entry]})
+    assert event.kind == (kind or EventKind.RENAME)
+    assert event.symbol == key.split("$", 1)[1]
+
+
+def test_a_gift_to_a_connected_person_is_told_from_any_other_gift() -> None:
+    """`gift$` and `gift-unconnected$` share a prefix but not a kind."""
+    events = _events(
+        {"gift$FOO": [_disposal("-10")], "gift-unconnected$FOO": [_disposal("-10")]}
+    )
+    connected, unconnected = events
+    assert connected.kind is EventKind.GIFT_CONNECTED
+    assert connected.outcome is Outcome.CLOGGED_LOSS
+    assert unconnected.kind is EventKind.GIFT_UNCONNECTED
+    assert unconnected.outcome is Outcome.LOSS
+    assert all(event.is_gift for event in events)
+
+
+def test_an_unknown_log_key_is_refused() -> None:
+    """A key the report cannot name must fail rather than print nothing."""
+    with pytest.raises(
+        CalculationError, match=r"Unknown calculation log key: what\.FOO"
+    ):
+        _events({"what.FOO": [_disposal("1")]})
+
+
+def test_an_unknown_income_log_key_is_refused() -> None:
+    """The income log is decoded by the same rule."""
+    with pytest.raises(CalculationError, match=r"Unknown income log key: what\.FOO"):
+        build_report_view(_report(yields={DAY: {"what.FOO": [_entry()]}}))
+
+
+def test_a_purchase_without_units_is_a_management_fee() -> None:
+    """A `buy$` of nothing is the fee the report names separately."""
+    (event,) = _events({"buy$FOO": [_entry(quantity="0", amount="-5")]})
+    assert event.kind is EventKind.MANAGEMENT_FEE
+    assert event.is_acquisition
+    assert event.number is None
+
+
+def test_the_counters_skip_what_the_report_does_not_count() -> None:
+    """Disposals, option grants and gifts count; a fee and a nil spin-off do not."""
+    view = build_report_view(
+        _report(
+            {
+                DAY: {
+                    "buy$FOO": [_entry(quantity="1", amount="-10")],
+                    "buy$BAR": [_entry(quantity="0", amount="-5")],
+                    "spin-off$FOO": [
+                        _entry(
+                            rule_type=RuleType.SPIN_OFF, amount="-1", spin_off=SPIN_OFF
+                        )
+                    ],
+                    "sell$FOO": [_disposal("10")],
+                    "option$META call": [_disposal("10")],
+                    "gift$BAR": [_disposal("10")],
+                    "exempt$T26": [_disposal("10")],
+                },
+                OTHER_DAY: {
+                    "spin-off$FOO": [
+                        _entry(
+                            rule_type=RuleType.SPIN_OFF,
+                            quantity="0",
+                            amount="-1",
+                            spin_off=SPIN_OFF,
+                        )
+                    ],
+                },
+            }
+        )
+    )
+    assert view.summary.acquisition_count == 2
+    assert view.summary.disposal_count == 3
+    numbered = [(event.kind, event.number) for day in view.days for event in day.events]
+    assert numbered == [
+        (EventKind.ACQUISITION, 1),
+        (EventKind.MANAGEMENT_FEE, None),
+        (EventKind.SPIN_OFF, 2),
+        (EventKind.DISPOSAL, 1),
+        (EventKind.OPTION_GRANT, 2),
+        (EventKind.GIFT_CONNECTED, 3),
+        (EventKind.EXEMPT, None),
+        (EventKind.SPIN_OFF, None),
+    ]
+
+
+def test_the_running_totals_add_up_the_rounded_events() -> None:
+    """Gain, loss, nil and clogged loss each go to their own total."""
+    view = build_report_view(
+        _report(
+            {
+                DAY: {
+                    "sell$FOO": [_disposal("10.005")],
+                    "sell$BAR": [_disposal("-4")],
+                    "sell$BAZ": [_disposal("0")],
+                    "gift$QUX": [_disposal("-2.50")],
+                    "gift-unconnected$FOO": [_disposal("1")],
+                }
+            }
+        )
+    )
+    gain, loss, nil, clogged, unconnected = view.days[0].events
+    assert (gain.outcome, gain.gain_to_date) == (Outcome.GAIN, Decimal("10.01"))
+    assert (loss.outcome, loss.loss_to_date) == (Outcome.LOSS, Decimal("4.00"))
+    assert (nil.outcome, nil.gain) == (Outcome.NIL, Decimal("0.00"))
+    assert nil.gain_to_date is None
+    assert (clogged.outcome, clogged.gift_loss_to_date) == (
+        Outcome.CLOGGED_LOSS,
+        Decimal("2.50"),
+    )
+    assert unconnected.gain_to_date == Decimal("11.01")
+    assert view.summary.total_gain == Decimal("11.01")
+    assert view.summary.total_loss == Decimal("4.00")
+    assert view.summary.gift_loss == Decimal("2.50")
+    assert view.summary.net_gain == Decimal("7.01")
+
+
+def test_an_exempt_disposal_stays_out_of_every_total() -> None:
+    """Its gain is stated but disregarded, so no counter and no total moves."""
+    view = build_report_view(_report({DAY: {"exempt$T26": [_disposal("10")]}}))
+    (event,) = view.days[0].events
+    assert (event.outcome, event.gain) == (Outcome.GAIN, Decimal("10.00"))
+    assert event.pool_units_left
+    assert view.summary.total_gain == Decimal(0)
+    assert view.summary.disposal_count == 0
+
+
+def test_a_line_shows_its_own_proceeds_only_beside_others() -> None:
+    """One rule matching the whole disposal has nothing to break down."""
+    (whole,) = _events({"sell$FOO": [_disposal("10", quantity="4")]})
+    assert [line.shows_proceeds for line in whole.lines] == [False]
+    (split,) = _events(
+        {"sell$FOO": [_disposal("10", quantity="3"), _disposal("6", quantity="1")]}
+    )
+    assert [line.shows_proceeds for line in split.lines] == [True, True]
+
+
+def test_the_events_stated_in_prose_carry_no_lines() -> None:
+    """A rename, a reorganisation and a spouse transfer print no rule list."""
+    events = _events(
+        {
+            "rename$OLD": [_entry(rule_type=RuleType.RENAME, renamed_to="NEW")],
+            "split$FOO": [_entry(rule_type=RuleType.STOCK_SPLIT)],
+            "transfer-to-spouse$FOO": [_entry(rule_type=RuleType.TRANSFER_TO_SPOUSE)],
+            "sell$FOO": [_disposal("1")],
+        }
+    )
+    assert [bool(event.lines) for event in events] == [False, False, False, True]
+
+
+def test_a_pool_emptied_by_the_event_has_no_price_per_unit() -> None:
+    """Nothing is divided by a pool of no units."""
+    (event,) = _events(
+        {"transfer-to-spouse$FOO": [_entry(rule_type=RuleType.TRANSFER_TO_SPOUSE)]}
+    )
+    assert event.pool_quantity == 0
+    assert event.pool_per_unit is None
+
+
+def test_excess_reported_income_prices_a_unit_to_four_places() -> None:
+    """The unit price of ERI is the one figure kept beyond the penny."""
+    (event,) = _events(
+        {
+            "excess-reported-income$FOO": [
+                _entry(
+                    rule_type=RuleType.EXCESS_REPORTED_INCOME,
+                    amount="-10",
+                    allowable_cost="1",
+                    new_pool_cost="11",
+                    eris=[ERI],
+                )
+            ]
+        }
+    )
+    assert event.eri_unit_price == Decimal("0.5000")
+
+
+def test_an_acquisition_carries_the_income_added_to_its_cost() -> None:
+    """Each ERI on an acquisition line is priced and dated for the report."""
+    (event,) = _events(
+        {"buy$FOO": [_entry(quantity="3", amount="-30", eris=[ERI], spin_off=SPIN_OFF)]}
+    )
+    (line,) = event.lines
+    assert line.spin_off_source == "FOO"
+    assert [(eri.cost, eri.unit_price, eri.date) for eri in line.eris] == [
+        (Decimal("1.50"), Decimal("0.5000"), DAY)
+    ]
+
+
+def test_a_disposal_line_keeps_the_sign_the_report_prints() -> None:
+    """A gain too small to survive rounding is still stated as a gain."""
+    (event,) = _events({"sell$FOO": [_disposal("0.001")]})
+    (line,) = event.lines
+    assert line.is_gain
+    assert line.gain == Decimal("0.00")
+    assert line.bnb_date is None
+
+
+def test_a_bed_and_breakfast_line_carries_the_day_it_matched() -> None:
+    """The date only reaches the report on the rule that used it."""
+    (event,) = _events(
+        {
+            "sell$FOO": [
+                _entry(
+                    rule_type=RuleType.BED_AND_BREAKFAST,
+                    amount="110",
+                    allowable_cost="100",
+                    gain="10",
+                    bed_and_breakfast_date_index=OTHER_DAY,
+                )
+            ]
+        }
+    )
+    assert event.lines[0].bnb_date == OTHER_DAY
+
+
+def _yields(log: dict[str, list[CalculationEntry]]) -> list[IncomeEventView]:
+    """Build the view of one day's income events."""
+    return list(build_report_view(_report(yields={DAY: log})).income_days[0].events)
+
+
+def _dividend(
+    *, is_interest: bool = False, treaty: TaxTreaty | None = None
+) -> Dividend:
+    """Build a dividend of £100 with £15 withheld."""
+    return Dividend(
+        date=DAY,
+        symbol="FOO",
+        amount=Decimal(100),
+        tax_at_source=Decimal(-15),
+        is_interest=is_interest,
+        tax_treaty=treaty,
+    )
+
+
+def test_the_income_log_keys_name_their_events() -> None:
+    """Interest is named after its currency, everything else after the $."""
+    events = _yields(
+        {
+            "dividend$FOO": [
+                _entry(rule_type=RuleType.DIVIDEND, amount="100", dividend=_dividend())
+            ],
+            "interestUK$Testing": [_entry(rule_type=RuleType.INTEREST, amount="3")],
+            "interestUSD$Testing": [_entry(rule_type=RuleType.INTEREST, amount="4")],
+            "interestTaxGBP$Testing": [
+                _entry(rule_type=RuleType.INTEREST_TAX, amount="1")
+            ],
+            "interestTaxUSD$Testing": [
+                _entry(rule_type=RuleType.INTEREST_TAX, amount="2")
+            ],
+            "excess-reported-income-distribution$BAR": [
+                _entry(
+                    rule_type=RuleType.EXCESS_REPORTED_INCOME_DISTRIBUTION,
+                    amount="22.26",
+                    eris=[ERI],
+                )
+            ],
+        }
+    )
+    assert [(e.kind, e.symbol, e.origin, e.number) for e in events] == [
+        (IncomeKind.DIVIDEND, "FOO", None, 1),
+        (IncomeKind.INTEREST, "Testing", "UK", 1),
+        (IncomeKind.INTEREST, "USD", "Foreign", 2),
+        (IncomeKind.INTEREST_TAX, "GBP", "UK", 1),
+        (IncomeKind.INTEREST_TAX, "USD", "Foreign", 2),
+        (IncomeKind.ERI_DISTRIBUTION, "BAR", None, 1),
+    ]
+    assert events[-1].unit_price == Decimal("0.5000")
+    assert events[-1].is_interest is False
+
+
+def test_a_dividend_states_the_tax_withheld_and_any_treaty_relief() -> None:
+    """Both figures reach the report already rounded to the penny."""
+    treaty = TaxTreaty(
+        country="USA", country_rate=Decimal("0.30"), treaty_rate=Decimal("0.15")
+    )
+    (event,) = _yields(
+        {
+            "dividend$FOO": [
+                _entry(
+                    rule_type=RuleType.DIVIDEND,
+                    amount="100",
+                    dividend=_dividend(treaty=treaty),
+                )
+            ]
+        }
+    )
+    assert event.amount == Decimal("100.00")
+    assert event.tax_at_source == Decimal("15.00")
+    assert (event.treaty_country, event.treaty_rate, event.treaty_amount) == (
+        "USA",
+        Decimal("15.00"),
+        Decimal("15.00"),
+    )
+
+
+def test_a_dividend_paid_as_interest_carries_no_treaty() -> None:
+    """Nothing is claimed back on interest, so the treaty fields stay empty."""
+    (event,) = _yields(
+        {
+            "dividend$FOO": [
+                _entry(
+                    rule_type=RuleType.DIVIDEND,
+                    amount="100",
+                    dividend=_dividend(is_interest=True),
+                )
+            ]
+        }
+    )
+    assert event.is_interest
+    assert event.treaty_country is None
+    assert event.treaty_rate is None
+    assert event.treaty_amount is None
+
+
+def test_the_income_section_is_left_out_when_nothing_was_paid() -> None:
+    """An empty yields log means the report has no income pages."""
+    view = build_report_view(_report({DAY: {"sell$FOO": [_disposal("1")]}}))
+    assert view.income_days == ()
+    assert view.income_summary.eri_dividends is None
+    assert view.income_summary.eri_interest is None
+    assert view.income_summary.dividend_count == 0
+
+
+def test_the_income_summary_splits_excess_reported_income_by_fund() -> None:
+    """Interest funds and dividend funds are stated on their own lines."""
+    interest_eri = ExcessReportedIncome(
+        price=Decimal("0.25"),
+        symbol="BAR",
+        date=DAY,
+        distribution_date=OTHER_DAY,
+        is_interest=True,
+    )
+    view = build_report_view(
+        _report(
+            yields={
+                DAY: {
+                    "excess-reported-income-distribution$FOO": [
+                        _entry(
+                            rule_type=RuleType.EXCESS_REPORTED_INCOME_DISTRIBUTION,
+                            amount="10",
+                            eris=[ERI],
+                        )
+                    ],
+                    "excess-reported-income-distribution$BAR": [
+                        _entry(
+                            rule_type=RuleType.EXCESS_REPORTED_INCOME_DISTRIBUTION,
+                            amount="4",
+                            eris=[interest_eri],
+                        )
+                    ],
+                }
+            }
+        )
+    )
+    assert view.income_summary.eri_count == 2
+    assert view.income_summary.eri_dividends == Decimal("10.00")
+    assert view.income_summary.eri_interest == Decimal("4.00")
+    assert view.income_summary.total_dividends == Decimal("10.00")
+
+
+def test_the_view_names_the_period_the_report_covers() -> None:
+    """The title comes straight from the report."""
+    assert build_report_view(_report()).title_period == "2024-25"


### PR DESCRIPTION
Moves everything `template.tex.j2` used to decide - event kind from log keys, running totals/counters, derived prices, sentence choice, rounding - into one typed module, so the template becomes loops and `\VAR{}` over it.

- `cgt_calc/report_view.py`: `build_report_view()` plus frozen dataclasses/enums. Makes every one of those decisions for the detailed report, with the same prefix order and rounding/summation as the old template. `render_text.py` still reads the gift and spouse-transfer keys for its own two sections; a follow-up can route it through the view.
- `template.tex.j2`: `BLOCK{ set }` count 77 -> 0; no `startswith`/slices/`namespace`/`round_decimal` left. Every sentence unchanged, typos included. Layout tidied with `lstrip_blocks`, dropping the stray indentation and `% if ...` comment lines the old template leaked into the `.tex`.
- `render_latex.py`: passes `view=build_report_view(report)`, adds a `money` filter, drops `report`/`Decimal`/`round_decimal` from context.
- `tests/general/test_report_view.py`: 31 tests (prefix decoding incl. gift ambiguity, counters incl. uncounted kinds, running totals, `shows_proceeds`).
- The nine `.tex` goldens are regenerated for the layout change only: each is identical to its previous version once whitespace runs and comment-only lines are normalised, with paragraph breaks preserved.

The PDF is unchanged for every report the calculator produces; the `.tex` source differs only in whitespace and comment lines, and the stdout fixture is byte-identical. An unknown internal calculation-log key now raises `CalculationError` instead of producing a partial event.
