### PR TITLE
Export parsed transactions with `--dump-transactions`

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -121,6 +121,7 @@ ISINs
 isoformat
 json
 KeyError
+jsonable
 Lansdown
 latex
 len

--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -154,6 +154,7 @@ OCC
 OCI
 OpenFIGI
 OPRA
+OptionType
 OSError
 OTGLY
 ParsingError

--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -118,9 +118,11 @@ iShares
 ISIN
 IsinConverter
 ISINs
+isoformat
 json
 KeyError
 Lansdown
+latex
 len
 LF
 lifecycle

--- a/cgt_calc/args_parser.py
+++ b/cgt_calc/args_parser.py
@@ -211,16 +211,15 @@ Environment variables:
         action="store_true",
         help="save LaTeX source instead of generating a PDF",
     )
-    output_group.add_argument(
-        "--dump-transactions",
-        nargs="?",
-        const="continue",
-        default=None,
-        type=str.lower,
-        choices=["continue", "exit", "only", "normal"],
-        help="dump parsed transactions in chronological order; "
-        "'continue' to proceed with calculations (default if mode omitted), "
-        "or 'exit' / 'only' to exit without calculating",
+    set_completer(
+        output_group.add_argument(
+            "--dump-transactions",
+            type=output_path_type,
+            metavar="PATH",
+            default=None,
+            help="write parsed transactions as CSV to a new file, then continue calculating",
+        ),
+        shtab.FILE,
     )
 
     # General Options

--- a/cgt_calc/args_parser.py
+++ b/cgt_calc/args_parser.py
@@ -211,6 +211,17 @@ Environment variables:
         action="store_true",
         help="save LaTeX source instead of generating a PDF",
     )
+    output_group.add_argument(
+        "--dump-transactions",
+        nargs="?",
+        const="continue",
+        default=None,
+        type=str.lower,
+        choices=["continue", "exit", "only", "normal"],
+        help="dump parsed transactions in chronological order; "
+        "'continue' to proceed with calculations (default if mode omitted), "
+        "or 'exit' / 'only' to exit without calculating",
+    )
 
     # General Options
     general_group = parser.add_argument_group("General")

--- a/cgt_calc/cli.py
+++ b/cgt_calc/cli.py
@@ -24,6 +24,7 @@ from .isin_converter import IsinConverter
 from .logging import setup_logging, style_text
 from .parsers.broker_registry import BrokerRegistry
 from .spin_off_handler import SpinOffHandler
+from .transaction_dumper import dump_transactions
 
 if TYPE_CHECKING:
     import argparse
@@ -43,6 +44,12 @@ def calculate_cgt(args: argparse.Namespace) -> None:
     # Read data from input files
     isin_converter = IsinConverter(isin_translation_file)
     broker_transactions = BrokerRegistry.load_all_transactions(args, isin_converter)
+
+    if args.dump_transactions:
+        dump_transactions(broker_transactions)
+        if args.dump_transactions in {"exit", "only"}:
+            return
+
     currency_converter = CurrencyConverter.create(args.exchange_rates_file)
     price_fetcher = CurrentPriceFetcher(currency_converter)
     initial_prices = InitialPrices(args.initial_prices_file)

--- a/cgt_calc/cli.py
+++ b/cgt_calc/cli.py
@@ -18,7 +18,7 @@ from .args_parser import (
 )
 from .currency_converter import CurrencyConverter
 from .current_price_fetcher import CurrentPriceFetcher
-from .exceptions import CgtError
+from .exceptions import CgtError, TransactionDumpError
 from .initial_prices import InitialPrices
 from .isin_converter import IsinConverter
 from .logging import setup_logging, style_text
@@ -28,8 +28,87 @@ from .transaction_dumper import dump_transactions
 
 if TYPE_CHECKING:
     import argparse
+    from collections.abc import Iterator, Sequence
+    from pathlib import Path
+
+    from .model import BrokerTransaction
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _paths_written_after_dump(args: argparse.Namespace) -> Iterator[tuple[Path, str]]:
+    """Yield each file the rest of this run may write, and what it is.
+
+    The dump is saved before anything else, so a destination naming one of
+    these would be silently replaced by the time the run finished. The report
+    names follow render_latex.render_pdf; pdflatex leaves its own log and aux
+    file next to the report and removes them again afterwards.
+    """
+    if not args.no_report:
+        directory = args.output.parent
+        jobname = args.output.stem
+        yield args.output, "the report from --output"
+        yield directory / f"{jobname}.tex", "the LaTeX source from --output"
+        if not args.no_pdflatex:
+            # pdflatex names its output after the report's stem, so an
+            # --output carrying any other suffix, or none, still lands here.
+            yield directory / f"{jobname}.pdf", "the PDF report from --output"
+            for suffix in (".latex.log", ".log", ".aux"):
+                yield (
+                    directory / f"{jobname}{suffix}",
+                    "a pdflatex working file from --output",
+                )
+    for cache, option in (
+        (args.exchange_rates_file, "--exchange-rates-file"),
+        (args.isin_translation_file, "--isin-translation-file"),
+        (args.spin_offs_file, "--spin-offs-file"),
+    ):
+        if cache is not None:
+            yield cache, f"the cache from {option}"
+
+
+def _save_transaction_dump(
+    args: argparse.Namespace, transactions: Sequence[BrokerTransaction]
+) -> None:
+    """Write the parsed transactions to the new CSV file the user asked for."""
+    path: Path = args.dump_transactions
+    destination = path.resolve()
+    for other, description in _paths_written_after_dump(args):
+        if other.resolve() == destination:
+            raise TransactionDumpError(
+                f"--dump-transactions path '{path}' is also {description}, "
+                "which this run writes after saving the dump. Choose a "
+                "different filename."
+            )
+    if not path.parent.is_dir():
+        raise TransactionDumpError(
+            f"--dump-transactions directory '{path.parent}' does not exist. "
+            "Create it, or choose a path in a directory that does."
+        )
+    try:
+        with path.open("x", encoding="utf-8", newline="") as stream:
+            dump_transactions(transactions, stream)
+    except FileExistsError as err:
+        raise TransactionDumpError(
+            f"--dump-transactions file '{path}' already exists. Choose a new "
+            "filename, or move the existing file out of the way."
+        ) from err
+    except OSError as err:
+        raise TransactionDumpError(
+            f"Could not write parsed transactions to '{path}': {err}. A partly "
+            "written file may be left behind; remove it or choose another "
+            "filename before retrying."
+        ) from err
+    count = len(transactions)
+    noun = "transaction" if count == 1 else "transactions"
+    LOGGER.info(
+        style_text(
+            f"Saved {count} parsed {noun} to {path}",
+            colour=Fore.CYAN,
+            emoji="💾",
+            stream=sys.stderr,
+        )
+    )
 
 
 def calculate_cgt(args: argparse.Namespace) -> None:
@@ -45,10 +124,8 @@ def calculate_cgt(args: argparse.Namespace) -> None:
     isin_converter = IsinConverter(isin_translation_file)
     broker_transactions = BrokerRegistry.load_all_transactions(args, isin_converter)
 
-    if args.dump_transactions:
-        dump_transactions(broker_transactions)
-        if args.dump_transactions in {"exit", "only"}:
-            return
+    if args.dump_transactions is not None:
+        _save_transaction_dump(args, broker_transactions)
 
     currency_converter = CurrencyConverter.create(args.exchange_rates_file)
     price_fetcher = CurrentPriceFetcher(currency_converter)

--- a/cgt_calc/exceptions.py
+++ b/cgt_calc/exceptions.py
@@ -283,6 +283,15 @@ class MissingExternalToolError(CgtError):
         super().__init__(f"Required tool '{tool}' is not available on PATH")
 
 
+class TransactionDumpError(CgtError):
+    """Raised when the parsed-transaction CSV cannot be written."""
+
+    def __init__(self, message: str):
+        """Initialise."""
+        self.message = message
+        super().__init__(self.message)
+
+
 class IsinTranslationError(CgtError):
     """Raised when invalid ISIN translation data is encountered."""
 

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -27,6 +27,7 @@ from .model import (
     PortfolioEntry,
     Position,
 )
+from .transaction_dumper import dump_transactions
 from .util import round_decimal
 
 if TYPE_CHECKING:
@@ -42,7 +43,13 @@ if TYPE_CHECKING:
 
 # The CLI entry points live in cgt_calc.cli now; re-exported here so
 # existing imports and `python -m cgt_calc.main` keep working.
-__all__ = ["CapitalGainsCalculator", "calculate_cgt", "init", "main"]
+__all__ = [
+    "CapitalGainsCalculator",
+    "calculate_cgt",
+    "dump_transactions",
+    "init",
+    "main",
+]
 
 LOGGER = logging.getLogger(__name__)
 

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -27,7 +27,6 @@ from .model import (
     PortfolioEntry,
     Position,
 )
-from .transaction_dumper import dump_transactions
 from .util import round_decimal
 
 if TYPE_CHECKING:
@@ -43,13 +42,7 @@ if TYPE_CHECKING:
 
 # The CLI entry points live in cgt_calc.cli now; re-exported here so
 # existing imports and `python -m cgt_calc.main` keep working.
-__all__ = [
-    "CapitalGainsCalculator",
-    "calculate_cgt",
-    "dump_transactions",
-    "init",
-    "main",
-]
+__all__ = ["CapitalGainsCalculator", "calculate_cgt", "init", "main"]
 
 LOGGER = logging.getLogger(__name__)
 

--- a/cgt_calc/transaction_dumper.py
+++ b/cgt_calc/transaction_dumper.py
@@ -62,10 +62,24 @@ def _jsonable(value: object) -> object:
             field.name: _jsonable(getattr(value, field.name)) for field in fields(value)
         }
     if isinstance(value, dict):
-        return {str(key): _jsonable(item) for key, item in value.items()}
+        return {_json_key(key): _jsonable(item) for key, item in value.items()}
     if isinstance(value, list | tuple):
         return [_jsonable(item) for item in value]
-    raise TypeError(f"Cannot export a {type(value).__name__} to CSV")
+    raise TypeError(f"Cannot export {type(value).__name__} to CSV")
+
+
+def _json_key(key: object) -> str:
+    """Render a mapping key, which JSON can only hold as text.
+
+    Keys go through the same rules as values instead of through str(), which
+    would turn anything that is not already text into a Python repr. That is
+    how a memory address reaches a file whose whole point is that two exports
+    of one history compare cleanly.
+    """
+    rendered = _jsonable(key)
+    if not isinstance(rendered, str):
+        raise TypeError(f"Cannot export {type(key).__name__} as a CSV field name")
+    return rendered
 
 
 def _csv_field(value: object) -> str:

