### PR TITLE
Reserve a later day's disposals across renames and blame malformed counts

### DIFF
--- a/cgt_calc/matching.py
+++ b/cgt_calc/matching.py
@@ -1491,15 +1491,12 @@ class Matcher:
             taken = bnb_claimed_before_today.get((day, ticker), Decimal(0))
             if not is_disposal_day:
                 # Whatever that later day disposes of under the same-day rule
-                # is spoken for before either of ours can reach it. On the
-                # disposal day itself the sale and the transfer are the two
-                # laying claim, so subtracting them would hide the clash.
-                for log in (
-                    self.history.disposal_list,
-                    self.history.transfer_to_spouse_list,
-                ):
-                    if has_key(log, day, ticker):
-                        taken += log[day][ticker].quantity
+                # is spoken for before either of ours can reach it, under
+                # whichever of the holding's names that day's rows spell it -
+                # the same claim the 30-day walk reserves. On the disposal day
+                # itself the sale and the transfer are the two laying claim, so
+                # subtracting them would hide the clash.
+                taken += self._same_day_claims(day, ticker).quantity
             return acquisition.quantity - taken > 0
 
         if has_shares_going_spare(

--- a/cgt_calc/stock_split_planning.py
+++ b/cgt_calc/stock_split_planning.py
@@ -12,6 +12,7 @@ from .exceptions import (
     CalculationError,
     InvalidTransactionError,
     QuantityMissingError,
+    QuantityNotPositiveError,
     SymbolMissingError,
 )
 from .model import ActionType, Position
@@ -49,6 +50,25 @@ def _get_quantity_or_fail(transaction: BrokerTransaction) -> Decimal:
     quantity = transaction.quantity
     if quantity is None:
         raise QuantityMissingError(transaction)
+    return quantity
+
+
+def _stated_quantity(transaction: BrokerTransaction) -> Decimal:
+    """Return a trade row's stated count, refusing one that is not positive.
+
+    A day is planned before any of its rows has been processed, so a row
+    stating nothing, or a count of zero or less, has to be refused where the
+    plan reads it. Left to the row's own processing it would first shape the
+    plan, and whichever valid row is then measured against that plan is the
+    one the calculator blames.
+
+    Only rows that move a share count are read this way. A reorganisation
+    row states its own delta, which a consolidation states as a negative
+    number.
+    """
+    quantity = _get_quantity_or_fail(transaction)
+    if quantity <= 0:
+        raise QuantityNotPositiveError(transaction)
     return quantity
 
 
@@ -334,7 +354,7 @@ def _plan_stock_split(
     day_open_quantity = state.run.portfolio[symbol].quantity
     holding_at_event = day_open_quantity + sum(
         (
-            quantity_sign(other.action) * _get_quantity_or_fail(other)
+            quantity_sign(other.action) * _stated_quantity(other)
             for other in before_rows
         ),
         Decimal(0),
@@ -460,10 +480,14 @@ def signed_quantity(transactions: list[BrokerTransaction]) -> Decimal:
     """Net units these rows add to a holding, in their pooled counts."""
     total = Decimal(0)
     for transaction in transactions:
-        quantity = transaction.pool_quantity
-        if quantity is None:
-            raise QuantityMissingError(transaction)
-        total += quantity_sign(transaction.action) * quantity
+        stated = _stated_quantity(transaction)
+        # ``BrokerTransaction.pool_quantity``, now that the stated count is
+        # known to be there: a same-day reorganisation restates a row into the
+        # units the day ends in, and that is the count the pool moves by.
+        restated = transaction.calculation_quantity
+        total += quantity_sign(transaction.action) * (
+            stated if restated is None else restated
+        )
     return total
 
 

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -24,6 +24,7 @@ from cgt_calc.exceptions import (
     InvalidTransactionError,
     IsinMissingError,
     PriceMissingError,
+    QuantityNotPositiveError,
 )
 from cgt_calc.initial_prices import InitialPrices
 from cgt_calc.isin_converter import IsinConverter
@@ -1725,6 +1726,50 @@ def test_a_rename_day_refuses_more_units_than_the_whole_holding_has(
         InvalidTransactionError, match=r"more than the available balance\(40\)"
     ):
         get_report(calculator, transactions)
+
+
+def _malformed_purchase(
+    date: datetime.date, symbol: str, quantity: str
+) -> BrokerTransaction:
+    """Build a purchase whose stated count is not a positive number."""
+    return BrokerTransaction(
+        date=date,
+        action=ActionType.BUY,
+        symbol=symbol,
+        description=f"malformed buy {symbol}",
+        quantity=Decimal(quantity),
+        price=Decimal(20),
+        fees=Decimal(0),
+        amount=Decimal(-1000),
+        currency=CurrencyCode("GBP"),
+        broker="Test",
+    )
+
+
+@pytest.mark.parametrize("quantity", ["-50", "0"], ids=["negative", "zero"])
+@pytest.mark.parametrize("buy_first", [True, False], ids=["buy first", "sale first"])
+def test_a_malformed_purchase_on_a_rename_day_blames_its_own_row(
+    *, quantity: str, buy_first: bool
+) -> None:
+    """The row with the impossible count is named, not the sale it shrinks.
+
+    A rename day works out what the whole holding can give up before any of
+    its rows is read, so a count of less than nothing there takes shares off
+    that total and the sale of the whole holding is the row refused for it.
+    """
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    sale = _gbp_trade(RENAME_DAY, ActionType.SELL, "OLD", 100, 2000)
+    malformed = _malformed_purchase(RENAME_DAY, "NEW", quantity)
+    transactions = [
+        _gbp_trade(datetime.date(2024, 5, 1), ActionType.BUY, "OLD", 100, 1000),
+        *([malformed, sale] if buy_first else [sale, malformed]),
+        _rename_transaction(RENAME_DAY, "OLD", "NEW"),
+    ]
+
+    with pytest.raises(QuantityNotPositiveError) as excinfo:
+        get_report(calculator, transactions)
+
+    assert "symbol='NEW'" in str(excinfo.value)
 
 
 def test_a_purchase_under_the_retired_name_is_there_to_sell_later() -> None:

--- a/tests/general/test_stock_splits.py
+++ b/tests/general/test_stock_splits.py
@@ -19,7 +19,11 @@ from typing import TYPE_CHECKING
 import pytest
 
 from cgt_calc.const import RENAME_DESCRIPTION_PREFIX
-from cgt_calc.exceptions import CalculationError, InvalidTransactionError
+from cgt_calc.exceptions import (
+    CalculationError,
+    InvalidTransactionError,
+    QuantityNotPositiveError,
+)
 from cgt_calc.model import (
     ActionType,
     BrokerTransaction,
@@ -268,6 +272,58 @@ def test_a_consolidation_reduces_the_units_and_keeps_the_cost() -> None:
     )
     assert calculator.portfolio["FOO"].quantity == Decimal(1)
     assert calculator.portfolio["FOO"].amount == Decimal(700)
+
+
+def _malformed_purchase(date: datetime.date, symbol: str) -> BrokerTransaction:
+    """Build a purchase stating a negative count."""
+    return BrokerTransaction(
+        date=date,
+        action=ActionType.BUY,
+        symbol=symbol,
+        description=f"malformed buy {symbol}",
+        quantity=Decimal(-50),
+        price=Decimal(20),
+        fees=Decimal(0),
+        amount=Decimal(-1000),
+        currency=GBP,
+        broker="Testing",
+    )
+
+
+def test_a_malformed_purchase_after_a_reorganisation_blames_its_own_row() -> None:
+    """The row with the impossible count is named, not the reorganisation.
+
+    A consolidation's own delta is allowed to be negative, which
+    ``test_a_consolidation_reduces_the_units_and_keeps_the_cost`` covers. A
+    purchase's is not, and the day's plan reads it before any row is
+    processed.
+    """
+    with pytest.raises(QuantityNotPositiveError) as excinfo:
+        run(
+            [
+                trade(POOL_DAY, ActionType.BUY, "FOO", "100", "5"),
+                legacy_split(EVENT_DAY, "FOO", "100"),
+                _malformed_purchase(EVENT_DAY, "FOO"),
+                trade(EVENT_DAY, ActionType.SELL, "FOO", "200", "10"),
+            ]
+        )
+
+    assert "malformed buy FOO" in str(excinfo.value)
+
+
+def test_a_malformed_purchase_before_a_reorganisation_blames_its_own_row() -> None:
+    """The same row, read where the plan works out what the event acts on."""
+    with pytest.raises(QuantityNotPositiveError) as excinfo:
+        run(
+            [
+                trade(POOL_DAY, ActionType.BUY, "FOO", "40", "5"),
+                trade(EVENT_DAY, ActionType.SELL, "FOO", "10", "10"),
+                _malformed_purchase(EVENT_DAY, "FOO"),
+                legacy_split(EVENT_DAY, "FOO", "100"),
+            ]
+        )
+
+    assert "malformed buy FOO" in str(excinfo.value)
 
 
 def test_a_later_part_disposal_takes_its_share_of_the_unchanged_cost() -> None:

--- a/tests/general/test_transfer_to_spouse.py
+++ b/tests/general/test_transfer_to_spouse.py
@@ -37,7 +37,7 @@ from .calc_test_data import (
     transaction,
     transfer_to_spouse_transaction,
 )
-from .test_calc import _rename_transaction, create_calculator, get_report
+from .test_calc import _gbp_trade, _rename_transaction, create_calculator, get_report
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -1578,6 +1578,93 @@ def test_a_sale_and_a_transfer_under_two_names_of_one_holding_are_refused() -> N
         "The sale is recorded under OLD, which the day's renames make one "
         "holding with NEW." in message
     )
+
+
+CONTENTION_BUY_DAY = datetime.date(2024, 6, 1)
+CONTENTION_DAY = datetime.date(2024, 6, 10)
+CONTENTION_LATER_DAY = datetime.date(2024, 6, 20)
+
+
+def _contention_history(
+    later_day_rows: list[BrokerTransaction],
+) -> list[BrokerTransaction]:
+    """Build a sale and a transfer of one holding, then a later rename day."""
+    return [
+        _gbp_trade(CONTENTION_BUY_DAY, ActionType.BUY, "X", 100, 500),
+        _gbp_trade(CONTENTION_DAY, ActionType.SELL, "X", 25, 500),
+        transfer_to_spouse_transaction(CONTENTION_DAY, "X", 25),
+        *later_day_rows,
+        _rename_transaction(CONTENTION_LATER_DAY, "X", "Z"),
+    ]
+
+
+def test_a_later_day_s_own_sale_leaves_nothing_to_contend_over() -> None:
+    """A later day's purchase its own sale has taken is not in dispute.
+
+    The 20 June purchase is written under the new ticker and the sale of it
+    under the retired one, which the day's rename makes one holding. That
+    sale takes the whole purchase under the same-day rule, so neither the
+    sale nor the transfer of 10 June can be identified against it and there
+    is nothing for them to argue over.
+    """
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+
+    report = get_report(
+        calculator,
+        _contention_history(
+            [
+                _gbp_trade(CONTENTION_LATER_DAY, ActionType.BUY, "Z", 30, 600),
+                _gbp_trade(CONTENTION_LATER_DAY, ActionType.SELL, "X", 30, 600),
+            ]
+        ),
+    )
+
+    (sale,) = report.calculation_log[CONTENTION_DAY]["sell$X"]
+    (transfer,) = report.calculation_log[CONTENTION_DAY]["transfer-to-spouse$X"]
+    # Both price from the pool at its 5 a share average, which is what neither
+    # of them reaching the 20 a share purchase of 20 June looks like.
+    assert sale.rule_type is RuleType.SECTION_104
+    assert sale.allowable_cost == Decimal(125)
+    assert transfer.allowable_cost == Decimal(125)
+    assert report.total_gain() == Decimal(375)
+
+
+def test_a_later_day_s_sale_leaves_the_rest_of_its_purchase_to_contend_over() -> None:
+    """What that day's own sale does not take is still in dispute."""
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+
+    with pytest.raises(CalculationError, match="does not say how to split") as err:
+        get_report(
+            calculator,
+            _contention_history(
+                [
+                    _gbp_trade(CONTENTION_LATER_DAY, ActionType.BUY, "Z", 60, 1200),
+                    _gbp_trade(CONTENTION_LATER_DAY, ActionType.SELL, "X", 30, 600),
+                ]
+            ),
+        )
+
+    assert str(CONTENTION_LATER_DAY) in str(err.value)
+
+
+def test_a_later_day_s_transfer_to_a_spouse_reserves_its_purchase_too() -> None:
+    """A transfer claims a later day's purchase exactly as a sale does."""
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+
+    report = get_report(
+        calculator,
+        _contention_history(
+            [
+                _gbp_trade(CONTENTION_LATER_DAY, ActionType.BUY, "Z", 30, 600),
+                transfer_to_spouse_transaction(CONTENTION_LATER_DAY, "X", 30),
+            ]
+        ),
+    )
+
+    # The whole 20 a share purchase, not a share of the 5 a share pool.
+    (later,) = report.calculation_log[CONTENTION_LATER_DAY]["transfer-to-spouse$X"]
+    assert later.allowable_cost == Decimal(600)
+    assert report.total_gain() == Decimal(375)
 
 
 def _free_shares(date: datetime.date, symbol: str, quantity: int) -> BrokerTransaction:


### PR DESCRIPTION
This fixes two cases where the calculator rejects a valid history or reports an error against the wrong transaction. Results for histories that already calculate successfully are unchanged.

### Valid sales and spouse transfers were rejected

For example, your history contains:

1. Buy 100 shares under ticker `X`.
2. Ten days later, sell 25 shares and transfer 25 to your spouse.
3. Another ten days later, buy 30 shares under the new ticker `Z`, sell 30 under `X`, and rename `X` to `Z`.

The last day's sale is matched against all 30 shares bought that day. Same-day matching takes priority over matching an earlier sale against a purchase within the following 30 days. See [HMRC CG51560](https://www.gov.uk/hmrc-internal-manuals/capital-gains-manual/cg51560).

However, the check for competing sales and spouse transfers overlooked the last day's sale because it used the old ticker. It incorrectly treated the 30-share purchase as available to both earlier transactions and rejected the history because it could not decide how to divide those shares between them.

The check now counts the later day's sales and spouse transfers under both ticker names. The example calculates successfully, using the existing holding's average cost for both earlier transactions. If shares really remain available to both, the calculator still rejects that unresolved case.

### Invalid quantities blamed the wrong transaction

On a rename or share-reorganisation day, the calculator checks how many shares are available before processing individual transactions. A purchase with a negative quantity could reduce that total and make a valid sale appear to exceed your holding, or make a reorganisation appear to leave a negative balance.

Planning now rejects zero and negative trade quantities before using them. The error says "Positive quantity required" and names the offending transaction. A share consolidation's own negative change remains valid: it reduces the number of shares you hold.

The separate purchase-lookup bug remains tracked in #1119: a purchase within 30 days can still be missed when recorded under the other ticker on a rename day. This PR does not fix that calculation error.
