### PR TITLE
Record purchases separately from spin-off shares and management fees

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -68,6 +68,7 @@ CSVs
 CurrencyConverter
 currentPrice
 cusip
+DayAcquisitions
 dataclass
 dest
 dataclasses

--- a/cgt_calc/calculator_state.py
+++ b/cgt_calc/calculator_state.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     import datetime
 
     from .model import (
+        AcquisitionLog,
         CalculationEntry,
         CalculationLog,
         CurrencyCode,
@@ -38,7 +39,10 @@ class PreparedHistory:
     them.
     """
 
-    acquisition_list: HmrcTransactionLog = field(default_factory=dict)
+    # What each day added to a holding, kept apart by how it got there so
+    # that matching can ask for the day's genuine acquisitions without
+    # reconstructing them from a total (see `DayAcquisitions`).
+    acquisition_list: AcquisitionLog = field(default_factory=dict)
     disposal_list: HmrcTransactionLog = field(default_factory=dict)
     # Grants of written options, by date and contract name. Kept apart from
     # disposal_list: a grant disposes of the option the grant creates, not of
@@ -113,12 +117,6 @@ class PreparedHistory:
 
     spin_offs: dict[datetime.date, list[SpinOff]] = field(
         default_factory=lambda: defaultdict(list)
-    )
-    # What the first pass recorded for each spun-off holding, by date and
-    # symbol. It is only an estimate, and the second pass swaps exactly
-    # this much out of the day's acquisitions for the real figure.
-    spin_off_estimates: dict[tuple[datetime.date, str], Decimal] = field(
-        default_factory=lambda: defaultdict(Decimal)
     )
     # Disposals that are gifts at market value rather than sales, and
     # whether the recipient is a connected person. A loss on a gift to a

--- a/cgt_calc/ingestion.py
+++ b/cgt_calc/ingestion.py
@@ -32,6 +32,7 @@ from .model import (
     CurrencyCode,
     ExcessReportedIncome,
     ForeignCurrencyAmount,
+    HmrcTransactionData,
     OptionDisposalData,
     Position,
     SpinOff,
@@ -45,7 +46,7 @@ from .rename_planning import (
 )
 from .stock_split_planning import plan_stock_splits, source_account
 from .stock_splits import quantity_sign
-from .transaction_log import add_to_list
+from .transaction_log import add_to_list, day_acquisitions
 from .util import approx_equal, normalize_amount, round_decimal
 
 if TYPE_CHECKING:
@@ -267,17 +268,23 @@ class TransactionIngester:
         gbp_amount = (
             self.currency_converter.to_gbp_for(amount, transaction) - capital_adjustment
         )
-        if transaction.action is ActionType.SPIN_OFF:
-            self.history.spin_off_estimates[transaction.date, symbol] += gbp_amount
-        add_to_list(
-            self.history.acquisition_list,
-            transaction.date,
-            symbol,
+        added = HmrcTransactionData(
             quantity,
             gbp_amount,
             self.currency_converter.to_gbp_for(transaction.fees, transaction)
             + capital_fee_adjustment,
         )
+        record = day_acquisitions(
+            self.history.acquisition_list, transaction.date, symbol
+        )
+        if transaction.action is ActionType.SPIN_OFF:
+            # Shares a reorganisation creates are not acquired (TCGA 1992
+            # s127), and what they cost is a share of the source pool this
+            # pass can only estimate. Kept apart from what the day genuinely
+            # acquired, rather than added in for the walk to take back out.
+            record.reorganised += added
+        else:
+            record.purchased += added
 
     def _available_units(
         self, symbol: str, date_index: datetime.date
@@ -1041,14 +1048,11 @@ class TransactionIngester:
         gbp_fees = self.currency_converter.to_gbp_for(transaction.fees, transaction)
         symbol = get_symbol_or_fail(transaction)
         self.history.fee_days.add((transaction.date, symbol))
-        add_to_list(
-            self.history.acquisition_list,
-            transaction.date,
-            symbol,
-            transaction.quantity,
-            gbp_fees,
-            gbp_fees,
-        )
+        # Cost with no shares behind it. `fee_days` still records that a fee
+        # row was read at all, which a fee of nothing leaves no figure for.
+        day_acquisitions(
+            self.history.acquisition_list, transaction.date, symbol
+        ).cost_only += HmrcTransactionData(transaction.quantity, gbp_fees, gbp_fees)
         return amount
 
     def _convert_foreign_fees(self, transaction: BrokerTransaction) -> None:

--- a/cgt_calc/matching.py
+++ b/cgt_calc/matching.py
@@ -148,7 +148,8 @@ class Matcher:
         date_index: datetime.date,
     ) -> list[CalculationEntry]:
         """Process single acquisition."""
-        acquisition = self.history.acquisition_list[date_index][symbol]
+        record = self.history.acquisition_list[date_index][symbol]
+        acquisition = record.total
         acquisition_amount = acquisition.amount
         spin_offs_here = [
             spin_off
@@ -162,11 +163,11 @@ class Matcher:
             # reorganisation itself (CG51976). The first pass could only
             # estimate the source pool, so it recorded an estimate for this
             # holding; here the pool is authoritative and in GBP. Record the
-            # corrected figure on the run, exactly the estimate apart, and take
-            # the source's side at the same moment so that what one gives up is
-            # what the other receives. The recorded acquisition is left alone:
-            # it may also hold ordinary purchases of the same symbol, and the
-            # first pass's history stays as written.
+            # corrected figure on the run and take the source's side at the
+            # same moment, so that what one gives up is what the other
+            # receives. The recorded acquisition is left alone: it may also
+            # hold ordinary purchases of the same symbol, and the first pass's
+            # history stays as written.
             carried = Decimal(0)
             # Several rows for one spin-off, as when the holding is split
             # across brokers, are one reorganisation: the split of value is by
@@ -205,16 +206,18 @@ class Matcher:
                     )
                 )
                 source.amount -= share
-            acquisition_amount += carried - self.history.spin_off_estimates.get(
-                (date_index, symbol), Decimal(0)
+            # The estimate is not used at all: the real share of the source
+            # pool goes in beside what the day genuinely put into the holding.
+            acquisition_amount = (
+                record.purchased.amount + record.cost_only.amount + carried
             )
             self.run.spin_off_corrected_amounts[date_index, symbol] = acquisition_amount
         modified_amount = acquisition_amount
         position = self.run.portfolio[symbol]
         calculation_entries = []
-        # Management fee transaction can have 0 quantity
+        # A management fee is cost with no shares, and a fee of nothing is
+        # neither, so a day can record either without the other.
         assert acquisition.quantity >= 0
-        # Stock split can have 0 amount
         assert acquisition_amount >= 0
 
         bnb_acquisition = HmrcTransactionData()
@@ -1303,17 +1306,10 @@ class Matcher:
         pool = holding[0] if holding else source
         activity = []
         for name in names:
-            spun_in = sum(
-                (
-                    spin_off.quantity
-                    for spin_off in self.history.spin_offs.get(date_index, [])
-                    if spin_off.dest == name
-                ),
-                Decimal(0),
-            )
             if (
                 has_key(self.history.acquisition_list, date_index, name)
-                and self.history.acquisition_list[date_index][name].quantity > spun_in
+                and self.history.acquisition_list[date_index][name].purchased.quantity
+                > 0
             ):
                 activity.append("bought")
             if has_key(self.history.disposal_list, date_index, name):
@@ -1440,19 +1436,22 @@ class Matcher:
     ) -> HmrcTransactionData:
         """Return the acquisitions a disposal could be identified with.
 
-        Units a reorganisation restated are not here to be taken out: they
-        were never acquired (TCGA 1992 s127, CG51805), so they never enter
-        ``acquisition_list`` in the first place. A spun-off holding's cost is
-        the corrected figure once its day has been walked, in place of the
+        Units a reorganisation restated in place are not here to be taken out:
+        they were never acquired (TCGA 1992 s127, CG51805), so they never
+        enter ``acquisition_list`` in the first place. Shares a spin-off
+        created do enter it, and still answer here along with everything else
+        the day put in; which of them a disposal may be identified against is
+        a separate question this does not yet ask. A spun-off holding's cost
+        is the corrected figure once its day has been walked, in place of the
         estimate the first pass recorded.
         """
         if not has_key(self.history.acquisition_list, date_index, symbol):
             return HmrcTransactionData()
-        record = self.history.acquisition_list[date_index][symbol]
+        acquisition = self.history.acquisition_list[date_index][symbol].total
         corrected = self.run.spin_off_corrected_amounts.get((date_index, symbol))
         if corrected is not None:
-            return replace(record, amount=corrected)
-        return record
+            return replace(acquisition, amount=corrected)
+        return acquisition
 
     def _contending_acquisitions(
         self,

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -173,6 +173,34 @@ class HmrcTransactionData:
 
 
 @dataclass
+class DayAcquisitions:
+    """What a day put into one holding, kept apart by how it got there.
+
+    `purchased` is what the same-day and 30-day rules may identify a disposal
+    against: a purchase, a vest, or shares arriving from a spouse.
+
+    `reorganised` is what a spin-off created. That is not an acquisition
+    (TCGA 1992 s127, CG51805), and its amount is only the first pass's
+    estimate of the share of the source pool that carries across, which the
+    walk replaces with the real figure once it reaches the day. A
+    reorganisation an export states as a share count leaves nothing here at
+    all: it restates a holding rather than adding to one.
+
+    `cost_only` is pooled cost with no shares behind it, which is a management
+    fee.
+    """
+
+    purchased: HmrcTransactionData = field(default_factory=HmrcTransactionData)
+    reorganised: HmrcTransactionData = field(default_factory=HmrcTransactionData)
+    cost_only: HmrcTransactionData = field(default_factory=HmrcTransactionData)
+
+    @property
+    def total(self) -> HmrcTransactionData:
+        """Everything the day put in, which is what the pool moves by."""
+        return self.purchased + self.reorganised + self.cost_only
+
+
+@dataclass
 class ForeignCurrencyAmount:
     """Represent a decimal amount in foreign currency."""
 
@@ -290,6 +318,7 @@ class CapitalAdjustment:
 
 
 HmrcTransactionLog = dict[datetime.date, dict[str, HmrcTransactionData]]
+AcquisitionLog = dict[datetime.date, dict[str, DayAcquisitions]]
 ForeignAmountLog = dict[tuple[str, datetime.date], ForeignCurrencyAmount]
 ExcessReportedIncomeLog = dict[datetime.date, dict[str, ExcessReportedIncome]]
 ExcessReportedIncomeDistributionLog = dict[

--- a/cgt_calc/transaction_log.py
+++ b/cgt_calc/transaction_log.py
@@ -4,20 +4,41 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .model import ExcessReportedIncome, HmrcTransactionData, HmrcTransactionLog
+from .model import (
+    DayAcquisitions,
+    ExcessReportedIncome,
+    HmrcTransactionData,
+    HmrcTransactionLog,
+)
 
 if TYPE_CHECKING:
     import datetime
     from decimal import Decimal
 
+    from .model import AcquisitionLog
 
-def has_key(
-    transactions: HmrcTransactionLog,
+
+def has_key[T](
+    transactions: dict[datetime.date, dict[str, T]],
     date_index: datetime.date,
     symbol: str,
 ) -> bool:
-    """Check if transaction log has entry for date_index and symbol."""
+    """Check if transaction log has entry for date_index and symbol.
+
+    Generic over what a log records, so that the acquisition log, whose
+    entries keep a day's purchases apart from what a reorganisation or a fee
+    put in, is asked the same way as the rest.
+    """
     return date_index in transactions and symbol in transactions[date_index]
+
+
+def day_acquisitions(
+    current_list: AcquisitionLog,
+    date_index: datetime.date,
+    symbol: str,
+) -> DayAcquisitions:
+    """Return what a day has put into a holding, starting an empty record."""
+    return current_list.setdefault(date_index, {}).setdefault(symbol, DayAcquisitions())
 
 
 def add_to_list(

--- a/tests/general/test_acquisition_ledger.py
+++ b/tests/general/test_acquisition_ledger.py
@@ -1,0 +1,146 @@
+"""What a day put into a holding stays sorted by how it got there.
+
+The acquisition log used to add a purchase, a spin-off's shares and a
+management fee into one figure per day and ticker, and matching worked out
+what it was made of by subtracting the parts it could find recorded
+elsewhere. These pin what each part is recorded as, so a later change can ask
+for the day's genuine acquisitions directly.
+"""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+from cgt_calc.model import (
+    AcquisitionLog,
+    ActionType,
+    BrokerTransaction,
+    CurrencyCode,
+    HmrcTransactionData,
+)
+
+from .calc_test_data import GBP, transaction
+from .test_calc import _gbp_fee, _gbp_trade, create_calculator, get_report
+from .test_spin_off_basis import BUY_DAY, FLAT, SPIN_OFF_DAY, spin_off
+from .test_stock_splits import legacy_split
+
+DAY = datetime.date(2024, 5, 10)
+EARLIER_DAY = datetime.date(2024, 5, 1)
+
+
+def _ledger(transactions: list[BrokerTransaction]) -> AcquisitionLog:
+    """Return the acquisition log a run of these transactions records."""
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    get_report(calculator, transactions)
+    return calculator.state.history.acquisition_list
+
+
+def test_a_day_s_purchase_and_spin_off_stay_separately_recorded() -> None:
+    """The five bought and the ten spun off are two records, not fifteen units.
+
+    A tenth of FOO's value goes to BAR, so £10 of its £100 carries across,
+    beside the £50 paid for five more.
+    """
+    calculator, _ = spin_off(
+        [
+            transaction(BUY_DAY, ActionType.BUY, "FOO", 10, 10, 0, -100, GBP),
+            transaction(SPIN_OFF_DAY, ActionType.BUY, "BAR", 5, 10, 0, -50, GBP),
+        ],
+        10,
+        {BUY_DAY: {GBP: FLAT}, SPIN_OFF_DAY: {GBP: FLAT}},
+    )
+
+    record = calculator.state.history.acquisition_list[SPIN_OFF_DAY]["BAR"]
+    assert record.purchased.quantity == Decimal(5)
+    assert record.purchased.amount == Decimal(50)
+    assert record.reorganised.quantity == Decimal(10)
+    assert record.reorganised.amount == Decimal(10)
+    assert record.cost_only == HmrcTransactionData()
+    # The blend they used to be, which is still what the pool moves by.
+    assert record.total.quantity == Decimal(15)
+    assert record.total.amount == Decimal(60)
+
+
+def test_a_management_fee_is_recorded_as_cost_with_no_shares() -> None:
+    """A fee brings in cost that no shares of its own carry."""
+    record = _ledger(
+        [
+            _gbp_trade(EARLIER_DAY, ActionType.BUY, "X", 100, 1000),
+            _gbp_fee(DAY, "X", 40),
+        ]
+    )[DAY]["X"]
+
+    assert record.cost_only.amount == Decimal(40)
+    assert record.cost_only.quantity == Decimal(0)
+    assert record.purchased == HmrcTransactionData()
+    assert record.reorganised == HmrcTransactionData()
+    assert record.total.quantity == Decimal(0)
+
+
+def test_a_purchase_and_a_fee_on_one_day_stay_separately_recorded() -> None:
+    """A purchase under the same name no longer hides the fee.
+
+    Both used to add into one record whose quantity a fee cannot change, so
+    the only sign of the fee was a total priced above what the shares cost.
+    """
+    record = _ledger(
+        [
+            _gbp_trade(EARLIER_DAY, ActionType.BUY, "X", 100, 1000),
+            _gbp_trade(DAY, ActionType.BUY, "X", 50, 750),
+            _gbp_fee(DAY, "X", 100),
+        ]
+    )[DAY]["X"]
+
+    assert record.purchased.quantity == Decimal(50)
+    assert record.purchased.amount == Decimal(750)
+    assert record.cost_only.amount == Decimal(100)
+    assert record.total.amount == Decimal(850)
+
+
+def test_a_vest_and_a_transfer_from_a_spouse_are_recorded_as_purchases() -> None:
+    """Neither is a reorganisation, so both stay identifiable acquisitions.
+
+    A vest is an acquisition at market value, and shares from a spouse arrive
+    at the base cost they left with (TCGA 1992 s58, CG22200).
+    """
+    ledger = _ledger(
+        [
+            transaction(DAY, ActionType.STOCK_ACTIVITY, "VEST", 10, 10, 0, None, GBP),
+            transaction(
+                DAY,
+                ActionType.TRANSFER_FROM_SPOUSE,
+                "GIFTED",
+                40,
+                10,
+                0,
+                None,
+                CurrencyCode(GBP),
+            ),
+        ]
+    )
+
+    assert ledger[DAY]["VEST"].purchased.quantity == Decimal(10)
+    assert ledger[DAY]["VEST"].purchased.amount == Decimal(100)
+    assert ledger[DAY]["VEST"].reorganised == HmrcTransactionData()
+    assert ledger[DAY]["GIFTED"].purchased.quantity == Decimal(40)
+    assert ledger[DAY]["GIFTED"].purchased.amount == Decimal(400)
+    assert ledger[DAY]["GIFTED"].reorganised == HmrcTransactionData()
+
+
+def test_a_reorganisation_stated_as_a_share_count_records_no_acquisition() -> None:
+    """A split restates a holding, so it puts nothing into the day's record.
+
+    Only a spin-off reaches ``reorganised``: it names a holding of its own and
+    carries cost into it, where a split leaves the same pool under the same
+    name.
+    """
+    split_day = datetime.date(2023, 5, 15)
+    ledger = _ledger(
+        [
+            _gbp_trade(datetime.date(2023, 5, 2), ActionType.BUY, "FOO", 100, 1000),
+            legacy_split(split_day, "FOO", "100"),
+        ]
+    )
+
+    assert split_day not in ledger


### PR DESCRIPTION
The calculator currently combines purchases, spin-off shares, and management fees into one daily record. This hides which shares were actually purchased and what they cost, so code has to reconstruct that information by subtracting other entries.

This PR records each category separately. That makes purchases directly available for later matching fixes, while preserving current matching rules and reported results.

For example: on one day, you buy 5 shares of `BAR` for GBP 50, and a spin-off also creates 10 shares of `BAR` worth GBP 10 of carried-over cost.

1. Today, the day's record for `BAR` is one number: 15 shares, GBP 60. A separate list keeps a second copy of the spin-off's GBP 10 purely so it can be subtracted back out when something needs to know what was actually purchased.
2. After this change, the record keeps the two apart from the start: `purchased` is 5 shares for GBP 50, `reorganised` is 10 shares for GBP 10, and `total` (15 shares, GBP 60) is still there for the places that want the combined figure. The separate subtraction-only list is deleted.

A management fee's cost now goes into its own `cost_only` figure the same way, instead of being told apart from a purchase by noticing "this entry has cost but no shares" - a fragile signal, since a real purchase the same day hides it.

This changes how additions are stored, not the matching rules or reported results. Existing matching still uses the combined total; spin-off and management-fee corrections remain separate follow-ups.

Groundwork, not a fix by itself: shares a spin-off creates are not an acquisition (TCGA 1992 s127), so a disposal shouldn't be matched against them under the same-day or 30-day rules - but that changes tax figures and needs this separation first. Separate, later change.