--- a/cgt_calc/transaction_dumper.py
+++ b/cgt_calc/transaction_dumper.py
@@ -1,9 +1,15 @@
-"""Dump parsed broker transactions in chronological order."""
+"""Export parsed broker transactions as CSV for inspection."""
 
 from __future__ import annotations
 
-import sys
-from typing import TYPE_CHECKING
+import csv
+from dataclasses import fields, is_dataclass
+import datetime
+from decimal import Decimal
+from enum import Enum
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -11,52 +17,96 @@ if TYPE_CHECKING:
 
     from .model import BrokerTransaction
 
-__all__ = ["dump_transactions"]
+__all__ = ["DUMP_FIELDS", "dump_transactions"]
+
+# Every BrokerTransaction field as it stands once parsing is done, in the
+# order the dataclass declares them, except:
+#  * `source` is last, because its file and row provenance is what differs
+#    when two exports describe the same transactions;
+#  * `calculation_quantity` is left out, because the calculator sets it while
+#    planning share reorganisations, long after this snapshot is taken.
+DUMP_FIELDS: Final = (
+    "date",
+    "action",
+    "symbol",
+    "description",
+    "quantity",
+    "price",
+    "fees",
+    "amount",
+    "currency",
+    "broker",
+    "isin",
+    "foreign_fees",
+    "ambiguous_quantity",
+    "option_contract",
+    "written_option_tax",
+    "capital_adjustments",
+    "affects_cash_balance",
+    "source",
+)
+
+
+def _jsonable(value: object) -> object:
+    """Convert one value to JSON types, deliberately without a str() catch-all.
+
+    An unknown type raises instead of being rendered through Python's repr,
+    so a new model field forces a decision about how to export it.
+    """
+    if value is None or isinstance(value, bool | int):
+        return value
+    if isinstance(value, str | Decimal | Path):
+        return str(value)
+    if isinstance(value, datetime.date):
+        # datetime.datetime is a date, and isoformat covers both.
+        return value.isoformat()
+    if isinstance(value, Enum):
+        # The name is stable; the value is an implementation detail.
+        return value.name
+    if is_dataclass(value) and not isinstance(value, type):
+        return {
+            field.name: _jsonable(getattr(value, field.name)) for field in fields(value)
+        }
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_jsonable(item) for item in value]
+    raise TypeError(f"Cannot export a {type(value).__name__} to CSV")
+
+
+def _csv_field(value: object) -> str:
+    """Render one transaction field as CSV text.
+
+    Scalars are written plainly and exactly; anything with structure becomes
+    compact JSON in the one field. None is written as an empty field, which an
+    empty string also produces: this is a diagnostic export, not a backup.
+
+    Everything but text goes through json.dumps, which already writes a
+    boolean as true/false and a number bare, as the schema asks.
+    """
+    if value is None:
+        return ""
+    rendered = _jsonable(value)
+    if isinstance(rendered, str):
+        return rendered
+    return json.dumps(rendered, sort_keys=True, separators=(",", ":"))
 
 
 def dump_transactions(
-    transactions: Sequence[BrokerTransaction],
-    stream: TextIO | None = None,
+    transactions: Sequence[BrokerTransaction], stream: TextIO
 ) -> None:
-    """Print parsed broker transactions in chronological order.
+    """Write parsed transactions to `stream` as CSV, header first.
 
-    Args:
-        transactions: Sequence of broker transactions to dump.
-        stream: Output stream to write to (defaults to stdout).
+    Rows keep the order the broker registry returned, which is the order the
+    calculation reads them in and not necessarily the order they happened.
 
+    The stream belongs to the caller: it is neither closed nor reconfigured
+    here, and it has to be opened with newline="" so that the writer's own
+    record terminator is what reaches the file.
     """
-    if stream is None:
-        stream = sys.stdout
-
-    if not transactions:
-        print("No transactions loaded.", file=sys.stderr)
-        return
-
-    header = (
-        f"{'Date':10} | {'Action':22} | {'Symbol':6} | {'Qty':>12} | "
-        f"{'Price':>12} | {'Amount':>16} | {'Fees':>8} | {'Broker':15}"
-    )
-    print(file=stream)
-    print(header, file=stream)
-    print("-" * len(header), file=stream)
-
-    for t in transactions:
-        qty_str = f"{t.quantity}" if t.quantity is not None else "-"
-        price_str = (
-            f"{t.price:.4f}".rstrip("0").rstrip(".") or "0"
-            if t.price is not None
-            else "-"
+    writer = csv.writer(stream)
+    writer.writerow(DUMP_FIELDS)
+    for transaction in transactions:
+        writer.writerow(
+            [_csv_field(getattr(transaction, name)) for name in DUMP_FIELDS]
         )
-        amount_str = f"{t.amount:.2f} {t.currency}" if t.amount is not None else "-"
-        fees_str = f"{t.fees:.2f}"
-        broker_str = t.broker or "-"
-
-        row = (
-            f"{t.date!s:10} | {t.action.name:22} | {t.symbol or '-':6} | "
-            f"{qty_str:>12} | {price_str:>12} | {amount_str:>16} | "
-            f"{fees_str:>8} | {broker_str:15}"
-        )
-        print(row, file=stream)
-
-    print("-" * len(header), file=stream)
-    print(f"Total: {len(transactions)} transaction(s)\n", file=stream)

--- a/cgt_calc/transaction_dumper.py
+++ b/cgt_calc/transaction_dumper.py
@@ -1,0 +1,62 @@
+"""Dump parsed broker transactions in chronological order."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import TextIO
+
+    from .model import BrokerTransaction
+
+__all__ = ["dump_transactions"]
+
+
+def dump_transactions(
+    transactions: Sequence[BrokerTransaction],
+    stream: TextIO | None = None,
+) -> None:
+    """Print parsed broker transactions in chronological order.
+
+    Args:
+        transactions: Sequence of broker transactions to dump.
+        stream: Output stream to write to (defaults to stdout).
+
+    """
+    if stream is None:
+        stream = sys.stdout
+
+    if not transactions:
+        print("No transactions loaded.", file=sys.stderr)
+        return
+
+    header = (
+        f"{'Date':10} | {'Action':22} | {'Symbol':6} | {'Qty':>12} | "
+        f"{'Price':>12} | {'Amount':>16} | {'Fees':>8} | {'Broker':15}"
+    )
+    print(file=stream)
+    print(header, file=stream)
+    print("-" * len(header), file=stream)
+
+    for t in transactions:
+        qty_str = f"{t.quantity}" if t.quantity is not None else "-"
+        price_str = (
+            f"{t.price:.4f}".rstrip("0").rstrip(".") or "0"
+            if t.price is not None
+            else "-"
+        )
+        amount_str = f"{t.amount:.2f} {t.currency}" if t.amount is not None else "-"
+        fees_str = f"{t.fees:.2f}"
+        broker_str = t.broker or "-"
+
+        row = (
+            f"{t.date!s:10} | {t.action.name:22} | {t.symbol or '-':6} | "
+            f"{qty_str:>12} | {price_str:>12} | {amount_str:>16} | "
+            f"{fees_str:>8} | {broker_str:15}"
+        )
+        print(row, file=stream)
+
+    print("-" * len(header), file=stream)
+    print(f"Total: {len(transactions)} transaction(s)\n", file=stream)

--- a/cgt_calc/transaction_dumper.py
+++ b/cgt_calc/transaction_dumper.py
@@ -69,17 +69,23 @@ def _jsonable(value: object) -> object:
 
 
 def _json_key(key: object) -> str:
-    """Render a mapping key, which JSON can only hold as text.
+    """Return a mapping key, which JSON can only hold as text.
 
