### PR TITLE
Correct report and spin-off prompt wording

### DIFF
--- a/cgt_calc/resources/template.tex.j2
+++ b/cgt_calc/resources/template.tex.j2
@@ -58,7 +58,7 @@ Capital loss to date is £\VAR{ event.loss_to_date|money }
 \BLOCK{ elif event.kind == "spin_off" }
     \BLOCK{ if event.quantity > 0 }
 \subsubsection*{
-    Spin-off adjustment \VAR{ event.number }: \VAR{ event.spin_off_source } cost adjusted because of \VAR{ event.spin_off_dest } shares spinned off
+    Spin-off adjustment \VAR{ event.number }: \VAR{ event.spin_off_source } cost adjusted because of \VAR{ event.spin_off_dest } shares spun off
 }
     \BLOCK{ endif }
 \BLOCK{ elif event.kind == "eri" }
@@ -181,14 +181,14 @@ Loss is £\VAR{ (-event.gain)|money }; the gain or loss is disregarded (exempt a
     (£\VAR{ line.pool_per_unit|money }/unit)%
             \BLOCK{ if event.is_acquisition and line.spin_off_source }
 
-    Cost basis calculated based on cost of \VAR{ line.spin_off_source } share pool from which \VAR{ event.symbol } shares were spinned off%
+    Cost basis calculated based on cost of \VAR{ line.spin_off_source } share pool from which \VAR{ event.symbol } shares were spun off%
             \BLOCK{ endif }
             \BLOCK{ if event.is_acquisition }
                 \BLOCK{ for eri in line.eris }
 
     Cost basis increased by £\VAR{ eri.cost|money }
     (£\VAR{ eri.unit_price|money }/unit)%
-    , due to exccess reported income on \mbox{\VAR{ eri.date.strftime("%d %b %Y") }}%
+    , due to excess reported income on \mbox{\VAR{ eri.date.strftime("%d %b %Y") }}%
                 \BLOCK{ endfor }
             \BLOCK{ endif }
         \BLOCK{ endif }.

--- a/cgt_calc/spin_off_handler.py
+++ b/cgt_calc/spin_off_handler.py
@@ -72,8 +72,8 @@ class SpinOffHandler:
             # provide any info on SpinOffs
             try:
                 ticker = input(
-                    "For a spin off, please enter the original ticker from which the "
-                    f"new stock (symbol: {symbol}) was spinned off on {date}: "
+                    "For a spin-off, please enter the original ticker from which the "
+                    f"new stock (symbol: {symbol}) was spun off on {date}: "
                 )
             except EOFError as err:
                 raise InteractiveInputRequiredError(

--- a/tests/general/data/latex/spin_off.tex
+++ b/tests/general/data/latex/spin_off.tex
@@ -45,13 +45,13 @@
     new pool cost: £10.00
     (£1.00/unit)%
 
-    Cost basis calculated based on cost of FOO share pool from which BAR shares were spinned off%
+    Cost basis calculated based on cost of FOO share pool from which BAR shares were spun off%
 .
 
 \end{enumerate}
 
 \subsubsection*{
-    Spin-off adjustment 3: FOO cost adjusted because of BAR shares spinned off
+    Spin-off adjustment 3: FOO cost adjusted because of BAR shares spun off
 }
 
 \begin{enumerate}

--- a/tests/general/data/test_run_with_example_files_report.tex
+++ b/tests/general/data/test_run_with_example_files_report.tex
@@ -208,7 +208,7 @@ Capital gain to date is £213.65
 
     Cost basis increased by £22.26
     (£0.7300/unit)%
-    , due to exccess reported income on \mbox{30 Jun 2020}%
+    , due to excess reported income on \mbox{30 Jun 2020}%
 .
 
 \end{enumerate}

--- a/tests/general/test_spin_off_handler.py
+++ b/tests/general/test_spin_off_handler.py
@@ -64,6 +64,30 @@ def test_eof_during_prompt_raises_clear_error(
         handler.get_spin_off_source("NEW", SPIN_OFF_DATE, {})
 
 
+def test_interactive_prompt_uses_clear_spin_off_wording(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The prompt identifies the new and original tickers in clear English."""
+    prompts: list[str] = []
+
+    def enter_source(prompt: str) -> str:
+        prompts.append(prompt)
+        return "OLD"
+
+    handler = SpinOffHandler(tmp_path / "spin_offs.csv")
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", enter_source)
+
+    handler.get_spin_off_source("NEW", SPIN_OFF_DATE, {"OLD": Position()})
+
+    assert prompts == [
+        (
+            "For a spin-off, please enter the original ticker from which the new stock "
+            "(symbol: NEW) was spun off on 2021-05-10: "
+        )
+    ]
+
+
 def test_recording_spin_off_creates_missing_parent_directories(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
- replace “spinned off” with “spun off” in the detailed report and interactive prompt
- hyphenate “spin-off” when used as a noun in the prompt
- correct “exccess reported income” to “excess reported income”
- add a regression test for the prompt wording
- regenerate only the two affected LaTeX goldens

This changes wording only. Calculations and report layout are unchanged.