### PR TITLE
Reconcile a disposal's proceeds on the difference, not two roundings

### DIFF
--- a/cgt_calc/matching.py
+++ b/cgt_calc/matching.py
@@ -1872,9 +1872,13 @@ class Matcher:
                             calculated_proceeds += entry.amount + entry.fees
                             calculated_gain += entry.gain
                         assert transaction_quantity == calculated_quantity
-                        assert round_decimal(
-                            transaction_disposal_proceeds, 10
-                        ) == round_decimal(calculated_proceeds, 10), (
+                        # The difference is what must be inside the tolerance:
+                        # rounded separately, figures that agree to ten places
+                        # can land either side of a step.
+                        proceeds_difference = (
+                            transaction_disposal_proceeds - calculated_proceeds
+                        )
+                        assert round_decimal(proceeds_difference, 10) == 0, (
                             f"{transaction_disposal_proceeds} != {calculated_proceeds}"
                         )
                         assert transaction_capital_gain == round_decimal(

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -853,6 +853,50 @@ def test_same_day_rule_all_shares_disposed_no_rounding_error() -> None:
     )
 
 
+def test_disposal_proceeds_reconcile_across_a_rounding_step() -> None:
+    """Proceeds that agree to ten places reconcile across a rounding step.
+
+    The walk rebuilds the proceeds through a unit price, so its figure can sit
+    a few ULPs from the recorded one and round the other way.
+    """
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    quantity = Decimal("0.6245225058")
+    # Built by hand: the transaction helper rounds to six places, and it is the
+    # eleventh that puts the recorded and the rebuilt proceeds either side of a step.
+    transactions = [
+        BrokerTransaction(
+            date=datetime.date(2024, 5, 1),
+            action=ActionType.BUY,
+            symbol="FOO",
+            description="buy FOO",
+            quantity=quantity,
+            price=Decimal(10),
+            fees=Decimal(0),
+            amount=Decimal("-6.245225058"),
+            currency=CurrencyCode("GBP"),
+            broker="Test",
+        ),
+        BrokerTransaction(
+            date=datetime.date(2024, 5, 2),
+            action=ActionType.SELL,
+            symbol="FOO",
+            description="sell FOO",
+            quantity=quantity,
+            price=Decimal("15.06699561"),
+            fees=Decimal(0),
+            amount=Decimal("9.40968379635"),
+            currency=CurrencyCode("GBP"),
+            broker="Test",
+        ),
+    ]
+
+    report = get_report(calculator, transactions)
+
+    assert report.disposal_count == 1
+    assert report.disposal_proceeds == Decimal("9.41")
+    assert report.total_gain() == Decimal("3.16")
+
+
 def _rename_transaction(date: datetime.date, old: str, new: str) -> BrokerTransaction:
     """Build a RENAME BrokerTransaction that moves the pool from old to new."""
     return BrokerTransaction(


### PR DESCRIPTION
Fixes #1096.

The reconciliation rounded the recorded proceeds and the proceeds rebuilt from the calculation entries to ten places separately, then compared the two rounded figures. The recorded side is the amount as the row states it; the rebuilt side comes back through a unit price, so it can sit a few ULPs away. When the pair straddles a ten-place step the two land on different grid points and the walk stops on a disposal that agrees far below the precision the check is asking for. Your repro raises `AssertionError: 9.40968379635 != 9.409683796349999999999999998` on `749eb24`, the two sides being `2E-27` apart.

Rounding the difference instead, as you suggested. Worth naming the one behaviour change that comes with it: the tolerance becomes uniform. Two independently rounded figures pass when they share a grid point, which is anything from a full step apart to nothing at all depending on where the pair sits; rounding the difference passes any pair within half a step, wherever it sits. That is a tightening at the ceiling, from just under `1E-10` to just under `5E-11`, and the real reconstruction error is bounded by the arithmetic context around `1E-26`, so nothing loses room. `round_decimal(difference, N) == 0` is also the shape the four other tolerance assertions in this file already use, at lines 327, 392, 647 and 714; this was the odd one out.

The failure message is untouched. I checked a real mismatch still stops the run by temporarily stubbing `process_disposal` to shave a penny off an entry: it refuses, and the message reads as before. I did not keep that as a test, since the invariant cannot be broken by input data and the stub would pin this method's signature for no gain.

One test, your repro. I confirmed it discriminates by running it against unfixed `main`, where it fails with exactly the assertion above.

I also looked at the `transaction_capital_gain` assertion on the next line for the same problem, and it is not the same class: `calculated_gain` is the sum of the entries' gains, and `transaction_capital_gain` is that same sum rounded, accumulated in the same order from the same three sites, so the two sides are equal by construction rather than reconstructed through a unit price. Left alone.

Checks: `uv run pytest` 1659 passed, with and without `CGT_TEST_MODE_STRICT`. Plus ruff format, ruff check, mypy, ty, codespell and Harper.

Disclosure: written with AI assistance (Claude). The bug was reproduced against `main` first, and the new test was confirmed to fail on the unfixed assertion before anything was changed.