-    Keys go through the same rules as values instead of through str(), which
-    would turn anything that is not already text into a Python repr. That is
-    how a memory address reaches a file whose whole point is that two exports
-    of one history compare cleanly.
+    Only a key that is already text is accepted. str() on anything else would
+    turn it into a Python repr, and for an arbitrary object that includes its
+    memory address, in a file whose whole point is that two exports of one
+    history compare cleanly.
+
+    Converting other types instead would not be safe either: the conversion is
+    not one-to-one, so OptionType.CALL and the string "CALL" would both become
+    "CALL" and one of the two entries would quietly vanish. Distinct text keys
+    cannot collide, because a mapping already holds only one of any two equal
+    strings. A mapping keyed by something else needs a decision about how to
+    name its entries, so it is refused until someone makes it.
     """
-    rendered = _jsonable(key)
-    if not isinstance(rendered, str):
+    if not isinstance(key, str):
         raise TypeError(f"Cannot export {type(key).__name__} as a CSV field name")
-    return rendered
+    return key
 
 
 def _csv_field(value: object) -> str:

--- a/cgt_calc/transaction_dumper.py
+++ b/cgt_calc/transaction_dumper.py
@@ -11,39 +11,33 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
+from .model import BrokerTransaction
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import TextIO
 
-    from .model import BrokerTransaction
-
 __all__ = ["DUMP_FIELDS", "dump_transactions"]
 
-# Every BrokerTransaction field as it stands once parsing is done, in the
-# order the dataclass declares them, except:
-#  * `source` is last, because its file and row provenance is what differs
-#    when two exports describe the same transactions;
+# The columns come from BrokerTransaction itself, so a field added to the
+# model is exported rather than quietly missing from a file users are told
+# holds every parsed value. Two deliberate departures from its declared order:
 #  * `calculation_quantity` is left out, because the calculator sets it while
-#    planning share reorganisations, long after this snapshot is taken.
+#    planning share reorganisations, long after this snapshot is taken;
+#  * `source` is moved last, because its file and row provenance is what
+#    differs when two exports describe the same transactions.
+# A test pins the resulting header, so a new field still has to be looked at,
+# and _jsonable refuses a type it does not know rather than guessing.
+_EXCLUDED_FIELDS: Final = frozenset({"calculation_quantity"})
+_TRAILING_FIELDS: Final = ("source",)
+
 DUMP_FIELDS: Final = (
-    "date",
-    "action",
-    "symbol",
-    "description",
-    "quantity",
-    "price",
-    "fees",
-    "amount",
-    "currency",
-    "broker",
-    "isin",
-    "foreign_fees",
-    "ambiguous_quantity",
-    "option_contract",
-    "written_option_tax",
-    "capital_adjustments",
-    "affects_cash_balance",
-    "source",
+    tuple(
+        field.name
+        for field in fields(BrokerTransaction)
+        if field.name not in _EXCLUDED_FIELDS and field.name not in _TRAILING_FIELDS
+    )
+    + _TRAILING_FIELDS
 )
 
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -96,15 +96,15 @@ cgt-calc --year 2024 --schwab-file transactions.csv --dump-transactions parsed-t
 This helps when you want to compare two exports of the same account, or see what a broker file
 actually produced before reading the report.
 
-The file is written before any calculation starts, and cgt-calc confirms it on **stderr**:
+cgt-calc saves the file before any calculation starts, and confirms it on **stderr**:
 
 ```text
 Saved 123 parsed transactions to parsed-transactions.csv
 ```
 
-That message means the file is complete and closed. It is not the message that ends a successful
-run, which is `Done! Report generated successfully.` or, without a PDF,
-`Done! Calculations complete (PDF generation skipped).`
+That message means the file is complete. It is not the message that ends a run, which begins
+`Done!`, so a saved file does not show that the calculation succeeded. If the calculation fails, the
+file is kept for you to inspect and the command still exits with an error.
 
 ### What the file contains
 
@@ -112,57 +112,41 @@ One row per transaction, under a header naming every column. The rows are in the
 calculation reads them, which is not always the order they happened: some brokers export the newest
 row first, and cgt-calc deliberately places some of a day’s rows before others.
 
-The file shows the transactions after cgt-calc has read and prepared your broker exports, and before
-the capital gains calculation. It reflects whatever duplicate handling the parser for your broker
-supports; the export itself removes nothing, so follow the
-[instructions for your broker](brokers/index.md) and do not assume overlapping exports are safe.
-
-Any excess reported income (ERI) records loaded for funds you hold are included as well. They appear
-with the action `EXCESS_REPORTED_INCOME` and an `isin` in place of a `symbol`, and carry only a
-per-unit `price`: the `quantity` and `amount` are worked out during the calculation, so those
-columns are empty here. See the [offshore funds guide](offshore-funds.md).
-
-The calculation has not run yet. Currency conversion, its own checks, share split and other
-reorganisation planning, and the tax calculation all come later, so ticker names and quantities can
-differ from the ones in the final report.
-
-Numbers are exact rather than rounded for display. `price`, `fees` and `amount` are in the row’s
-`currency`. Fees charged in another currency stay in `foreign_fees` under their own currency, and
-every amount recorded inside a column keeps the currency stored with it.
-
-Some columns hold several named values at once (`foreign_fees`, `option_contract`,
-`written_option_tax`, `capital_adjustments` and `source`). These use JSON, which keeps the names and
-their values together in one cell, such as `{"EUR":"2.50"}` for a fee of 2.50 euros. An empty column
-means the value was either not set or empty text; the two look the same. Inside a JSON column they
-stay apart, as `null` and `""`.
-
 Every transaction cgt-calc loaded is exported, including dates outside the reporting period.
 `--year`, `--from` and `--to` still choose the period the report covers.
 
-The file is a snapshot for inspection, not an input format. Its columns are not the seven columns of
-the [RAW format](brokers/raw.md), and it cannot be passed back with `--raw-file`.
+Because the calculation has not run yet, ticker names and quantities can differ from the final
+report. The file reflects whatever duplicate handling the parser for your broker supports and
+removes nothing itself, so follow the [instructions for your broker](brokers/index.md) and do not
+assume overlapping exports are safe.
 
-The `source` column identifies the input file each transaction came from, and includes a row number
-when the parser records one. It can therefore contain paths from your own machine next to your
-transaction details. Read it before you send it to anyone. Saving the file writes only to the name
-you gave; the calculation that follows behaves as it always does, including any data it fetches, as
-described in the [privacy notes](privacy.md).
+Numbers are exact rather than rounded for display. `price`, `fees` and `amount` are in the row’s
+`currency`, and fees charged in another currency stay in `foreign_fees` under their own currency.
+
+Columns holding several named values, such as `foreign_fees` and `source`, use JSON, which keeps
+names and values together in one cell: `{"EUR":"2.50"}` is a fee of 2.50 euros. An empty column
+means the value was unset or empty text, which look the same outside JSON.
+
+Excess reported income (ERI) records loaded for funds you hold appear with the action
+`EXCESS_REPORTED_INCOME` and an `isin` in place of a `symbol`. They carry only a per-unit `price`,
+so `quantity` and `amount` stay empty until the calculation works them out. See the
+[offshore funds guide](offshore-funds.md).
+
+The file is a snapshot for inspection, not an input format: its columns are not the seven columns of
+the [RAW format](brokers/raw.md), and it cannot be passed back with `--raw-file`. `source` names the
+input file each transaction came from, and includes a row number when the parser records one, so the
+export can contain paths from your own machine. Read it before you send it to anyone, and see the
+[privacy notes](privacy.md).
 
 ### Where it is written
 
-`--dump-transactions` requires a path and always creates a new file. cgt-calc refuses to overwrite
-an existing file, refuses a path whose directory does not exist, and refuses a path the same run
-would write later, such as the report or one of the cache files. In each case it reports the problem
-and stops without calculating.
-
-If writing fails partway through, cgt-calc stops with an error naming the path. Remove the partly
-written file, or choose another name, before trying again.
+`--dump-transactions` always creates a new file. cgt-calc refuses to overwrite an existing file,
+refuses a path whose directory does not exist, and refuses a path the same run would write later,
+such as the report or one of the cache files. If writing fails partway through, it stops with an
+error naming the path; remove the partly written file, or choose another name, before trying again.
 
 Nothing else about the run changes. `--output`, `--no-report` and `--no-pdflatex` still do what they
-normally do, and the usual checks on your input still apply. If the calculation fails after the file
-was saved, the file is kept for you to inspect and the command still exits with an error. A saved
-file does not show that the calculation succeeded, or that the history you supplied was complete or
-valid, so check the exit status and any errors printed.
+normally do, and the usual checks on your input still apply.
 
 ## Check the result
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -84,6 +84,75 @@ To save the LaTeX source without creating a PDF, use `--no-pdflatex`. The source
 `--output` path with a `.tex` extension (by default, `out/calculations.tex`). For example,
 `--output reports/2024-25.pdf` writes `reports/2024-25.tex`.
 
+## Inspect parsed transactions
+
+Use `--dump-transactions` with a path to save the transactions cgt-calc read from your exports, then
+carry on with the normal calculation:
+
+```shell
+cgt-calc --year 2024 --schwab-file transactions.csv --dump-transactions parsed-transactions.csv
+```
+
+This helps when you want to compare two exports of the same account, or see what a broker file
+actually produced before reading the report.
+
+The file is written before any calculation starts, and cgt-calc confirms it on **stderr**:
+
+```text
+Saved 123 parsed transactions to parsed-transactions.csv
+```
+
+That message means the file is complete and closed. It is not the message that ends a successful
+run, which is `Done! Report generated successfully.` or, without a PDF,
+`Done! Calculations complete (PDF generation skipped).`
+
+### What the file contains
+
+One row per transaction, under a header naming every column. The rows are in the order the
+calculation reads them, which is not always the order they happened: some brokers export the newest
+row first, and cgt-calc deliberately places some of a day’s rows before others.
+
+The rows are what the broker parsers produced. Broker-specific reconciliation, removal of rows
+repeated across overlapping exports, Excess Reported Income filtering and that ordering have all
+been applied. Currency conversion, the calculation’s own checks, share split and other
+reorganisation planning, and the tax calculation have not, because they all come later. Ticker names
+and quantities can therefore differ from the ones in the final report.
+
+Numbers are exact rather than rounded for display. `price`, `fees` and `amount` are in the row’s
+`currency`. Fees charged in another currency stay in `foreign_fees` under their own currency, and
+each nested amount keeps the currency recorded with it.
+
+Columns holding more than one value (`foreign_fees`, `option_contract`, `written_option_tax`,
+`capital_adjustments` and `source`) contain JSON. An empty column means the value was either not set
+or empty text; the two look the same. Inside the JSON columns they stay apart, as `null` and `""`.
+
+Every transaction cgt-calc loaded is exported, including dates outside the reporting period.
+`--year`, `--from` and `--to` still choose the period the report covers.
+
+The file is a snapshot for inspection, not an input format. Its columns are not the seven columns of
+the [RAW format](brokers/raw.md), and it cannot be passed back with `--raw-file`.
+
+`source` records the file and row each transaction came from, so the export can contain paths from
+your own machine next to your transaction details. Read it before you send it to anyone. Saving it
+writes only to the path you gave; the calculation that follows behaves as it always does, including
+any data it fetches, as described in the [privacy notes](privacy.md).
+
+### Where it is written
+
+`--dump-transactions` requires a path and always creates a new file. cgt-calc refuses to overwrite
+an existing file, refuses a path whose directory does not exist, and refuses a path the same run
+would write later, such as the report or one of the cache files. In each case it reports the problem
+and stops without calculating.
+
+If writing fails partway through, cgt-calc stops with an error naming the path. Remove the partly
+written file, or choose another name, before trying again.
+
+Nothing else about the run changes. `--output`, `--no-report` and `--no-pdflatex` still do what they
+normally do, and the usual checks on your input still apply. If the calculation fails after the file
+was saved, the file is kept for you to inspect and the command still exits with an error. A saved
+file does not show that the calculation succeeded, or that the history you supplied was complete or
+valid, so check the exit status and any errors printed.
+
 ## Check the result
 
 Before relying on the figures:
@@ -137,7 +206,9 @@ the calculation. Follow HMRC's
 required records and retention period.
 
 Run `cgt-calc --help` for the complete list of available options. Use `--verbose` when you need more
-detail while investigating a warning or error.
+detail while investigating a warning or error, and
+[`--dump-transactions`](#inspect-parsed-transactions) to see the transactions the calculation
+started from.
 
 ## Report part of a tax year (advanced)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -86,8 +86,8 @@ To save the LaTeX source without creating a PDF, use `--no-pdflatex`. The source
 
 ## Inspect parsed transactions
 
-Use `--dump-transactions` with a path to save the transactions cgt-calc read from your exports, then
-carry on with the normal calculation:
+Use `--dump-transactions` followed by a filename to save the transactions cgt-calc read from your
+exports to a CSV file, then carry on with the normal calculation:
 
 ```shell
 cgt-calc --year 2024 --schwab-file transactions.csv --dump-transactions parsed-transactions.csv
@@ -112,19 +112,25 @@ One row per transaction, under a header naming every column. The rows are in the
 calculation reads them, which is not always the order they happened: some brokers export the newest
 row first, and cgt-calc deliberately places some of a day’s rows before others.
 
-The rows are what the broker parsers produced. Broker-specific reconciliation, removal of rows
-repeated across overlapping exports, Excess Reported Income filtering and that ordering have all
-been applied. Currency conversion, the calculation’s own checks, share split and other
-reorganisation planning, and the tax calculation have not, because they all come later. Ticker names
-and quantities can therefore differ from the ones in the final report.
+The file shows the transactions after cgt-calc has read and prepared your broker exports, and before
+the capital gains calculation. Any income cgt-calc adds for offshore funds you hold is already
+included. It also includes whatever duplicate handling the parser for your broker supports; the
+export itself removes nothing, so follow the [instructions for your broker](brokers/index.md) and do
+not assume overlapping exports are safe.
+
+The calculation has not run yet. Currency conversion, its own checks, share split and other
+reorganisation planning, and the tax calculation all come later, so ticker names and quantities can
+differ from the ones in the final report.
 
 Numbers are exact rather than rounded for display. `price`, `fees` and `amount` are in the row’s
 `currency`. Fees charged in another currency stay in `foreign_fees` under their own currency, and
-each nested amount keeps the currency recorded with it.
+every amount recorded inside a column keeps the currency stored with it.
 
-Columns holding more than one value (`foreign_fees`, `option_contract`, `written_option_tax`,
-`capital_adjustments` and `source`) contain JSON. An empty column means the value was either not set
-or empty text; the two look the same. Inside the JSON columns they stay apart, as `null` and `""`.
+Some columns hold several named values at once (`foreign_fees`, `option_contract`,
+`written_option_tax`, `capital_adjustments` and `source`). These use JSON, which keeps the names and
+their values together in one cell, such as `{"EUR":"2.50"}` for a fee of 2.50 euros. An empty column
+means the value was either not set or empty text; the two look the same. Inside a JSON column they
+stay apart, as `null` and `""`.
 
 Every transaction cgt-calc loaded is exported, including dates outside the reporting period.
 `--year`, `--from` and `--to` still choose the period the report covers.
@@ -132,10 +138,11 @@ Every transaction cgt-calc loaded is exported, including dates outside the repor
 The file is a snapshot for inspection, not an input format. Its columns are not the seven columns of
 the [RAW format](brokers/raw.md), and it cannot be passed back with `--raw-file`.
 
-`source` records the file and row each transaction came from, so the export can contain paths from
-your own machine next to your transaction details. Read it before you send it to anyone. Saving it
-writes only to the path you gave; the calculation that follows behaves as it always does, including
-any data it fetches, as described in the [privacy notes](privacy.md).
+The `source` column identifies the input file each transaction came from, and includes a row number
+when the parser records one. It can therefore contain paths from your own machine next to your
+transaction details. Read it before you send it to anyone. Saving the file writes only to the name
+you gave; the calculation that follows behaves as it always does, including any data it fetches, as
+described in the [privacy notes](privacy.md).
 
 ### Where it is written
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -113,10 +113,14 @@ calculation reads them, which is not always the order they happened: some broker
 row first, and cgt-calc deliberately places some of a day’s rows before others.
 
 The file shows the transactions after cgt-calc has read and prepared your broker exports, and before
-the capital gains calculation. Any income cgt-calc adds for offshore funds you hold is already
-included. It also includes whatever duplicate handling the parser for your broker supports; the
-export itself removes nothing, so follow the [instructions for your broker](brokers/index.md) and do
-not assume overlapping exports are safe.
+the capital gains calculation. It reflects whatever duplicate handling the parser for your broker
+supports; the export itself removes nothing, so follow the
+[instructions for your broker](brokers/index.md) and do not assume overlapping exports are safe.
+
+Any excess reported income (ERI) records loaded for funds you hold are included as well. They appear
+with the action `EXCESS_REPORTED_INCOME` and an `isin` in place of a `symbol`, and carry only a
+per-unit `price`: the `quantity` and `amount` are worked out during the calculation, so those
+columns are empty here. See the [offshore funds guide](offshore-funds.md).
 
 The calculation has not run yet. Currency conversion, its own checks, share split and other
 reorganisation planning, and the tax calculation all come later, so ticker names and quantities can

--- a/tests/general/test_args_parser.py
+++ b/tests/general/test_args_parser.py
@@ -1017,43 +1017,38 @@ def test_autoconvert_currency_is_opt_in() -> None:
     assert parser.parse_args(["--autoconvert-currency"]).autoconvert_currency is True
 
 
-def test_dump_transactions_default_none() -> None:
-    """--dump-transactions defaults to None when not specified."""
+def test_dump_transactions_defaults_to_no_export() -> None:
+    """--dump-transactions is off unless a destination is given."""
     parser = create_parser()
+
     assert parser.parse_args([]).dump_transactions is None
 
 
-def test_dump_transactions_flag_defaults_to_continue() -> None:
-    """--dump-transactions defaults to continue when passed without a value."""
-    parser = create_parser()
-    assert parser.parse_args(["--dump-transactions"]).dump_transactions == "continue"
-
-
 @pytest.mark.parametrize(
-    ("arg", "expected"),
+    "value",
     [
-        ("continue", "continue"),
-        ("normal", "normal"),
-        ("exit", "exit"),
-        ("only", "only"),
-        ("EXIT", "exit"),
-        ("Only", "only"),
-        ("Normal", "normal"),
-        ("CONTINUE", "continue"),
+        "parsed.csv",
+        "reports/parsed.csv",
+        # The option once took mode words; they are now ordinary filenames.
+        "only",
+        "continue",
     ],
 )
-def test_dump_transactions_accepted_modes(arg: str, expected: str) -> None:
-    """--dump-transactions accepts continue, normal, exit, only case-insensitively."""
+def test_dump_transactions_takes_a_path(value: str) -> None:
+    """--dump-transactions accepts any non-empty path."""
     parser = create_parser()
-    args = parser.parse_args(["--dump-transactions", arg])
-    assert args.dump_transactions == expected
+
+    args = parser.parse_args(["--dump-transactions", value])
+
+    assert args.dump_transactions == Path(value)
 
 
-def test_dump_transactions_rejects_invalid_mode() -> None:
-    """--dump-transactions rejects unknown modes."""
+@pytest.mark.parametrize("argv", [["--dump-transactions"], ["--dump-transactions", ""]])
+def test_dump_transactions_requires_a_destination(argv: list[str]) -> None:
+    """--dump-transactions is rejected without a usable path."""
     parser = create_parser()
 
     with pytest.raises(SystemExit) as exc_info:
-        parser.parse_args(["--dump-transactions", "invalid"])
+        parser.parse_args(argv)
 
     assert exc_info.value.code == 2

--- a/tests/general/test_args_parser.py
+++ b/tests/general/test_args_parser.py
@@ -1015,3 +1015,45 @@ def test_autoconvert_currency_is_opt_in() -> None:
 
     assert parser.parse_args([]).autoconvert_currency is False
     assert parser.parse_args(["--autoconvert-currency"]).autoconvert_currency is True
+
+
+def test_dump_transactions_default_none() -> None:
+    """--dump-transactions defaults to None when not specified."""
+    parser = create_parser()
+    assert parser.parse_args([]).dump_transactions is None
+
+
+def test_dump_transactions_flag_defaults_to_continue() -> None:
+    """--dump-transactions defaults to continue when passed without a value."""
+    parser = create_parser()
+    assert parser.parse_args(["--dump-transactions"]).dump_transactions == "continue"
+
+
+@pytest.mark.parametrize(
+    ("arg", "expected"),
+    [
+        ("continue", "continue"),
+        ("normal", "normal"),
+        ("exit", "exit"),
+        ("only", "only"),
+        ("EXIT", "exit"),
+        ("Only", "only"),
+        ("Normal", "normal"),
+        ("CONTINUE", "continue"),
+    ],
+)
+def test_dump_transactions_accepted_modes(arg: str, expected: str) -> None:
+    """--dump-transactions accepts continue, normal, exit, only case-insensitively."""
+    parser = create_parser()
+    args = parser.parse_args(["--dump-transactions", arg])
+    assert args.dump_transactions == expected
+
+
+def test_dump_transactions_rejects_invalid_mode() -> None:
+    """--dump-transactions rejects unknown modes."""
+    parser = create_parser()
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["--dump-transactions", "invalid"])
+
+    assert exc_info.value.code == 2

--- a/tests/general/test_dump_transactions.py
+++ b/tests/general/test_dump_transactions.py
@@ -384,6 +384,63 @@ def test_an_unexportable_value_is_refused() -> None:
         _dump_to_string([transaction])
 
 
+def test_no_python_repr_reaches_the_file() -> None:
+    """No column leaks a Python object literal, whichever column it is.
+
+    Checking the whole export rather than named cells covers a column no
+    assertion here thought to look at, which is what a repr fallback would
+    quietly fill.
+    """
+    text = _dump_to_string([_rich()])
+
+    for leak in (
+        "Decimal(",
+        "datetime.date(",
+        "datetime.datetime(",
+        "PosixPath(",
+        "WindowsPath(",
+        "ActionType.",
+        "OptionType.",
+        " object at 0x",
+    ):
+        assert leak not in text, f"{leak!r} leaked into the export"
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        # JSON names values with text, and these have no text form the
+        # export can choose on the author's behalf.
+        7,
+        ("GOOG", datetime.date(2023, 1, 1)),
+    ],
+)
+def test_a_key_that_is_not_text_is_refused(key: object) -> None:
+    """A mapping key is held to the same rules as a value.
+
+    str() on a key would put a Python repr, and for an arbitrary object a
+    memory address, into a file that is meant to compare cleanly.
+    """
+    transaction = _minimal()
+    transaction.foreign_fees = {key: Decimal(1)}  # type: ignore[dict-item]  # ty: ignore[invalid-assignment]
+
+    with pytest.raises(TypeError, match="Cannot export"):
+        _dump_to_string([transaction])
+
+
+def test_keys_with_a_text_form_are_kept() -> None:
+    """A key the rules can render becomes that text, not its repr."""
+    transaction = _minimal()
+    transaction.foreign_fees = {  # ty: ignore[invalid-assignment]
+        datetime.date(2023, 1, 1): Decimal(1),  # type: ignore[dict-item]
+        CurrencyCode("USD"): Decimal(2),
+    }
+
+    (row,) = _read_rows(_dump_to_string([transaction]))
+
+    assert json.loads(row["foreign_fees"]) == {"2023-01-01": "1", "USD": "2"}
+
+
 def test_the_stream_stays_open_for_the_caller() -> None:
     """The exporter never closes a stream it was handed."""
     stream = io.StringIO(newline="")

--- a/tests/general/test_dump_transactions.py
+++ b/tests/general/test_dump_transactions.py
@@ -409,17 +409,20 @@ def test_no_python_repr_reaches_the_file() -> None:
 @pytest.mark.parametrize(
     "key",
     [
-        # JSON names values with text, and these have no text form the
-        # export can choose on the author's behalf.
+        # JSON names entries with text, and none of these is text.
         7,
+        datetime.date(2023, 1, 1),
+        OptionType.CALL,
         ("GOOG", datetime.date(2023, 1, 1)),
     ],
 )
 def test_a_key_that_is_not_text_is_refused(key: object) -> None:
-    """A mapping key is held to the same rules as a value.
+    """A mapping keyed by anything but text is refused, not guessed at.
 
     str() on a key would put a Python repr, and for an arbitrary object a
-    memory address, into a file that is meant to compare cleanly.
+    memory address, into a file that is meant to compare cleanly. Converting
+    it under the value rules would not be safe either, since two keys can
+    share one text form.
     """
     transaction = _minimal()
     transaction.foreign_fees = {key: Decimal(1)}  # type: ignore[dict-item]  # ty: ignore[invalid-assignment]
