### PR TITLE
Read every Schwab Equity Awards export through `--schwab-award-file`

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -85,6 +85,7 @@ ETFs
 ETNs
 expanduser
 f
+FairMarketValuePrice
 FeesAndCommissions
 FIGI
 FileNotFoundError
@@ -104,6 +105,7 @@ I/O
 IBKR
 IBKR's
 idx
+IndexError
 ingester
 intraday
 InvalidOperation
@@ -116,6 +118,7 @@ ISIN
 IsinConverter
 ISINs
 json
+KeyError
 Lansdown
 len
 LF

--- a/cgt_calc/parsers/base_parsers.py
+++ b/cgt_calc/parsers/base_parsers.py
@@ -128,6 +128,40 @@ class BaseSingleFileParser[T: BrokerTransaction](BaseParser):
         load passes its own token so every file in it shares one boundary; a
         file loaded on its own is a boundary of its own.
         """
+        if file_path == STDIN_PATH:
+            return cls.load_from_stream(
+                sys.stdin,
+                STDIN_PATH,
+                warn_on_empty=warn_on_empty,
+                show_parsing_msg=show_parsing_msg,
+                account=account,
+            )
+        with file_path.open(encoding=cls.encoding) as file:
+            return cls.load_from_stream(
+                file,
+                file_path,
+                warn_on_empty=warn_on_empty,
+                show_parsing_msg=show_parsing_msg,
+                account=account,
+            )
+
+    @classmethod
+    def load_from_stream(
+        cls,
+        file: TextIO,
+        file_path: Path,
+        *,
+        warn_on_empty: bool = True,
+        show_parsing_msg: bool = True,
+        account: str | None = None,
+    ) -> list[T]:
+        """Load broker data from a stream someone else opened.
+
+        ``file_path`` is what the stream holds, used to report rows and to
+        record where each transaction came from. Callers that have already
+        read the input, to decide which parser owns it, hand the text back
+        here rather than reopening a path or a stdin that is now exhausted.
+        """
         # A file passed on its own is a boundary of its own, and nothing
         # follows it, so it finalizes here. A directory load supplies its own
         # token and finalizes once over every file instead.
@@ -135,15 +169,9 @@ class BaseSingleFileParser[T: BrokerTransaction](BaseParser):
         boundary = (
             account if account is not None else next_account_token(cls.pretty_name)
         )
-        if file_path == STDIN_PATH:
-            if show_parsing_msg:
-                parsing_msg("stdin")
-            transactions = cls.read_transactions(sys.stdin, STDIN_PATH)
-        else:
-            with file_path.open(encoding=cls.encoding) as file:
-                if show_parsing_msg:
-                    parsing_msg(file_path)
-                transactions = cls.read_transactions(file, file_path)
+        if show_parsing_msg:
+            parsing_msg("stdin" if file_path == STDIN_PATH else file_path)
+        transactions = cls.read_transactions(file, file_path)
         if not transactions and warn_on_empty:
             LOGGER.warning("No transactions detected in file %s", file_path)
         cls.stamp_source(transactions, file_path, boundary)

--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -9,16 +9,19 @@ from dataclasses import dataclass, replace
 import datetime
 from decimal import Decimal
 from enum import StrEnum
+import io
 import itertools
 import logging
+import sys
 from typing import TYPE_CHECKING, ClassVar, Final, TextIO, override
 
 import shtab
 
 from cgt_calc.args_validators import (
+    STDIN_PATH,
     DeprecatedAction,
     existing_directory_type,
-    existing_file_type,
+    existing_file_or_stdin_type,
     set_completer,
 )
 from cgt_calc.const import TICKER_RENAMES
@@ -37,6 +40,10 @@ from cgt_calc.model import (
     TransactionSource,
 )
 from cgt_calc.parsers.schwab_cusip_bonds import adjust_cusip_bond_price
+from cgt_calc.parsers.schwab_equity_award_json import (
+    COMPLETE_CSV_COLUMNS,
+    SchwabEquityAwardsParser,
+)
 from cgt_calc.parsers.schwab_options import (
     parse_option_contract,
     reconcile_written_options,
@@ -768,11 +775,25 @@ def _read_schwab_awards(
     if schwab_award_transactions_file is None:
         return AwardPrices(award_prices={})
 
-    initial_prices: dict[datetime.date, dict[str, Decimal]] = defaultdict(dict)
-
     with schwab_award_transactions_file.open(encoding="utf-8") as csv_file:
         parsing_msg(schwab_award_transactions_file)
         lines = list(csv.reader(csv_file))
+    return _award_prices_from_lines(lines, schwab_award_transactions_file)
+
+
+def _award_prices_from_lines(
+    lines: list[list[str]],
+    schwab_award_transactions_file: Path,
+) -> AwardPrices:
+    """Read initial stock prices from the rows of an award-price CSV.
+
+    The guards below stay with the rows they protect rather than with the
+    reading: ``_read_schwab_awards`` is called directly with a path as well as
+    through the CLI, and an empty file or a wrong header has to name itself
+    either way instead of surfacing as IndexError or KeyError.
+    """
+    initial_prices: dict[datetime.date, dict[str, Decimal]] = defaultdict(dict)
+
     if not lines:
         raise ParsingError(
             schwab_award_transactions_file, "Charles Schwab Award CSV file is empty"
@@ -868,6 +889,33 @@ def _read_schwab_awards(
     return AwardPrices(award_prices=dict(initial_prices))
 
 
+def _is_complete_award_export(content: str, file_path: Path) -> bool:
+    """Say which Equity Awards export the award input holds.
+
+    The contents decide, not the filename: users rename these exports, and
+    ``--schwab-award-file`` takes either kind. The header alone decides, so a
+    file holding nothing but a header is still routed to the reader that owns
+    its layout and reports the shortage in that layout's own terms.
+    """
+    if content.startswith("{"):
+        return True
+    header = next(csv.reader(io.StringIO(content)), [])
+    # The complete layout is tested first because a real one also carries
+    # FairMarketValuePrice; only the last two columns are unique to it.
+    if COMPLETE_CSV_COLUMNS.issubset(header):
+        return True
+    if {column.value for column in RequiredAwardColumn}.issubset(header):
+        return False
+    raise ParsingError(
+        file_path,
+        "This is not a Schwab Equity Awards export cgt-calc reads. The "
+        "award-price CSV holds Date, Symbol and FairMarketValuePrice; the "
+        "complete CSV holds VestFairMarketValue and PurchaseFairMarketValue; "
+        "the JSON export starts with '{'.",
+        row_index=1,
+    )
+
+
 class SchwabParser(BaseSingleFileParser[BrokerTransaction]):
     """Parser for Charles Schwab transaction files."""
 
@@ -889,10 +937,12 @@ class SchwabParser(BaseSingleFileParser[BrokerTransaction]):
         set_completer(
             arg_group.add_argument(
                 "--schwab-award-file",
-                type=existing_file_type,
+                type=existing_file_or_stdin_type,
                 default=None,
                 metavar="PATH",
-                help="Charles Schwab Equity Awards transaction history in CSV format",
+                help="Charles Schwab Equity Awards export: the award-price CSV "
+                "that prices vests in the main history, or the complete "
+                "transaction history as JSON or CSV",
             ),
             shtab.FILE,
         )
@@ -900,7 +950,7 @@ class SchwabParser(BaseSingleFileParser[BrokerTransaction]):
             "--schwab-award",
             action=DeprecatedAction,
             dest="schwab_award_file",
-            type=existing_file_type,
+            type=existing_file_or_stdin_type,
             help=argparse.SUPPRESS,
         )
         # Schwab keeps both forms: `--schwab-file` predates the directory
@@ -932,15 +982,76 @@ class SchwabParser(BaseSingleFileParser[BrokerTransaction]):
                 "--schwab-file and --schwab-dir cannot be used together. Pass "
                 "the directory holding every export, or the single file."
             )
-        award_path = args.schwab_award_file
-        cls.awards_prices = _read_schwab_awards(award_path)
+        award_transactions = cls._load_award_file(args)
         if args.schwab_dir:
             # list is invariant, so widen explicitly rather than return list[T].
             transactions: list[BrokerTransaction] = list(
                 cls.load_from_dir(args.schwab_dir)
             )
             return transactions
-        return super().load_from_args(args)
+        # A complete award export cannot be combined with a main history, so
+        # at most one of these two holds anything. The registry then reports
+        # them under this parser's name, so a canonical complete import says
+        # "Charles Schwab" where the old option said "Charles Schwab Equity
+        # Awards". Only that progress line: each transaction still records the
+        # parser that read it.
+        return award_transactions + super().load_from_args(args)
+
+    @classmethod
+    def _load_award_file(cls, args: argparse.Namespace) -> list[BrokerTransaction]:
+        """Read --schwab-award-file and route it by what it holds.
+
+        An award-price CSV supplies `awards_prices` and imports nothing; a
+        complete export imports its own history and prices no vests. Either
+        way `awards_prices` is assigned, because it is class-level state and
+        leaving it would price this run's vests from the last run's file.
+        """
+        cls.awards_prices = AwardPrices(award_prices={})
+        award_path = args.schwab_award_file
+        if award_path is None:
+            return []
+        # Read once and classify the text: stdin cannot be reopened, and the
+        # reader that owns the layout is handed this same content.
+        if award_path == STDIN_PATH:
+            parsing_msg("stdin")
+            content = sys.stdin.read()
+        else:
+            with award_path.open(encoding=cls.encoding) as award_file:
+                parsing_msg(award_path)
+                content = award_file.read()
+        # The same leading noise a complete export already tolerates. It is
+        # applied before classification, so a price CSV led by a byte-order
+        # mark or a blank line is now read too.
+        content = content.lstrip("\ufeff \t\r\n")
+        if not _is_complete_award_export(content, award_path):
+            cls.awards_prices = _award_prices_from_lines(
+                list(csv.reader(io.StringIO(content))), award_path
+            )
+            return []
+        if args.schwab_equity_award_json:
+            raise CgtError(
+                "A complete Equity Awards export was given to both "
+                "--schwab-award-file and --schwab-equity-award-json. Accepting "
+                "both could duplicate transactions: cgt-calc cannot tell two "
+                "exports of one history from two exports of different periods. "
+                "Pass the history once, through --schwab-award-file."
+            )
+        if args.schwab_file or args.schwab_dir:
+            raise CgtError(
+                "--schwab-award-file holds a complete Equity Awards history, "
+                "and combining one with a main history is not supported yet. "
+                "Pass the complete export on its own, or pass it with "
+                "--schwab-equity-award-json and make sure no transaction "
+                "appears in both files. That option only adds transactions, it "
+                "does not price vests, so the main history has to import on "
+                "its own: if it holds a vest cgt-calc cannot price, pass the "
+                "award-price CSV with --schwab-award-file as well."
+            )
+        return list(
+            SchwabEquityAwardsParser.load_from_stream(
+                io.StringIO(content), award_path, show_parsing_msg=False
+            )
+        )
 
     @classmethod
     @override

--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -1332,8 +1332,9 @@ class SchwabEquityAwardsParser(BaseSingleFileParser[SchwabAwardTransaction]):
     pretty_name = "Charles Schwab Equity Awards"
     format_name = "JSON"
     argument_help: ClassVar[str | None] = (
-        "Charles Schwab Equity Awards transaction history, in the JSON or the "
-        "complete CSV export layout"
+        "Charles Schwab Equity Awards transaction history, JSON or complete "
+        "CSV. Prefer --schwab-award-file; this option remains the way to "
+        "combine the history with --schwab-file or --schwab-dir"
     )
     deprecated_flags: ClassVar[list[str]] = ["--schwab_equity_award_json"]
 

--- a/docs/brokers/index.md
+++ b/docs/brokers/index.md
@@ -8,18 +8,18 @@ If your shares came from an employer, check the broker guide carefully. Schwab s
 award-export formats described in its guide, Morgan Stanley support is limited to Alphabet's GSU
 plan, and Sharesight requires equity grants to be recorded in a particular way.
 
-| Broker                                        | CLI option                                                                             | Notes                                              |
-| --------------------------------------------- | -------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| [Charles Schwab](schwab.md)                   | `--schwab-file` or `--schwab-dir`, `--schwab-award-file`, `--schwab-equity-award-json` | Written equity options, some Equity Awards formats |
-| [Freetrade](freetrade.md)                     | `--freetrade-file`                                                                     | Activity CSV export                                |
-| [Hargreaves Lansdown](hargreaves-lansdown.md) | `--hl-dir`                                                                             | Tax Centre CSVs plus contract notes                |
-| [Interactive Brokers](interactive-brokers.md) | `--interactive-brokers-file`                                                           | Transaction history CSV                            |
-| [Morgan Stanley](morgan-stanley.md)           | `--mssb-dir`                                                                           | Alphabet GSU reports only                          |
-| [Revolut](revolut.md)                         | `--revolut-file`                                                                       | Invest account statement CSV                       |
-| [Sharesight](sharesight.md)                   | `--sharesight-dir`                                                                     | Multi-broker portfolio tracker                     |
-| [Trading 212](trading212.md)                  | `--trading212-dir`                                                                     | Folder of yearly exports                           |
-| [Vanguard](vanguard.md)                       | `--vanguard-file`                                                                      | Client Transactions Listing CSV                    |
-| [RAW format](raw.md)                          | `--raw-file`                                                                           | Generic fallback for other brokers                 |
+| Broker                                        | CLI option                                               | Notes                                              |
+| --------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------- |
+| [Charles Schwab](schwab.md)                   | `--schwab-file` or `--schwab-dir`, `--schwab-award-file` | Written equity options, some Equity Awards formats |
+| [Freetrade](freetrade.md)                     | `--freetrade-file`                                       | Activity CSV export                                |
+| [Hargreaves Lansdown](hargreaves-lansdown.md) | `--hl-dir`                                               | Tax Centre CSVs plus contract notes                |
+| [Interactive Brokers](interactive-brokers.md) | `--interactive-brokers-file`                             | Transaction history CSV                            |
+| [Morgan Stanley](morgan-stanley.md)           | `--mssb-dir`                                             | Alphabet GSU reports only                          |
+| [Revolut](revolut.md)                         | `--revolut-file`                                         | Invest account statement CSV                       |
+| [Sharesight](sharesight.md)                   | `--sharesight-dir`                                       | Multi-broker portfolio tracker                     |
+| [Trading 212](trading212.md)                  | `--trading212-dir`                                       | Folder of yearly exports                           |
+| [Vanguard](vanguard.md)                       | `--vanguard-file`                                        | Client Transactions Listing CSV                    |
+| [RAW format](raw.md)                          | `--raw-file`                                             | Generic fallback for other brokers                 |
 
 ## Dates and time zones
 

--- a/docs/brokers/schwab.md
+++ b/docs/brokers/schwab.md
@@ -293,24 +293,30 @@ cgt-calc --year 2025 --schwab-award-file schwab_awards.json
 cgt-calc --year 2025 --schwab-award-file schwab_awards.csv
 ```
 
-`--schwab-award-file` takes every award export cgt-calc reads, the award-price CSV above included.
-It decides which one a file is from its contents, so the option name and the file extension do not
-have to agree, and both complete layouts produce the same result.
+cgt-calc identifies the format from the file's contents, so both layouts produce the same result.
 
 The complete CSV states one transaction per row, followed by a row for each lot or grant with the
 transaction columns left blank. Keep the file exactly as Schwab exported it: cgt-calc reads those
 blank columns as the marker that a row continues the transaction above it.
 
-Use either layout only for an actual Schwab transaction export that you have checked. Do not import
-the same vest, sale, dividend or cash movement again through `--schwab-file`. cgt-calc does not yet
-reconcile a main history against a complete award history, so anything present in both is counted
-twice. Passing a complete export with `--schwab-award-file` alongside `--schwab-file` or
-`--schwab-dir` is refused for that reason.
+Use either layout only for a transaction history Schwab exported. Open the file first and confirm
+its rows are dated transactions with actions such as `Deposit`, `Sale` or `Dividend`, rather than a
+summary of your holdings or outstanding grants. Do not import the same vest, sale, dividend or cash
+movement again through `--schwab-file`. cgt-calc does not yet reconcile a main history against a
+complete award history, so anything present in both is counted twice. Passing a complete export with
+`--schwab-award-file` alongside `--schwab-file` or `--schwab-dir` is refused for that reason.
+
+The complete importer supports restricted-stock vests, ESPP purchases, sales, forced quick sales,
+dividends, dividend tax and forced cash disbursements. It recognises gifts but stops so that you can
+classify the recipient, as explained below. It skips `Lapse` rows because they repeat the shares
+already recorded by the related vest. For an ESPP purchase it uses the market value on the purchase
+date as the acquisition cost, on the assumption that the discount was taxed as employment income.
+Check that assumption against your payroll and award records.
 
 #### Combining a main history with a complete export
 
-If you do need both, the older `--schwab-equity-award-json` still accepts that combination and keeps
-working:
+If you need a main history and a complete award export in one run, the older
+`--schwab-equity-award-json` still accepts that combination and keeps working:
 
 ```shell
 cgt-calc --year 2025 --schwab-file schwab_transactions.csv \
@@ -321,13 +327,6 @@ Nothing checks the two files against each other, so make sure no transaction app
 option only adds transactions; it does not price vests. The main history therefore has to import on
 its own, and a `Stock Plan Activity` it cannot price still needs the award-price CSV passed with
 `--schwab-award-file` as well.
-
-The complete importer supports restricted-stock vests, ESPP purchases, sales, forced quick sales,
-dividends, dividend tax and forced cash disbursements. It recognises gifts but stops so that you can
-classify the recipient, as explained below. It skips `Lapse` rows because they repeat the shares
-already recorded by the related vest. For an ESPP purchase it uses the market value on the purchase
-date as the acquisition cost, on the assumption that the discount was taxed as employment income.
-Check that assumption against your payroll and award records.
 
 #### Share splits in complete exports
 
@@ -398,8 +397,10 @@ what each file holds:
     the two together: the main history with `--schwab-file`, the award-price CSV with
     `--schwab-award-file`.
 
-If neither file holds everything, this combination is not supported yet, so do not use both. Do not
-rename columns or invent a price merely to bypass the error.
+If neither file holds everything, cgt-calc cannot reconcile the two for you, but
+[Combining a main history with a complete export](#combining-a-main-history-with-a-complete-export)
+describes the one route that still works and what you have to check yourself. Do not rename columns
+or invent a price merely to bypass the error.
 
 ### `Missing columns` or a row/column-count error
 

--- a/docs/brokers/schwab.md
+++ b/docs/brokers/schwab.md
@@ -49,7 +49,9 @@ Two rules to get right:
 
 - **Do not put the Equity Awards CSV in this directory.** It is also a `.csv`, so cgt-calc would
     read it as transaction history and stop with `Missing columns in Schwab transaction file`. Keep
-    it elsewhere and pass it with `--schwab-award-file`.
+    it elsewhere and pass it with `--schwab-award-file`. A complete transaction export is a separate
+    case: cgt-calc cannot yet combine one with a main history, as [Equity awards](#equity-awards)
+    explains.
 - **Do not put exports from two different Schwab accounts in one directory.** The CSV does not say
     which account a row belongs to, so cgt-calc cannot separate them. Combining several accounts is
     not supported.
@@ -393,7 +395,8 @@ what each file holds:
     `--schwab-file`. Check first: anything that happened only in the main account is not in that
     export and would be left out of the calculation.
 - If the main history holds everything you need, ask Schwab for the award-price CSV as well and pass
-    the two together, both through `--schwab-award-file`.
+    the two together: the main history with `--schwab-file`, the award-price CSV with
+    `--schwab-award-file`.
 
 If neither file holds everything, this combination is not supported yet, so do not use both. Do not
 rename columns or invent a price merely to bypass the error.
@@ -407,10 +410,13 @@ gain/loss report, statement or spreadsheet converted from PDF has a different la
 export looks like: “This is not a Schwab Equity Awards export cgt-calc reads.” Check the file's
 heading against that message. The award-price CSV holds `Date`, `Symbol` and `FairMarketValuePrice`;
 the complete CSV holds `VestFairMarketValue` and `PurchaseFairMarketValue`; the JSON export starts
-with `{`. Any Equity Awards export goes to `--schwab-award-file`, whichever of the three it is.
+with `{`. Whichever of the three it is, it goes to `--schwab-award-file` rather than
+`--schwab-file`.
 
-With `--schwab-dir`, this error names the offending file: take it out of the directory. If it is an
-Equity Awards export, pass it with `--schwab-award-file` instead.
+With `--schwab-dir`, this error names the offending file: take it out of the directory. If it is the
+award-price CSV, pass it with `--schwab-award-file` instead. If it is a complete transaction export,
+`--schwab-award-file` will not take it alongside `--schwab-dir`: see
+[Combining a main history with a complete export](#combining-a-main-history-with-a-complete-export).
 
 If you combined several history ranges, confirm that there is one header, every data row has the
 same number of fields, and none of the source files used a different export format.

--- a/docs/brokers/schwab.md
+++ b/docs/brokers/schwab.md
@@ -47,11 +47,11 @@ it does not search subdirectories.
 
 Two rules to get right:
 
-- **Do not put the Equity Awards CSV in this directory.** It is also a `.csv`, so cgt-calc would
-    read it as transaction history and stop with `Missing columns in Schwab transaction file`. Keep
-    it elsewhere and pass it with `--schwab-award-file`. A complete transaction export is a separate
-    case: cgt-calc cannot yet combine one with a main history, as [Equity awards](#equity-awards)
-    explains.
+- **Do not put an Equity Awards CSV in this directory.** It is also a `.csv`, so cgt-calc would read
+    it as transaction history and stop with `Missing columns in Schwab transaction file`. Keep it
+    elsewhere. Pass an award-price CSV with `--schwab-award-file`. For a complete transaction
+    export, follow
+    [Combining a main history with a complete export](#combining-a-main-history-with-a-complete-export).
 - **Do not put exports from two different Schwab accounts in one directory.** The CSV does not say
     which account a row belongs to, so cgt-calc cannot separate them. Combining several accounts is
     not supported.

--- a/docs/brokers/schwab.md
+++ b/docs/brokers/schwab.md
@@ -252,6 +252,9 @@ Check the file's heading to see which one you have. `FairMarketValuePrice` and n
 `VestFairMarketValue` means the award-price CSV. `VestFairMarketValue` and `PurchaseFairMarketValue`
 means the complete CSV export.
 
+Both go to `--schwab-award-file`, which reads the heading and works out which one it has. What
+changes is what cgt-calc does with the file, described in the two sections below.
+
 ### Award-price CSV
 
 Use this method when the main transaction CSV contains `Stock Plan Activity` rows with a blank
@@ -284,12 +287,13 @@ The complete export is the award account's own history rather than a price list,
 on its own:
 
 ```shell
-cgt-calc --year 2025 --schwab-equity-award-json schwab_awards.json
-cgt-calc --year 2025 --schwab-equity-award-json schwab_awards.csv
+cgt-calc --year 2025 --schwab-award-file schwab_awards.json
+cgt-calc --year 2025 --schwab-award-file schwab_awards.csv
 ```
 
-Both layouts go through the same option and produce the same result. cgt-calc decides which one a
-file is from its contents, so the option name and the file extension do not have to agree.
+`--schwab-award-file` takes every award export cgt-calc reads, the award-price CSV above included.
+It decides which one a file is from its contents, so the option name and the file extension do not
+have to agree, and both complete layouts produce the same result.
 
 The complete CSV states one transaction per row, followed by a row for each lot or grant with the
 transaction columns left blank. Keep the file exactly as Schwab exported it: cgt-calc reads those
@@ -298,7 +302,23 @@ blank columns as the marker that a row continues the transaction above it.
 Use either layout only for an actual Schwab transaction export that you have checked. Do not import
 the same vest, sale, dividend or cash movement again through `--schwab-file`. cgt-calc does not yet
 reconcile a main history against a complete award history, so anything present in both is counted
-twice.
+twice. Passing a complete export with `--schwab-award-file` alongside `--schwab-file` or
+`--schwab-dir` is refused for that reason.
+
+#### Combining a main history with a complete export
+
+If you do need both, the older `--schwab-equity-award-json` still accepts that combination and keeps
+working:
+
+```shell
+cgt-calc --year 2025 --schwab-file schwab_transactions.csv \
+    --schwab-equity-award-json schwab_awards.json
+```
+
+Nothing checks the two files against each other, so make sure no transaction appears in both. That
+option only adds transactions; it does not price vests. The main history therefore has to import on
+its own, and a `Stock Plan Activity` it cannot price still needs the award-price CSV passed with
+`--schwab-award-file` as well.
 
 The complete importer supports restricted-stock vests, ESPP purchases, sales, forced quick sales,
 dividends, dividend tax and forced cash disbursements. It recognises gifts but stops so that you can
@@ -369,24 +389,28 @@ and cgt-calc cannot use it to price a vest in your main history. Which way round
 what each file holds:
 
 - If the complete export holds everything you need for the year, including any purchases, sales,
-    dividends and cash movements, pass it with `--schwab-equity-award-json` on its own and leave out
+    dividends and cash movements, pass it with `--schwab-award-file` on its own and leave out
     `--schwab-file`. Check first: anything that happened only in the main account is not in that
     export and would be left out of the calculation.
 - If the main history holds everything you need, ask Schwab for the award-price CSV as well and pass
-    the two together.
+    the two together, both through `--schwab-award-file`.
 
 If neither file holds everything, this combination is not supported yet, so do not use both. Do not
 rename columns or invent a price merely to bypass the error.
 
 ### `Missing columns` or a row/column-count error
 
-Make sure `--schwab-file` points to the main transaction-history CSV and `--schwab-award-file`
-points to the supported award-price CSV. A positions export, realised gain/loss report, statement,
-JSON file or spreadsheet converted from PDF has a different layout.
+Make sure `--schwab-file` points to the main transaction-history CSV. A positions export, realised
+gain/loss report, statement or spreadsheet converted from PDF has a different layout.
+
+`--schwab-award-file` reports a file it does not recognise differently, saying what each supported
+export looks like: “This is not a Schwab Equity Awards export cgt-calc reads.” Check the file's
+heading against that message. The award-price CSV holds `Date`, `Symbol` and `FairMarketValuePrice`;
+the complete CSV holds `VestFairMarketValue` and `PurchaseFairMarketValue`; the JSON export starts
+with `{`. Any Equity Awards export goes to `--schwab-award-file`, whichever of the three it is.
 
 With `--schwab-dir`, this error names the offending file: take it out of the directory. If it is an
-Equity Awards export, pass it with `--schwab-award-file` when it is the award-price CSV, or with
-`--schwab-equity-award-json` when it is the complete transaction export.
+Equity Awards export, pass it with `--schwab-award-file` instead.
 
 If you combined several history ranges, confirm that there is one header, every data row has the
 same number of fields, and none of the source files used a different export format.

--- a/tests/general/test_args_parser.py
+++ b/tests/general/test_args_parser.py
@@ -804,8 +804,6 @@ def test_raw_file_stdin() -> None:
     [
         "--initial-prices-file",
         "--initial-prices",
-        "--schwab-award-file",
-        "--schwab-award",
     ],
 )
 def test_options_without_a_stdin_consumer_reject_stdin(
@@ -860,6 +858,38 @@ def test_reject_duplicate_stdin_allows_a_single_option() -> None:
     reject_duplicate_stdin(parser, args)
 
     assert args.raw_file == STDIN_PATH
+
+
+def test_schwab_award_file_help_names_every_layout_it_takes() -> None:
+    """The canonical option's help says it takes either kind of export."""
+    help_text = " ".join(create_parser().format_help().split())
+
+    assert (
+        "--schwab-award-file PATH Charles Schwab Equity Awards export: the "
+        "award-price CSV that prices vests in the main history, or the "
+        "complete transaction history as JSON or CSV" in help_text
+    )
+
+
+@pytest.mark.parametrize("option", ["--schwab-award-file", "--schwab-award"])
+def test_schwab_award_file_accepts_stdin(option: str) -> None:
+    """The canonical award option reads a piped export, as its alias does."""
+    parser = create_parser()
+
+    args = parser.parse_args([option, "-"])
+
+    assert args.schwab_award_file == STDIN_PATH
+
+
+def test_reject_duplicate_stdin_covers_the_award_file() -> None:
+    """Changing the option type is all the existing stdin check needs."""
+    parser = create_parser()
+    args = parser.parse_args(["--schwab-award-file", "-", "--raw-file", "-"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        reject_duplicate_stdin(parser, args)
+
+    assert exc_info.value.code == 2
 
 
 def test_reject_duplicate_stdin_allows_an_option_and_its_alias() -> None:

--- a/tests/schwab/test_schwab.py
+++ b/tests/schwab/test_schwab.py
@@ -65,6 +65,29 @@ def test_award_rows_overlapping_in_a_column_are_reported(tmp_path: Path) -> None
     assert exc_info.value.row_index == 2
 
 
+def test_an_empty_award_file_is_reported(tmp_path: Path) -> None:
+    """Reading a path directly still names the empty file.
+
+    The CLI classifies the contents first and never reaches this, but
+    _read_schwab_awards is called with a path too, and the guard is what keeps
+    an empty file from surfacing as IndexError on the header lookup.
+    """
+    award_file = tmp_path / "awards.csv"
+    award_file.write_text("")
+
+    with pytest.raises(ParsingError, match="Award CSV file is empty"):
+        _read_schwab_awards(award_file)
+
+
+def test_an_award_file_without_the_price_column_is_reported(tmp_path: Path) -> None:
+    """And a header lacking FairMarketValuePrice, rather than a KeyError."""
+    award_file = tmp_path / "awards.csv"
+    award_file.write_text("Date,Symbol,Quantity\n08/15/2023,BAR,400\n")
+
+    with pytest.raises(ParsingError, match="Missing columns in Schwab Award file"):
+        _read_schwab_awards(award_file)
+
+
 @pytest.mark.parametrize("price", ["NaN", "$Infinity", "$not-a-number"])
 def test_award_price_that_is_not_a_finite_amount_is_reported(
     tmp_path: Path, price: str

--- a/tests/schwab/test_schwab_award_file.py
+++ b/tests/schwab/test_schwab_award_file.py
@@ -29,6 +29,8 @@ EQUITY_AWARD = Path("tests") / "schwab" / "data" / "equity_award"
 RSU = Path("tests") / "schwab" / "data" / "rsu_settlement"
 COMPLETE_JSON = EQUITY_AWARD / "schwab_equity_award_v2.json"
 COMPLETE_CSV = EQUITY_AWARD / "schwab_equity_award_v2.csv"
+# A complete CSV that also carries the award-price CSV's own columns.
+AMBIGUOUS_COMPLETE_CSV = EQUITY_AWARD / "nvda_synthetic.csv"
 PRICE_CSV = RSU / "awards.csv"
 MAIN_HISTORY = RSU / "transactions.csv"
 
@@ -77,6 +79,19 @@ def test_a_complete_json_export_is_imported(tmp_path: Path) -> None:
 def test_a_complete_csv_export_is_imported(tmp_path: Path) -> None:
     """The complete CSV history does too, under a JSON name."""
     transactions = _load(schwab_award_file=_renamed(tmp_path, COMPLETE_CSV, "a.json"))
+
+    assert transactions
+    assert not SchwabParser.awards_prices
+
+
+def test_a_complete_export_carrying_the_price_column_is_still_complete() -> None:
+    """The complete layout has to be tested before the price layout.
+
+    A real complete CSV also states FairMarketValuePrice, so checking the
+    price columns first would route this file to the price reader: it would
+    import none of its transactions and offer prices no vest asked for.
+    """
+    transactions = _load(schwab_award_file=str(AMBIGUOUS_COMPLETE_CSV))
 
     assert transactions
     assert not SchwabParser.awards_prices

--- a/tests/schwab/test_schwab_award_file.py
+++ b/tests/schwab/test_schwab_award_file.py
@@ -264,7 +264,9 @@ def test_the_award_file_is_announced_once(
         _load(schwab_award_file=str(fixture))
 
     assert caplog.text.count("Parsing ") == 1
-    assert str(fixture) in caplog.text
+    # parsing_msg prints forward slashes on every platform, so compare against
+    # that form rather than str(), which is backslashed on Windows.
+    assert fixture.as_posix() in caplog.text
 
 
 def test_a_complete_export_clears_the_prices_of_the_run_before() -> None:

--- a/tests/schwab/test_schwab_award_file.py
+++ b/tests/schwab/test_schwab_award_file.py
@@ -1,0 +1,280 @@
+"""Test how --schwab-award-file routes each Schwab Equity Awards export.
+
+Schwab states an Equity Awards account in more than one layout, and the option
+takes any of them: the award-price CSV that prices vests listed in the main
+history, and the complete transaction history as JSON or as CSV. Which one a
+file holds is read from its contents, so these tests care about the contents
+and deliberately not about the extension.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from pathlib import Path
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cgt_calc.args_parser import create_parser
+from cgt_calc.exceptions import CgtError, ParsingError
+from cgt_calc.parsers.schwab import AwardPrices, SchwabParser
+from cgt_calc.parsers.schwab_equity_award_json import SchwabEquityAwardsParser
+
+if TYPE_CHECKING:
+    from cgt_calc.model import BrokerTransaction
+
+EQUITY_AWARD = Path("tests") / "schwab" / "data" / "equity_award"
+RSU = Path("tests") / "schwab" / "data" / "rsu_settlement"
+COMPLETE_JSON = EQUITY_AWARD / "schwab_equity_award_v2.json"
+COMPLETE_CSV = EQUITY_AWARD / "schwab_equity_award_v2.csv"
+PRICE_CSV = RSU / "awards.csv"
+MAIN_HISTORY = RSU / "transactions.csv"
+
+PRICE_HEADER = (
+    '"Date","Action","Symbol","Description","Quantity","FeesAndCommissions",'
+    '"DisbursementElection","Amount","AwardDate","AwardId",'
+    '"FairMarketValuePrice","SalePrice","SharesSoldWithheldForTaxes",'
+    '"NetSharesDeposited","Taxes"\n'
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_awards_prices(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep changes to the class-level award prices out of other test modules."""
+    monkeypatch.setattr(SchwabParser, "awards_prices", AwardPrices(award_prices={}))
+
+
+def _load(**flags: str) -> list[BrokerTransaction]:
+    """Load through the CLI wiring rather than calling the parser directly.
+
+    load_from_args is the layer that classifies the award file and fills in
+    awards_prices, so bypassing it would test nothing this PR changed.
+    """
+    argv = ["--year", "2023"]
+    for flag, value in flags.items():
+        argv += [f"--{flag.replace('_', '-')}", value]
+    args = create_parser().parse_args(argv)
+    return SchwabParser.load_from_args(args)
+
+
+def _renamed(tmp_path: Path, source: Path, name: str) -> str:
+    """Copy a fixture under a name whose extension contradicts its contents."""
+    target = tmp_path / name
+    target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+    return str(target)
+
+
+def test_a_complete_json_export_is_imported(tmp_path: Path) -> None:
+    """The complete JSON history imports its own transactions."""
+    transactions = _load(schwab_award_file=_renamed(tmp_path, COMPLETE_JSON, "a.csv"))
+
+    assert transactions
+    assert not SchwabParser.awards_prices
+
+
+def test_a_complete_csv_export_is_imported(tmp_path: Path) -> None:
+    """The complete CSV history does too, under a JSON name."""
+    transactions = _load(schwab_award_file=_renamed(tmp_path, COMPLETE_CSV, "a.json"))
+
+    assert transactions
+    assert not SchwabParser.awards_prices
+
+
+def test_a_price_csv_supplies_prices_and_imports_nothing(tmp_path: Path) -> None:
+    """The award-price CSV is still a price list, whatever it is called."""
+    transactions = _load(schwab_award_file=_renamed(tmp_path, PRICE_CSV, "a.json"))
+
+    assert transactions == []
+    assert SchwabParser.awards_prices
+
+
+@pytest.mark.parametrize("fixture", [COMPLETE_JSON, COMPLETE_CSV])
+def test_the_canonical_option_matches_the_old_one(fixture: Path) -> None:
+    """A complete export reaches the same parser through either option."""
+    canonical = _load(schwab_award_file=str(fixture))
+    args = create_parser().parse_args(
+        ["--year", "2023", "--schwab-equity-award-json", str(fixture)]
+    )
+
+    assert canonical == SchwabEquityAwardsParser.load_from_args(args)
+    assert canonical
+
+
+def test_a_price_csv_still_prices_a_vest_in_the_main_history() -> None:
+    """The supplementing case is untouched: prices reach the row parser.
+
+    The fixture's only Stock Plan Activity has a blank Price, so this raises
+    "Cannot price a vest" unless awards_prices survives the new routing.
+    """
+    transactions = _load(
+        schwab_file=str(MAIN_HISTORY), schwab_award_file=str(PRICE_CSV)
+    )
+
+    assert transactions
+
+
+def test_a_price_csv_may_still_accompany_the_old_option() -> None:
+    """Pricing a vest and importing an award history is not a conflict."""
+    transactions = _load(
+        schwab_file=str(MAIN_HISTORY),
+        schwab_award_file=str(PRICE_CSV),
+        schwab_equity_award_json=str(COMPLETE_JSON),
+    )
+
+    assert transactions
+
+
+def test_a_complete_export_through_both_award_options_is_refused() -> None:
+    """Two complete exports cannot be told apart from one passed twice."""
+    with pytest.raises(CgtError, match="could duplicate transactions") as exc_info:
+        _load(
+            schwab_award_file=str(COMPLETE_JSON),
+            schwab_equity_award_json=str(COMPLETE_JSON),
+        )
+
+    assert "Pass the history once" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("main", ["schwab_file", "schwab_dir"])
+def test_a_complete_export_with_a_main_history_is_refused(
+    main: str, tmp_path: Path
+) -> None:
+    """Reconciling the two histories is not supported yet, so it is refused."""
+    directory = tmp_path / "schwab"
+    directory.mkdir()
+    (directory / "transactions.csv").write_text(
+        MAIN_HISTORY.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    history = str(MAIN_HISTORY) if main == "schwab_file" else str(directory)
+
+    with pytest.raises(CgtError, match="not supported yet") as exc_info:
+        _load(**{main: history}, schwab_award_file=str(COMPLETE_JSON))
+
+    message = str(exc_info.value)
+    # The way out, and what that option cannot do for the main history.
+    assert "--schwab-equity-award-json" in message
+    assert "it does not price vests" in message
+
+
+def test_the_duplicate_input_is_reported_before_the_main_history() -> None:
+    """Both conditions at once: the unconditional problem is named first.
+
+    The other message offers --schwab-equity-award-json as the way to combine
+    a history, which is no help to someone who has already passed it.
+    """
+    with pytest.raises(CgtError) as exc_info:
+        _load(
+            schwab_file=str(MAIN_HISTORY),
+            schwab_award_file=str(COMPLETE_JSON),
+            schwab_equity_award_json=str(COMPLETE_JSON),
+        )
+
+    assert "could duplicate transactions" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "content",
+    ["", "Symbol,Quantity,Price\nAAPL,10,$100.00\n", "not a Schwab export at all\n"],
+)
+def test_content_of_no_known_layout_names_the_layouts(
+    tmp_path: Path, content: str
+) -> None:
+    """An unrecognised award file says what each supported export looks like."""
+    award_file = tmp_path / "positions.csv"
+    award_file.write_text(content, encoding="utf-8")
+
+    with pytest.raises(ParsingError, match="not a Schwab Equity Awards export"):
+        _load(schwab_award_file=str(award_file))
+
+
+def test_a_header_only_price_csv_is_read_as_a_price_csv(tmp_path: Path) -> None:
+    """The header decides, not whether the file went on to price anything.
+
+    Inferring the layout from an empty result would report this as an
+    unrecognised file instead of the empty price list it is.
+    """
+    award_file = tmp_path / "awards.csv"
+    award_file.write_text(PRICE_HEADER, encoding="utf-8")
+
+    with pytest.raises(ParsingError, match="Cannot price a vest"):
+        _load(schwab_file=str(MAIN_HISTORY), schwab_award_file=str(award_file))
+
+
+def test_a_header_only_complete_export_is_read_as_a_complete_export(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Same for the complete layout: it reports no transactions, not a bad file."""
+    award_file = tmp_path / "awards.csv"
+    header = COMPLETE_CSV.read_text(encoding="utf-8").splitlines()[0]
+    award_file.write_text(f"{header}\n", encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING):
+        assert _load(schwab_award_file=str(award_file)) == []
+
+    assert "No transactions detected in file" in caplog.text
+
+
+@pytest.mark.parametrize("lead", ["\ufeff", "\n", " \t\r\n"])
+def test_a_price_csv_behind_leading_noise_is_read(tmp_path: Path, lead: str) -> None:
+    """The complete export already tolerates this, and now both layouts do."""
+    award_file = tmp_path / "awards.csv"
+    award_file.write_text(
+        lead + PRICE_CSV.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+    assert _load(schwab_award_file=str(award_file)) == []
+    assert SchwabParser.awards_prices
+
+
+@pytest.mark.parametrize("fixture", [COMPLETE_JSON, PRICE_CSV])
+def test_the_award_file_may_be_piped(
+    fixture: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A canonical option that cannot be piped to would be a downgrade."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO(fixture.read_text(encoding="utf-8")))
+
+    _load(schwab_award_file="-")
+
+    assert bool(SchwabParser.awards_prices) == (fixture is PRICE_CSV)
+
+
+@pytest.mark.parametrize("fixture", [COMPLETE_JSON, COMPLETE_CSV, PRICE_CSV])
+def test_the_award_file_is_announced_once(
+    fixture: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The file is read once, so it is announced once, as it was before."""
+    with caplog.at_level(logging.INFO):
+        _load(schwab_award_file=str(fixture))
+
+    assert caplog.text.count("Parsing ") == 1
+    assert str(fixture) in caplog.text
+
+
+def test_a_complete_export_clears_the_prices_of_the_run_before() -> None:
+    """awards_prices is class-level, so every load has to assign it.
+
+    Left alone, this run's vests would be priced from the last run's file.
+    """
+    _load(schwab_award_file=str(PRICE_CSV))
+    assert SchwabParser.awards_prices
+
+    _load(schwab_award_file=str(COMPLETE_JSON))
+
+    assert not SchwabParser.awards_prices
+
+
+def test_no_award_file_clears_the_prices_of_the_run_before() -> None:
+    """The same for a run passing no award file at all.
+
+    Separate from the test above on purpose: chaining the two would leave this
+    assertion trivially true, because the complete export already emptied the
+    prices.
+    """
+    _load(schwab_award_file=str(PRICE_CSV))
+    assert SchwabParser.awards_prices
+
+    _load()
+
+    assert not SchwabParser.awards_prices

--- a/tests/schwab/test_schwab_equity_award_json.py
+++ b/tests/schwab/test_schwab_equity_award_json.py
@@ -1927,4 +1927,13 @@ def test_the_option_help_names_both_layouts() -> None:
 
     assert "--schwab-equity-award-json" in help_text
     assert "--schwab-equity-award-file" not in help_text
-    assert "JSON or the complete CSV" in " ".join(help_text.split())
+    assert "JSON or complete CSV" in " ".join(help_text.split())
+
+
+def test_the_option_help_points_at_the_canonical_one() -> None:
+    """It stays registered, and its help says which option to prefer."""
+    help_text = " ".join(create_parser().format_help().split())
+
+    assert "Prefer --schwab-award-file" in help_text
+    # And why it is still here: the combination the canonical option refuses.
+    assert "combine the history with --schwab-file or --schwab-dir" in help_text


### PR DESCRIPTION
Schwab exports an Equity Awards account in three layouts, and cgt-calc split them across two options. `--schwab-award-file` took only the award-price CSV, which prices vests already listed in the main history. The complete transaction history, JSON or CSV, needed `--schwab-equity-award-json`. Nothing on the file says which option it belongs to, and getting it wrong produced an error about the file rather than about the option:

```
cgt-calc --year 2025 --schwab-award-file schwab_awards.json
-> Missing columns in Schwab Award file: {'FairMarketValuePrice'}
```

That names a column the complete export was never going to have.

`--schwab-award-file` now takes all three, working out which one it has from the header alone:

- a leading `{` is the complete JSON export;
- `VestFairMarketValue` and `PurchaseFairMarketValue` are the complete CSV;
- `Date`, `Symbol` and `FairMarketValuePrice` are the award-price CSV.

Each goes to the reader that already handles it, so a complete export produces the same report through either option. The file extension is ignored, as it already was for `--schwab-equity-award-json`. A file matching none of the three is refused with a message naming what each layout looks like.

Two combinations are refused once the file is recognised as a complete export:

- Given to both `--schwab-award-file` and `--schwab-equity-award-json`. cgt-calc cannot tell two exports of one history from two exports of different periods, so accepting both could duplicate transactions.
- Given with `--schwab-file` or `--schwab-dir`. Reconciling a main history against a complete award history is not supported yet, and the error says what to do instead.

Pairing a main history with the award-price CSV is untouched: `--schwab-file` and `--schwab-award-file` still work together, and that is what prices a `Stock Plan Activity` row. Only a complete export is refused alongside a main history.

`--schwab-equity-award-json` keeps its current behaviour and gains no deprecation warning, because it remains the only way to run a main history and a complete export in one command. It appends the award transactions rather than reconciling them, so nothing detects a transaction present in both files. Its help text and the documentation say so.

`--schwab-award-file` and its `--schwab-award` alias now accept `-` for stdin, which the complete-history option already did.

The award-price CSV is otherwise unchanged, except that leading whitespace or a byte-order mark is now tolerated, as it already was for the complete export.