@@ -428,17 +431,34 @@ def test_a_key_that_is_not_text_is_refused(key: object) -> None:
         _dump_to_string([transaction])
 
 
-def test_keys_with_a_text_form_are_kept() -> None:
-    """A key the rules can render becomes that text, not its repr."""
+def test_two_keys_cannot_collapse_into_one() -> None:
+    """No entry disappears because two keys share a text form.
+
+    OptionType.CALL and "CALL" would both name a "CALL" entry, and one of the
+    two would quietly vanish. Refusing the key that is not already text is
+    what keeps that from happening.
+    """
     transaction = _minimal()
     transaction.foreign_fees = {  # ty: ignore[invalid-assignment]
-        datetime.date(2023, 1, 1): Decimal(1),  # type: ignore[dict-item]
-        CurrencyCode("USD"): Decimal(2),
+        OptionType.CALL: Decimal(1),  # type: ignore[dict-item]
+        "CALL": Decimal(2),  # type: ignore[dict-item]
+    }
+
+    with pytest.raises(TypeError, match="Cannot export"):
+        _dump_to_string([transaction])
+
+
+def test_text_keys_are_kept_as_they_are() -> None:
+    """A currency-keyed mapping exports under its own names."""
+    transaction = _minimal()
+    transaction.foreign_fees = {
+        CurrencyCode("PLN"): Decimal("0.30"),
+        CurrencyCode("EUR"): Decimal(2),
     }
 
     (row,) = _read_rows(_dump_to_string([transaction]))
 
-    assert json.loads(row["foreign_fees"]) == {"2023-01-01": "1", "USD": "2"}
+    assert json.loads(row["foreign_fees"]) == {"EUR": "2", "PLN": "0.30"}
 
 
 def test_the_stream_stays_open_for_the_caller() -> None:

--- a/tests/general/test_dump_transactions.py
+++ b/tests/general/test_dump_transactions.py
@@ -1,0 +1,206 @@
+"""Unit and integration tests for transaction dumping functionality."""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+import io
+import subprocess
+from typing import TYPE_CHECKING
+
+from cgt_calc.model import ActionType, BrokerTransaction, CurrencyCode
+from cgt_calc.transaction_dumper import dump_transactions
+import dump_transactions as dump_script
+from tests.utils import build_cmd, report_path
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _sample_transactions() -> list[BrokerTransaction]:
+    """Generate sample transactions for testing."""
+    return [
+        BrokerTransaction(
+            date=datetime.date(2023, 4, 25),
+            action=ActionType.STOCK_ACTIVITY,
+            symbol="GOOG",
+            description="RS",
+            quantity=Decimal("10.5"),
+            price=Decimal("100.25"),
+            fees=Decimal("1.50"),
+            amount=Decimal("1054.125"),
+            currency=CurrencyCode("USD"),
+            broker="Test Broker",
+        ),
+        BrokerTransaction(
+            date=datetime.date(2023, 5, 1),
+            action=ActionType.DIVIDEND,
+            symbol=None,
+            description="Dividend",
+            quantity=None,
+            price=None,
+            fees=Decimal(0),
+            amount=Decimal("50.00"),
+            currency=CurrencyCode("GBP"),
+            broker="",
+        ),
+        BrokerTransaction(
+            date=datetime.date(2023, 6, 1),
+            action=ActionType.BUY,
+            symbol="AAPL",
+            description="Buy AAPL",
+            quantity=Decimal(5),
+            price=Decimal(0),
+            fees=Decimal(0),
+            amount=Decimal(0),
+            currency=CurrencyCode("USD"),
+            broker="Broker B",
+        ),
+    ]
+
+
+def test_dump_transactions_empty(capsys: pytest.CaptureFixture[str]) -> None:
+    """An empty list prints an informative message to stderr."""
+    buf = io.StringIO()
+    dump_transactions([], stream=buf)
+
+    assert buf.getvalue() == ""
+    captured = capsys.readouterr()
+    assert "No transactions loaded." in captured.err
+
+
+def test_dump_transactions_formatting() -> None:
+    """Transactions are formatted in a clean table with headers and totals."""
+    buf = io.StringIO()
+    transactions = _sample_transactions()
+    dump_transactions(transactions, stream=buf)
+
+    output = buf.getvalue()
+    lines = [line for line in output.splitlines() if line]
+
+    assert len(lines) == 7
+    assert "Date" in lines[0]
+    assert "Action" in lines[0]
+    assert "Symbol" in lines[0]
+    assert "Qty" in lines[0]
+    assert "Price" in lines[0]
+    assert "Amount" in lines[0]
+    assert "Fees" in lines[0]
+    assert "Broker" in lines[0]
+
+    # Row 1: all fields present
+    assert (
+        lines[2]
+        == "2023-04-25 | STOCK_ACTIVITY         | GOOG   |         10.5 |       100.25 |      1054.12 USD |     1.50 | Test Broker    "
+    )
+
+    # Row 2: None fields display as "-"
+    assert (
+        lines[3]
+        == "2023-05-01 | DIVIDEND               | -      |            - |            - |        50.00 GBP |     0.00 | -              "
+    )
+
+    # Row 3: price of Decimal(0) displays as "0"
+    assert (
+        lines[4]
+        == "2023-06-01 | BUY                    | AAPL   |            5 |            0 |         0.00 USD |     0.00 | Broker B       "
+    )
+
+    assert lines[6] == "Total: 3 transaction(s)"
+
+
+def test_cli_dump_transactions_only_exits_without_calculations(
+    request: pytest.FixtureRequest,
+) -> None:
+    """--dump-transactions only dumps the table and exits 0 without calculating."""
+    cmd = build_cmd(
+        "--schwab-equity-award-json",
+        "tests/schwab/data/equity_award/schwab_equity_award_v1.json",
+        "--dump-transactions",
+        "only",
+        "--output",
+        report_path(request),
+    )
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0
+    assert "Date       | Action                 | Symbol" in result.stdout
+    assert "STOCK_ACTIVITY         | GOOG" in result.stdout
+    assert "Total: 4 transaction(s)" in result.stdout
+    # Ensure calculations and summary were not performed
+    assert "Tax summary" not in result.stdout
+    assert "Capital gains" not in result.stdout
+
+
+def test_cli_dump_transactions_exit_mode(
+    request: pytest.FixtureRequest,
+) -> None:
+    """--dump-transactions exit mode behaves identically to only mode."""
+    cmd = build_cmd(
+        "--schwab-equity-award-json",
+        "tests/schwab/data/equity_award/schwab_equity_award_v1.json",
+        "--dump-transactions",
+        "exit",
+        "--output",
+        report_path(request),
+    )
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0
+    assert "Total: 4 transaction(s)" in result.stdout
+    assert "Tax summary" not in result.stdout
+
+
+def test_cli_dump_transactions_continue_runs_calculations(
+    request: pytest.FixtureRequest,
+) -> None:
+    """--dump-transactions continue mode dumps table and continues calculations."""
+    cmd = build_cmd(
+        "--year",
+        "2023",
+        "--schwab-equity-award-json",
+        "tests/schwab/data/equity_award/schwab_equity_award_v2.json",
+        "--dump-transactions",
+        "continue",
+        "--output",
+        report_path(request),
+    )
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0
+    # Both dump table and calculation summary should be in stdout
+    assert "Date       | Action                 | Symbol" in result.stdout
+    assert "Total: 8 transaction(s)" in result.stdout
+    assert "Tax summary for 2023/2024" in result.stdout
+    assert "Capital gains" in result.stdout
+
+
+def test_cli_dump_transactions_flag_alone_defaults_to_continue(
+    request: pytest.FixtureRequest,
+) -> None:
+    """--dump-transactions without value defaults to continue mode."""
+    cmd = build_cmd(
+        "--year",
+        "2023",
+        "--schwab-equity-award-json",
+        "tests/schwab/data/equity_award/schwab_equity_award_v2.json",
+        "--dump-transactions",
+        "--output",
+        report_path(request),
+    )
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0
+    assert "Total: 8 transaction(s)" in result.stdout
+    assert "Tax summary for 2023/2024" in result.stdout
+
+
+def test_dump_transactions_script_entry_point() -> None:
+    """dump_transactions.py wrapper runs correctly and returns 0."""
+    exit_code = dump_script.main(
+        [
+            "--schwab-equity-award-json",
+            "tests/schwab/data/equity_award/schwab_equity_award_v1.json",
+        ]
+    )
+    assert exit_code == 0

--- a/tests/general/test_dump_transactions.py
+++ b/tests/general/test_dump_transactions.py
@@ -141,12 +141,38 @@ def _read_rows(text: str) -> list[dict[str, str]]:
     return list(csv.DictReader(io.StringIO(text, newline="")))
 
 
-def test_header_is_every_parsed_field() -> None:
-    """The export covers the model, excluding only calculation_quantity.
+def test_header_is_the_reviewed_schema() -> None:
+    """The header is pinned to the columns that were reviewed.
 
-    A new BrokerTransaction field fails here until someone decides whether it
-    belongs in the snapshot.
+    The exporter reads its columns from BrokerTransaction, so a field added
+    later is exported instead of quietly missing. This records the schema as
+    it stands, so adding one still has to be looked at: the new column needs a
+    serialisation rule, a place in the order, and a line in the documentation.
     """
+    assert DUMP_FIELDS == (
+        "date",
+        "action",
+        "symbol",
+        "description",
+        "quantity",
+        "price",
+        "fees",
+        "amount",
+        "currency",
+        "broker",
+        "isin",
+        "foreign_fees",
+        "ambiguous_quantity",
+        "option_contract",
+        "written_option_tax",
+        "capital_adjustments",
+        "affects_cash_balance",
+        "source",
+    )
+
+
+def test_only_calculation_quantity_is_left_out() -> None:
+    """Every model field is exported but the one the calculator fills in later."""
     model_fields = {field.name for field in fields(BrokerTransaction)}
 
     assert set(DUMP_FIELDS) == model_fields - {"calculation_quantity"}

--- a/tests/general/test_dump_transactions.py
+++ b/tests/general/test_dump_transactions.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING
 
 from cgt_calc.model import ActionType, BrokerTransaction, CurrencyCode
 from cgt_calc.transaction_dumper import dump_transactions
-import dump_transactions as dump_script
 from tests.utils import build_cmd, report_path
 
 if TYPE_CHECKING:
@@ -193,14 +192,3 @@ def test_cli_dump_transactions_flag_alone_defaults_to_continue(
     assert result.returncode == 0
     assert "Total: 8 transaction(s)" in result.stdout
     assert "Tax summary for 2023/2024" in result.stdout
-
-
-def test_dump_transactions_script_entry_point() -> None:
-    """dump_transactions.py wrapper runs correctly and returns 0."""
-    exit_code = dump_script.main(
-        [
-            "--schwab-equity-award-json",
-            "tests/schwab/data/equity_award/schwab_equity_award_v1.json",
-        ]
-    )
-    assert exit_code == 0

--- a/tests/general/test_dump_transactions.py
+++ b/tests/general/test_dump_transactions.py
@@ -1,194 +1,743 @@
-"""Unit and integration tests for transaction dumping functionality."""
+"""Tests for the parsed-transaction CSV export."""
 
 from __future__ import annotations
 
+import argparse
+import csv
+import dataclasses
+from dataclasses import fields
 import datetime
 from decimal import Decimal
 import io
+import json
+import logging
+from pathlib import Path
 import subprocess
-from typing import TYPE_CHECKING
+import sys
+from typing import TYPE_CHECKING, Self
 
-from cgt_calc.model import ActionType, BrokerTransaction, CurrencyCode
-from cgt_calc.transaction_dumper import dump_transactions
+import pytest
+
+from cgt_calc.cli import _save_transaction_dump
+from cgt_calc.exceptions import TransactionDumpError
+from cgt_calc.model import (
+    ActionType,
+    BrokerTransaction,
+    CapitalAdjustment,
+    CurrencyCode,
+    DatedAmount,
+    Isin,
+    OptionContract,
+    OptionType,
+    TransactionSource,
+    WrittenOptionTaxData,
+)
+from cgt_calc.transaction_dumper import DUMP_FIELDS, dump_transactions
 from tests.utils import build_cmd, report_path
 
 if TYPE_CHECKING:
-    import pytest
+    from collections.abc import Sequence
+
+RAW_HEADER = "date,action,symbol,quantity,price,fees,currency\n"
+
+DATE = datetime.date(2023, 4, 25)
+ZERO = Decimal(0)
+ONE = Decimal(1)
+USD = CurrencyCode("USD")
 
 
-def _sample_transactions() -> list[BrokerTransaction]:
-    """Generate sample transactions for testing."""
-    return [
-        BrokerTransaction(
-            date=datetime.date(2023, 4, 25),
-            action=ActionType.STOCK_ACTIVITY,
-            symbol="GOOG",
-            description="RS",
-            quantity=Decimal("10.5"),
-            price=Decimal("100.25"),
-            fees=Decimal("1.50"),
-            amount=Decimal("1054.125"),
-            currency=CurrencyCode("USD"),
-            broker="Test Broker",
+def _minimal(
+    *,
+    action: ActionType = ActionType.BUY,
+    symbol: str | None = "GOOG",
+    description: str = "",
+    quantity: Decimal | None = ONE,
+    price: Decimal | None = ONE,
+    fees: Decimal = ZERO,
+    amount: Decimal | None = ONE,
+    broker: str = "Test Broker",
+) -> BrokerTransaction:
+    """Build a transaction with only the required fields set."""
+    return BrokerTransaction(
+        date=DATE,
+        action=action,
+        symbol=symbol,
+        description=description,
+        quantity=quantity,
+        price=price,
+        fees=fees,
+        amount=amount,
+        currency=USD,
+        broker=broker,
+    )
+
+
+def _rich() -> BrokerTransaction:
+    """Build a transaction that populates every exported field."""
+    return BrokerTransaction(
+        date=datetime.date(2023, 4, 25),
+        action=ActionType.OPTION_GRANT,
+        symbol="GOOG",
+        description="Vest, tranche 2",
+        quantity=Decimal("10.5"),
+        price=Decimal("100.123456"),
+        fees=Decimal("1.50"),
+        amount=Decimal("1054.125"),
+        currency=CurrencyCode("USD"),
+        broker="Test Broker",
+        isin=Isin("US02079K3059"),
+        # Two currencies, deliberately not in sorted order.
+        foreign_fees={
+            CurrencyCode("PLN"): Decimal("0.30"),
+            CurrencyCode("EUR"): Decimal(2),
+        },
+        ambiguous_quantity=Decimal(21),
+        option_contract=OptionContract(
+            underlying="GOOG",
+            expiry=datetime.date(2024, 5, 17),
+            strike=Decimal(500),
+            option_type=OptionType.CALL,
         ),
-        BrokerTransaction(
-            date=datetime.date(2023, 5, 1),
-            action=ActionType.DIVIDEND,
-            symbol=None,
-            description="Dividend",
-            quantity=None,
-            price=None,
-            fees=Decimal(0),
-            amount=Decimal("50.00"),
-            currency=CurrencyCode("GBP"),
-            broker="",
+        written_option_tax=WrittenOptionTaxData(
+            taxable_quantity=Decimal(2),
+            close_costs=[
+                DatedAmount(
+                    date=datetime.date(2023, 6, 1),
+                    amount=Decimal("12.34"),
+                    currency=CurrencyCode("USD"),
+                )
+            ],
         ),
-        BrokerTransaction(
-            date=datetime.date(2023, 6, 1),
-            action=ActionType.BUY,
-            symbol="AAPL",
-            description="Buy AAPL",
-            quantity=Decimal(5),
-            price=Decimal(0),
-            fees=Decimal(0),
-            amount=Decimal(0),
-            currency=CurrencyCode("USD"),
-            broker="Broker B",
+        capital_adjustments=[
+            CapitalAdjustment(
+                date=datetime.date(2023, 5, 2),
+                net_amount=Decimal("-3.5"),
+                fees=Decimal("0.25"),
+                currency=CurrencyCode("USD"),
+            )
+        ],
+        affects_cash_balance=False,
+        source=TransactionSource(
+            parser="RAW format",
+            account="RAW format #1",
+            file=Path("history/raw.csv"),
+            row=7,
+            index=3,
+            timestamp=datetime.datetime(2023, 4, 25, 14, 30, 5),
+            rows_in_time_order=True,
         ),
+    )
+
+
+def _dump_to_string(transactions: Sequence[BrokerTransaction]) -> str:
+    """Export to an in-memory stream opened the way the CLI opens the file."""
+    stream = io.StringIO(newline="")
+    dump_transactions(transactions, stream)
+    return stream.getvalue()
+
+
+def _read_rows(text: str) -> list[dict[str, str]]:
+    """Parse exported CSV text back into rows."""
+    return list(csv.DictReader(io.StringIO(text, newline="")))
+
+
+def test_header_is_every_parsed_field() -> None:
+    """The export covers the model, excluding only calculation_quantity.
+
+    A new BrokerTransaction field fails here until someone decides whether it
+    belongs in the snapshot.
+    """
+    model_fields = {field.name for field in fields(BrokerTransaction)}
+
+    assert set(DUMP_FIELDS) == model_fields - {"calculation_quantity"}
+    assert DUMP_FIELDS[-1] == "source"
+    assert len(set(DUMP_FIELDS)) == len(DUMP_FIELDS)
+
+
+def test_empty_history_writes_the_header_alone(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """No transactions still produces valid CSV, and nothing else anywhere."""
+    text = _dump_to_string([])
+
+    assert text == ",".join(DUMP_FIELDS) + "\r\n"
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_every_field_is_exported() -> None:
+    """Each header column carries the parsed value, exactly as parsed."""
+    (row,) = _read_rows(_dump_to_string([_rich()]))
+
+    assert row["date"] == "2023-04-25"
+    assert row["action"] == "OPTION_GRANT"
+    assert row["symbol"] == "GOOG"
+    assert row["description"] == "Vest, tranche 2"
+    assert row["quantity"] == "10.5"
+    assert row["price"] == "100.123456"
+    assert row["fees"] == "1.50"
+    assert row["amount"] == "1054.125"
+    assert row["currency"] == "USD"
+    assert row["broker"] == "Test Broker"
+    assert row["isin"] == "US02079K3059"
+    assert row["ambiguous_quantity"] == "21"
+    assert row["affects_cash_balance"] == "false"
+    assert json.loads(row["foreign_fees"]) == {"EUR": "2", "PLN": "0.30"}
+    assert json.loads(row["option_contract"]) == {
+        "underlying": "GOOG",
+        "expiry": "2024-05-17",
+        "strike": "500",
+        "option_type": "CALL",
+        "multiplier": "100",
+    }
+    assert json.loads(row["written_option_tax"]) == {
+        "taxable_quantity": "2",
+        "close_costs": [{"date": "2023-06-01", "amount": "12.34", "currency": "USD"}],
+    }
+    assert json.loads(row["capital_adjustments"]) == [
+        {
+            "date": "2023-05-02",
+            "net_amount": "-3.5",
+            "fees": "0.25",
+            "currency": "USD",
+        }
+    ]
+    assert json.loads(row["source"]) == {
+        "parser": "RAW format",
+        "account": "RAW format #1",
+        # The exporter writes a path as its own platform spells it.
+        "file": str(Path("history/raw.csv")),
+        "row": 7,
+        "index": 3,
+        "timestamp": "2023-04-25T14:30:05",
+        "rows_in_time_order": True,
+    }
+
+
+def test_nested_integers_and_booleans_keep_their_json_types() -> None:
+    """Source row and index stay JSON numbers, and the order flag a boolean."""
+    (row,) = _read_rows(_dump_to_string([_rich()]))
+    source = json.loads(row["source"])
+
+    assert source["row"] == 7
+    assert source["index"] == 3
+    assert source["rows_in_time_order"] is True
+
+
+def test_nested_json_sorts_keys_for_a_stable_diff() -> None:
+    """Two exports of the same records compare byte for byte."""
+    text = _dump_to_string([_rich()])
+    (row,) = _read_rows(text)
+
+    assert row["foreign_fees"] == '{"EUR":"2","PLN":"0.30"}'
+    assert text == _dump_to_string([_rich()])
+
+
+def test_none_zero_and_empty_collections_are_distinguishable() -> None:
+    """A missing value empties the field; zero and empty collections do not."""
+    (row,) = _read_rows(
+        _dump_to_string(
+            [
+                _minimal(
+                    symbol=None,
+                    quantity=None,
+                    price=None,
+                    amount=None,
+                    fees=ZERO,
+                    description="",
+                    broker="",
+                )
+            ]
+        )
+    )
+
+    assert row["symbol"] == ""
+    assert row["quantity"] == ""
+    assert row["price"] == ""
+    assert row["amount"] == ""
+    assert row["isin"] == ""
+    assert row["description"] == ""
+    assert row["broker"] == ""
+    assert row["fees"] == "0"
+    assert row["foreign_fees"] == "{}"
+    assert row["capital_adjustments"] == "[]"
+    assert row["source"] == ""
+
+
+def test_exact_amounts_are_not_rounded() -> None:
+    """Values are exported at full precision, not display-rounded."""
+    (row,) = _read_rows(
+        _dump_to_string(
+            [_minimal(amount=Decimal("1054.125"), price=Decimal("0.123456789"))]
+        )
+    )
+
+    assert row["amount"] == "1054.125"
+    assert row["price"] == "0.123456789"
+
+
+def test_descriptions_separate_two_otherwise_identical_rows() -> None:
+    """A rename's source ticker lives in the description, so it must survive."""
+    first = _minimal(action=ActionType.RENAME, description="renamed from FB")
+    second = _minimal(action=ActionType.RENAME, description="renamed from META")
+
+    descriptions = [
+        row["description"] for row in _read_rows(_dump_to_string([first, second]))
+    ]
+
+    assert descriptions == ["renamed from FB", "renamed from META"]
+
+
+@pytest.mark.parametrize(
+    "description",
+    [
+        "comma, inside",
+        'quote " inside',
+        "carriage\rreturn",
+        "line\nfeed",
+        "windows\r\nbreak",
+        "café ☕ 日本",
+    ],
+)
+def test_awkward_text_round_trips_through_the_file(
+    tmp_path: Path, description: str
+) -> None:
+    """Separators and newlines inside a field survive as written bytes.
+
+    Read back in binary and decoded without newline translation: universal
+    newlines would hide a bare CR turned into a record break.
+    """
+    destination = tmp_path / "parsed.csv"
+    with destination.open("x", encoding="utf-8", newline="") as stream:
+        dump_transactions([_minimal(description=description)], stream)
+
+    text = destination.read_bytes().decode("utf-8")
+    (row,) = _read_rows(text)
+
+    assert row["description"] == description
+
+
+def test_export_neither_mutates_nor_reorders(tmp_path: Path) -> None:
+    """The snapshot is the records as they were, in the order they arrived."""
+    transactions = [
+        _minimal(symbol="AAPL", description="first"),
+        _minimal(symbol="GOOG", description="second"),
+    ]
+    before = [dataclasses.replace(transaction) for transaction in transactions]
+
+    destination = tmp_path / "parsed.csv"
+    with destination.open("x", encoding="utf-8", newline="") as stream:
+        dump_transactions(transactions, stream)
+
+    assert transactions == before
+    assert [
+        row["description"]
+        for row in _read_rows(destination.read_text(encoding="utf-8"))
+    ] == [
+        "first",
+        "second",
+    ]
+
+    # A later calculation stage changing the records cannot reach the file.
+    transactions[0].symbol = "CHANGED"
+    assert [
+        row["symbol"] for row in _read_rows(destination.read_text(encoding="utf-8"))
+    ] == [
+        "AAPL",
+        "GOOG",
     ]
 
 
-def test_dump_transactions_empty(capsys: pytest.CaptureFixture[str]) -> None:
-    """An empty list prints an informative message to stderr."""
-    buf = io.StringIO()
-    dump_transactions([], stream=buf)
+def test_an_unexportable_value_is_refused() -> None:
+    """An unknown type raises rather than being written through repr()."""
+    transaction = _minimal()
+    transaction.description = object()  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
 
-    assert buf.getvalue() == ""
-    captured = capsys.readouterr()
-    assert "No transactions loaded." in captured.err
-
-
-def test_dump_transactions_formatting() -> None:
-    """Transactions are formatted in a clean table with headers and totals."""
-    buf = io.StringIO()
-    transactions = _sample_transactions()
-    dump_transactions(transactions, stream=buf)
-
-    output = buf.getvalue()
-    lines = [line for line in output.splitlines() if line]
-
-    assert len(lines) == 7
-    assert "Date" in lines[0]
-    assert "Action" in lines[0]
-    assert "Symbol" in lines[0]
-    assert "Qty" in lines[0]
-    assert "Price" in lines[0]
-    assert "Amount" in lines[0]
-    assert "Fees" in lines[0]
-    assert "Broker" in lines[0]
-
-    # Row 1: all fields present
-    assert (
-        lines[2]
-        == "2023-04-25 | STOCK_ACTIVITY         | GOOG   |         10.5 |       100.25 |      1054.12 USD |     1.50 | Test Broker    "
-    )
-
-    # Row 2: None fields display as "-"
-    assert (
-        lines[3]
-        == "2023-05-01 | DIVIDEND               | -      |            - |            - |        50.00 GBP |     0.00 | -              "
-    )
-
-    # Row 3: price of Decimal(0) displays as "0"
-    assert (
-        lines[4]
-        == "2023-06-01 | BUY                    | AAPL   |            5 |            0 |         0.00 USD |     0.00 | Broker B       "
-    )
-
-    assert lines[6] == "Total: 3 transaction(s)"
+    with pytest.raises(TypeError, match="Cannot export"):
+        _dump_to_string([transaction])
 
 
-def test_cli_dump_transactions_only_exits_without_calculations(
-    request: pytest.FixtureRequest,
+def test_the_stream_stays_open_for_the_caller() -> None:
+    """The exporter never closes a stream it was handed."""
+    stream = io.StringIO(newline="")
+
+    dump_transactions([_minimal()], stream)
+
+    assert not stream.closed
+
+
+class _FailingStream:
+    """A destination that fails when the test says it should.
+
+    A buffered write only reaches the disk when the buffer fills or the file
+    is closed, so a full disk can surface at either point.
+    """
+
+    def __init__(self, when: str) -> None:
+        """Fail at `when`, which is "write" or "close"."""
+        self.when = when
+        self.closed = False
+
+    def _boom(self) -> None:
+        raise OSError(28, "No space left on device")
+
+    def write(self, text: str) -> int:
+        """Record the write, or fail it."""
+        if self.when == "write":
+            self._boom()
+        return len(text)
+
+    def close(self) -> None:
+        """Flush and close, or fail doing so."""
+        self.closed = True
+        if self.when == "close":
+            self._boom()
+
+    def __enter__(self) -> Self:
+        """Enter the context, as an open file does."""
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        """Close on the way out, as an open file does."""
+        self.close()
+
+
+@pytest.mark.parametrize("failing", ["create", "write", "close"])
+def test_a_failed_export_names_the_path_and_confirms_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+    failing: str,
 ) -> None:
-    """--dump-transactions only dumps the table and exits 0 without calculating."""
-    cmd = build_cmd(
+    """A disk that fills up at any point stops the run with an actionable error."""
+    destination = tmp_path / "parsed.csv"
+
+    def _open(*_args: object, **_kwargs: object) -> _FailingStream:
+        if failing == "create":
+            raise OSError(28, "No space left on device")
+        return _FailingStream(failing)
+
+    monkeypatch.setattr(Path, "open", _open)
+    args = argparse.Namespace(
+        dump_transactions=destination,
+        no_report=True,
+        exchange_rates_file=None,
+        isin_translation_file=None,
+        spin_offs_file=None,
+    )
+
+    with caplog.at_level(logging.INFO), pytest.raises(TransactionDumpError) as error:
+        _save_transaction_dump(args, [_minimal()])
+
+    message = str(error.value)
+    assert str(destination) in message
+    assert "No space left on device" in message
+    assert "remove it or choose another filename" in message
+    # The caller raises, so the run never reaches the calculation, and the
+    # confirmation that the snapshot is available is never printed.
+    assert "Saved" not in caplog.text
+
+
+def _raw_file(tmp_path: Path, *rows: str) -> str:
+    """Write a RAW-format history and return its path."""
+    path = tmp_path / "history.csv"
+    path.write_text(RAW_HEADER + "".join(f"{row}\n" for row in rows), encoding="utf-8")
+    return str(path)
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run the CLI and capture its output."""
+    return subprocess.run(
+        build_cmd(*args), capture_output=True, encoding="utf-8", check=False
+    )
+
+
+def _run_bare(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run the CLI with exactly these arguments and nothing added.
+
+    build_cmd appends --no-pdflatex and its own exchange rate cache, which a
+    test choosing those paths itself has to be able to override.
+    """
+    return subprocess.run(
+        [sys.executable, "-m", "cgt_calc.main", *args],
+        capture_output=True,
+        encoding="utf-8",
+        check=False,
+    )
+
+
+def test_cli_saves_the_csv_and_still_reports(
+    request: pytest.FixtureRequest, tmp_path: Path
+) -> None:
+    """The summary and the report are exactly what a run without the flag gives."""
+    destination = tmp_path / "parsed.csv"
+    source = (
         "--schwab-equity-award-json",
-        "tests/schwab/data/equity_award/schwab_equity_award_v1.json",
-        "--dump-transactions",
-        "only",
-        "--output",
-        report_path(request),
+        "tests/schwab/data/equity_award/schwab_equity_award_v2.json",
     )
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    output = report_path(request)
 
-    assert result.returncode == 0
-    assert "Date       | Action                 | Symbol" in result.stdout
-    assert "STOCK_ACTIVITY         | GOOG" in result.stdout
-    assert "Total: 4 transaction(s)" in result.stdout
-    # Ensure calculations and summary were not performed
-    assert "Tax summary" not in result.stdout
-    assert "Capital gains" not in result.stdout
-
-
-def test_cli_dump_transactions_exit_mode(
-    request: pytest.FixtureRequest,
-) -> None:
-    """--dump-transactions exit mode behaves identically to only mode."""
-    cmd = build_cmd(
-        "--schwab-equity-award-json",
-        "tests/schwab/data/equity_award/schwab_equity_award_v1.json",
+    plain = _run("--year", "2023", *source, "--output", output)
+    dumped = _run(
+        "--year",
+        "2023",
+        *source,
         "--dump-transactions",
-        "exit",
+        str(destination),
         "--output",
-        report_path(request),
+        output,
     )
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
 
-    assert result.returncode == 0
-    assert "Total: 4 transaction(s)" in result.stdout
-    assert "Tax summary" not in result.stdout
+    assert plain.returncode == 0
+    assert dumped.returncode == 0
+    assert dumped.stdout == plain.stdout
+    assert "Tax summary for 2023/2024" in dumped.stdout
+    # The report lands beside the --output path, named after its stem.
+    report = Path(output)
+    assert list(report.parent.glob(f"{report.stem}*")) != []
+
+    rows = _read_rows(destination.read_text(encoding="utf-8"))
+    assert len(rows) == 8
+    assert rows[0]["action"] == "STOCK_ACTIVITY"
 
 
-def test_cli_dump_transactions_continue_runs_calculations(
-    request: pytest.FixtureRequest,
-) -> None:
-    """--dump-transactions continue mode dumps table and continues calculations."""
-    cmd = build_cmd(
+def test_cli_saves_the_csv_without_a_report(tmp_path: Path) -> None:
+    """--no-report still calculates and still saves the snapshot."""
+    destination = tmp_path / "parsed.csv"
+
+    result = _run(
         "--year",
         "2023",
         "--schwab-equity-award-json",
         "tests/schwab/data/equity_award/schwab_equity_award_v2.json",
         "--dump-transactions",
-        "continue",
-        "--output",
-        report_path(request),
+        str(destination),
+        "--no-report",
     )
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
 
     assert result.returncode == 0
-    # Both dump table and calculation summary should be in stdout
-    assert "Date       | Action                 | Symbol" in result.stdout
-    assert "Total: 8 transaction(s)" in result.stdout
     assert "Tax summary for 2023/2024" in result.stdout
-    assert "Capital gains" in result.stdout
+    assert len(_read_rows(destination.read_text(encoding="utf-8"))) == 8
 
 
-def test_cli_dump_transactions_flag_alone_defaults_to_continue(
-    request: pytest.FixtureRequest,
+@pytest.mark.parametrize(
+    ("rows", "confirmation"),
+    [
+        ((), "Saved 0 parsed transactions to"),
+        (("2023-04-25,BUY,XYZ,10,5.00,0.00,USD",), "Saved 1 parsed transaction to"),
+        (
+            (
+                "2023-04-25,BUY,XYZ,10,5.00,0.00,USD",
+                "2023-06-15,BUY,XYZ,10,5.00,0.00,USD",
+            ),
+            "Saved 2 parsed transactions to",
+        ),
+    ],
+)
+def test_cli_confirms_the_saved_file_on_stderr(
+    tmp_path: Path, rows: tuple[str, ...], confirmation: str
 ) -> None:
-    """--dump-transactions without value defaults to continue mode."""
-    cmd = build_cmd(
+    """The confirmation names the count and path, and stays off stdout."""
+    destination = tmp_path / "parsed.csv"
+
+    result = _run(
         "--year",
         "2023",
-        "--schwab-equity-award-json",
-        "tests/schwab/data/equity_award/schwab_equity_award_v2.json",
+        "--raw-file",
+        _raw_file(tmp_path, *rows),
         "--dump-transactions",
-        "--output",
-        report_path(request),
+        str(destination),
+        "--no-report",
+        "--no-balance-check",
     )
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
 
     assert result.returncode == 0
-    assert "Total: 8 transaction(s)" in result.stdout
-    assert "Tax summary for 2023/2024" in result.stdout
+    assert f"{confirmation} {destination}" in result.stderr
+    assert "Saved" not in result.stdout
+    assert "Saved" not in destination.read_text(encoding="utf-8")
+    # Saved before the calculation it precedes.
+    assert result.stderr.index("Saved") < result.stderr.index("First pass complete")
+
+
+def test_cli_keeps_the_csv_when_the_calculation_fails(tmp_path: Path) -> None:
+    """A snapshot saved before calculation survives the failure it explains."""
+    destination = tmp_path / "parsed.csv"
+
+    result = _run(
+        "--year",
+        "2023",
+        "--raw-file",
+        _raw_file(tmp_path, "2023-08-31,SELL,XYZ,10,5.00,0.00,USD"),
+        "--dump-transactions",
+        str(destination),
+        "--no-report",
+        "--no-balance-check",
+    )
+
+    assert result.returncode != 0
+    assert "Tried to sell not owned symbol" in result.stderr
+    (row,) = _read_rows(destination.read_text(encoding="utf-8"))
+    assert row["action"] == "SELL"
+    assert row["symbol"] == "XYZ"
+
+
+def test_cli_exports_transactions_outside_the_reported_year(tmp_path: Path) -> None:
+    """The snapshot is every loaded row; --year only selects what is reported."""
+    destination = tmp_path / "parsed.csv"
+
+    result = _run(
+        "--year",
+        "2023",
+        "--raw-file",
+        _raw_file(
+            tmp_path,
+            "2022-05-03,BUY,XYZ,10,5.00,0.00,USD",
+            "2023-06-15,BUY,XYZ,10,5.00,0.00,USD",
+        ),
+        "--dump-transactions",
+        str(destination),
+        "--no-report",
+        "--no-balance-check",
+    )
+
+    assert result.returncode == 0
+    assert [
+        row["date"] for row in _read_rows(destination.read_text(encoding="utf-8"))
+    ] == [
+        "2022-05-03",
+        "2023-06-15",
+    ]
+
+
+def test_cli_refuses_an_existing_destination(tmp_path: Path) -> None:
+    """An existing file is never overwritten, and nothing is calculated."""
+    destination = tmp_path / "parsed.csv"
+    destination.write_bytes(b"keep me")
+
+    result = _run(
+        "--year",
+        "2023",
+        "--raw-file",
+        _raw_file(tmp_path, "2023-04-25,BUY,XYZ,10,5.00,0.00,USD"),
+        "--dump-transactions",
+        str(destination),
+        "--no-report",
+    )
+
+    assert result.returncode != 0
+    assert "already exists" in result.stderr
+    assert str(destination) in result.stderr
+    assert destination.read_bytes() == b"keep me"
+    assert "Saved" not in result.stderr
+    assert "First pass complete" not in result.stderr
+
+
+def test_cli_refuses_a_missing_parent_directory(tmp_path: Path) -> None:
+    """A destination in a directory that does not exist is reported, not created."""
+    destination = tmp_path / "missing" / "parsed.csv"
+
+    result = _run(
+        "--year",
+        "2023",
+        "--raw-file",
+        _raw_file(tmp_path, "2023-04-25,BUY,XYZ,10,5.00,0.00,USD"),
+        "--dump-transactions",
+        str(destination),
+        "--no-report",
+    )
+
+    assert result.returncode != 0
+    assert str(destination.parent) in result.stderr
+    assert not destination.parent.exists()
+    assert "Saved" not in result.stderr
+    assert "First pass complete" not in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("name", "extra"),
+    [
+        ("calculations.pdf", ()),
+        ("calculations.tex", ()),
+        # Written by pdflatex next to the report and removed afterwards.
+        ("calculations.latex.log", ()),
+        ("calculations.log", ()),
+        ("calculations.aux", ()),
+        ("rates.csv", ("--exchange-rates-file", "{directory}/rates.csv")),
+        ("isin.csv", ("--isin-translation-file", "{directory}/isin.csv")),
+        ("spin_offs.csv", ("--spin-offs-file", "{directory}/spin_offs.csv")),
+    ],
+)
+def test_cli_refuses_a_destination_it_would_overwrite(
+    tmp_path: Path, name: str, extra: tuple[str, ...]
+) -> None:
+    """A path the run writes later cannot be the snapshot destination."""
+    directory = tmp_path / "out"
+    directory.mkdir()
+
+    result = _run_bare(
+        "--year",
+        "2023",
+        "--raw-file",
+        _raw_file(tmp_path, "2023-04-25,BUY,XYZ,10,5.00,0.00,USD"),
+        "--exchange-rates-file",
+        "tests/exchange_rates_data.csv",
+        "--dump-transactions",
+        str(directory / name),
+        "--output",
+        str(directory / "calculations.pdf"),
+        # Last wins, so a case naming its own cache overrides the default above.
+        *(argument.format(directory=directory) for argument in extra),
+    )
+
+    assert result.returncode != 0
+    assert "Choose a different filename" in result.stderr
+    assert not (directory / name).exists()
+
+
+def test_cli_refuses_the_pdf_an_output_without_a_suffix_produces(
+    tmp_path: Path,
+) -> None:
+    """Pdflatex names the PDF after the report's stem, whatever --output said."""
+    directory = tmp_path / "out"
+    directory.mkdir()
+
+    result = _run_bare(
+        "--year",
+        "2023",
+        "--raw-file",
+        _raw_file(tmp_path, "2023-04-25,BUY,XYZ,10,5.00,0.00,USD"),
+        "--exchange-rates-file",
+        "tests/exchange_rates_data.csv",
+        "--dump-transactions",
+        str(directory / "report.pdf"),
+        "--output",
+        str(directory / "report"),
+    )
+
+    assert result.returncode != 0
+    assert "the PDF report from --output" in result.stderr
+    assert not (directory / "report.pdf").exists()
+
+
+def test_cli_creates_no_file_when_parsing_fails(tmp_path: Path) -> None:
+    """Parsing runs first, so a broken export leaves no half-made snapshot."""
+    destination = tmp_path / "parsed.csv"
+    history = tmp_path / "history.csv"
+    history.write_text(
+        RAW_HEADER + "2023-04-25,NONSENSE,XYZ,10,5,0,USD\n", encoding="utf-8"
+    )
+
+    result = _run(
+        "--year",
+        "2023",
+        "--raw-file",
+        str(history),
+        "--dump-transactions",
+        str(destination),
+        "--no-report",
+    )
+
+    assert result.returncode != 0
+    assert result.stderr.count("ERROR") >= 1
+    assert not destination.exists()

--- a/tests/general/test_exceptions.py
+++ b/tests/general/test_exceptions.py
@@ -29,6 +29,7 @@ from cgt_calc.exceptions import (
     QuantityMissingError,
     QuantityNotPositiveError,
     SymbolMissingError,
+    TransactionDumpError,
     UnclassifiedGiftError,
     UnexpectedColumnCountError,
     UnexpectedRowCountError,
@@ -128,6 +129,10 @@ CONTEXT_CASES: list[tuple[CgtError, list[str]]] = [
     (LatexRenderError(Path("render.log")), ["render.log"]),
     (MissingExternalToolError("pdflatex"), ["pdflatex"]),
     (IsinTranslationError("ISIN XS123 is broken"), ["ISIN XS123 is broken"]),
+    (
+        TransactionDumpError("parsed.csv already exists"),
+        ["parsed.csv already exists"],
+    ),
     (
         ExternalApiError("https://api.example.com/rates", "boom"),
         ["https://api.example.com/rates", "boom"],


### PR DESCRIPTION
When checking a broker import, users currently cannot inspect the parsed transactions that `cgt-calc` will calculate from. This makes it difficult to compare two broker export formats or confirm the effect of a parser change.

`--dump-transactions PATH` saves the parsed transactions to a new CSV file before calculation, then continues with the normal calculation and report. The export preserves exact numeric values and includes descriptions, identifiers, adjustments, option data, and source provenance. The normal summary remains on stdout. An existing destination is refused, and export failures stop the run with an error.

The diagnostic CSV is not the seven-column RAW input format and cannot be passed back with `--raw-file`. The file remains available if the subsequent calculation fails; a saved CSV does not confirm that the history is complete or that the calculation succeeded.
