### PR TITLE
Stop identifying disposals against shares a spin-off created

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ See [Installation](https://cgt-calc.uk/installation/), [Brokers](https://cgt-cal
 For supported transactions, the tool converts prices to **GBP** and applies the UK **same-day**,
 **30-day ("bed and breakfast")**, and **Section 104 holding** rules. These match a sale with shares
 bought or received on the same day, shares bought or received within the following 30 days, then
-older shares. It shows **Disposal proceeds** (the sale price or value used when no sale took place),
-**Allowable costs** (costs included in the gain or loss calculation), gains, losses, dividends, and
-interest in the terminal and writes the full calculation to a **PDF report**.
+older shares. Shares that arrive through a company reorganisation, such as a spin-off, are not
+matched this way: they join your Section 104 holding at their share of the original cost. It shows
+**Disposal proceeds** (the sale price or value used when no sale took place), **Allowable costs**
+(costs included in the gain or loss calculation), gains, losses, dividends, and interest in the
+terminal and writes the full calculation to a **PDF report**.
 
 cgt-calc reports the net gain from the transactions you supply and, for supported tax years,
 estimates the amount left after the annual tax-free allowance for capital gains (the **annual exempt

--- a/cgt_calc/matching.py
+++ b/cgt_calc/matching.py
@@ -223,18 +223,25 @@ class Matcher:
         bnb_acquisition = HmrcTransactionData()
         bed_and_breakfast_fees = Decimal(0)
 
-        if acquisition.quantity > 0 and has_key(self.run.bnb_list, date_index, symbol):
+        # What an earlier disposal took under the 30-day rule has to leave the
+        # pool at the price it was given, and it was identified against the
+        # day's genuine acquisitions alone. Priced over everything the day
+        # brought in, a day that also received shares by reorganisation would
+        # hand the disposal one figure and take a smaller one out of the pool,
+        # leaving the difference to be relieved a second time.
+        identifiable = self._identifiable_acquisition(date_index, symbol)
+        if identifiable.quantity > 0 and has_key(self.run.bnb_list, date_index, symbol):
             bnb_acquisition = self.run.bnb_list[date_index][symbol]
-            assert bnb_acquisition.quantity <= acquisition.quantity
+            assert bnb_acquisition.quantity <= identifiable.quantity
             # Multiply by the B&B quantity before dividing to avoid rounding errors from division
             bnb_cost_basis = normalize_amount(
-                (bnb_acquisition.quantity * acquisition_amount) / acquisition.quantity
+                (bnb_acquisition.quantity * identifiable.amount) / identifiable.quantity
             )
             modified_amount -= bnb_cost_basis
             modified_amount += bnb_acquisition.amount
             assert modified_amount > 0
             bed_and_breakfast_fees = (
-                acquisition.fees * bnb_acquisition.quantity / acquisition.quantity
+                identifiable.fees * bnb_acquisition.quantity / identifiable.quantity
             )
             calculation_entries.append(
                 CalculationEntry(
@@ -338,15 +345,16 @@ class Matcher:
 
     def _match_same_day(self, ctx: DisposalContext) -> None:
         """Identify the disposal against the same day's acquisitions."""
-        # Same day rule is first, against the day's real purchases only. Shares
-        # from a split are not an acquisition (TCGA 1992 s127, CG51805) and cost
-        # nothing, so matching them would hand the disposal a nil allowable cost
-        # and, on a day that also has a purchase, spread that purchase's cost
-        # over the free shares as well.
+        # Same day rule is first, against the day's real purchases only. What a
+        # reorganisation brought in is not an acquisition (TCGA 1992 s127,
+        # CG51805), so matching it would spread the day's purchase cost over
+        # shares that were never bought, and price the sale at the average of
+        # the two. What those shares cost reaches a disposal through the
+        # Section 104 pool instead (see _identifiable_acquisition).
         # The day's purchases are one acquisition of this holding (TCGA 1992
         # s105(1)(a)) whichever of its names today's rows spell them under.
         acquired_under = ctx.identity.acquired_under
-        same_day_acquisition = self._matchable_acquisition(
+        same_day_acquisition = self._identifiable_acquisition(
             ctx.date_index, acquired_under
         )
         if same_day_acquisition.quantity > 0:
@@ -477,7 +485,7 @@ class Matcher:
                 eri = self.get_eri(effective_symbol, search_index)
                 if eri:
                     eris.append(eri)
-                acquisition = self._matchable_acquisition(
+                acquisition = self._identifiable_acquisition(
                     search_index, effective_symbol
                 )
                 if acquisition.quantity > 0:
@@ -506,36 +514,6 @@ class Matcher:
                         == 0
                     ):
                         continue
-                    if any(
-                        spin_off.dest == effective_symbol
-                        for spin_off in self.history.spin_offs.get(search_index, [])
-                    ):
-                        # What those shares cost is a share of the source's pool
-                        # on the day of the spin-off, and the walk has not
-                        # reached that day. The only figure to hand is the
-                        # first-pass estimate, and that is wrong after any
-                        # profitable sale, so refuse rather than use it.
-                        raise CalculationError(
-                            f"Cannot compute the disposal of {ctx.symbol} on "
-                            f"{ctx.date_index}: a spin-off added {effective_symbol} "
-                            f"shares on {search_index}, within the following 30 "
-                            "days, and the bed and breakfast rule would identify "
-                            "this disposal against them. What they cost is a "
-                            "share of the source holding's pool on the day of the "
-                            "spin-off, which is not settled until that day, so "
-                            "this tool cannot say what they cost here.\n"
-                            "What to do: run again with this one disposal left "
-                            "out. That run still applies the spin-off to both "
-                            "holdings and shows what the spun-off shares cost, "
-                            f"as the {effective_symbol} acquisition on "
-                            f"{search_index}. Identify this disposal against them "
-                            "at that cost by hand (consider professional advice). "
-                            f"Any later {effective_symbol} figures in that run "
-                            "still include the shares disposed of here, so check "
-                            "those by hand as well. Do not leave the symbol or "
-                            "the spin-off row out: the spin-off also reduces the "
-                            "source holding's cost."
-                        )
                     # Bed and breakfasting is a record of how the disposal was
                     # matched rather than a problem. Surface it for the computed
                     # tax year; the rest of the history walk logs it at DEBUG.
@@ -1434,7 +1412,7 @@ class Matcher:
         date_index: datetime.date,
         symbol: str,
     ) -> HmrcTransactionData:
-        """Return the acquisitions a disposal could be identified with.
+        """Return all of a day's additions to a holding, spin-off cost corrected.
 
         Units a reorganisation restated in place are not here to be taken out:
         they were never acquired (TCGA 1992 s127, CG51805), so they never
@@ -1452,6 +1430,34 @@ class Matcher:
         if corrected is not None:
             return replace(acquisition, amount=corrected)
         return acquisition
+
+    def _identifiable_acquisition(
+        self,
+        date_index: datetime.date,
+        symbol: str,
+    ) -> HmrcTransactionData:
+        """Return the part of a day a disposal may be identified against.
+
+        The same-day rule reads a day's acquisitions as one transaction
+        (TCGA 1992 s105(1)(a)), and the 30-day rule reaches acquisitions made
+        in the days after a disposal. Shares a reorganisation brings in are
+        neither: it is "not to be treated as involving ... any acquisition of
+        the new holding or any part of it" (TCGA 1992 s127), and CG51560 says
+        of a disposal followed by such a reorganisation that "the additional
+        shares are not treated as acquired within the 30 days following the
+        disposal". So they are left out here, and reach a later disposal
+        through the Section 104 pool instead, which is where s127 puts them.
+
+        A management fee is not an acquisition either, and is still counted
+        here. Leaving it out would change what an unrelated purchase costs on
+        a day it was charged, which is its own fix (see issue 1121).
+        """
+        if not has_key(self.history.acquisition_list, date_index, symbol):
+            return HmrcTransactionData()
+        record = self.history.acquisition_list[date_index][symbol]
+        # No spin-off correction is wanted: what a purchase cost is what its
+        # own row said, settled when it was read.
+        return record.purchased + record.cost_only
 
     def _contending_acquisitions(
         self,
@@ -1474,13 +1480,14 @@ class Matcher:
         def has_shares_going_spare(
             day: datetime.date, ticker: str, *, is_disposal_day: bool
         ) -> bool:
-            # Only what is left over is worth arguing about. Shares from a
-            # split are already excluded, and a management fee is recorded as
-            # cost with no shares at all. Shares that cost nothing are still
-            # worth arguing over: whichever disposal is identified against
-            # them takes a nil allowable cost, and the other one takes a
-            # share of the pool instead.
-            acquisition = self._matchable_acquisition(day, ticker)
+            # Only what is left over is worth arguing about, and only what
+            # either of them could be identified against at all: shares a
+            # reorganisation brought in are not there for either to claim, and
+            # a management fee brings in no shares. Shares that cost nothing are
+            # still worth arguing over: whichever disposal is identified
+            # against them takes a nil allowable cost, and the other one takes
+            # a share of the pool instead.
+            acquisition = self._identifiable_acquisition(day, ticker)
             if acquisition.quantity <= 0:
                 return False
             # Claims an earlier disposal already made are settled and leave

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,9 +20,11 @@ because not every award export or transaction type is supported.
 For supported transactions, the tool converts prices to **GBP** and applies the UK **same-day**,
 **30-day ("bed and breakfast")**, and **Section 104 holding** rules. These match a sale with shares
 bought or received on the same day, shares bought or received within the following 30 days, then
-older shares. It shows **Disposal proceeds** (the sale price or value used when no sale took place),
-**Allowable costs** (costs included in the gain or loss calculation), gains, losses, dividends, and
-interest in the terminal and writes the full calculation to a **PDF report**.
+older shares. Shares that arrive through a company reorganisation, such as a spin-off, are not
+matched this way: they join your Section 104 holding at their share of the original cost. It shows
+**Disposal proceeds** (the sale price or value used when no sale took place), **Allowable costs**
+(costs included in the gain or loss calculation), gains, losses, dividends, and interest in the
+terminal and writes the full calculation to a **PDF report**.
 
 cgt-calc reports the net gain from the transactions you supply and, for supported tax years,
 estimates the amount left after the annual tax-free allowance for capital gains (the **annual exempt

--- a/tests/general/test_spin_off_basis.py
+++ b/tests/general/test_spin_off_basis.py
@@ -25,9 +25,11 @@ from cgt_calc.model import (
     BrokerTransaction,
     CapitalGainsReport,
     CurrencyCode,
+    RuleType,
 )
 from cgt_calc.parsers.broker_registry import _transaction_sort_key
 from cgt_calc.spin_off_handler import SpinOffHandler
+from cgt_calc.util import round_decimal
 
 from .calc_test_data import GBP, USD, transaction, transfer_to_spouse_transaction
 from .test_calc import get_report
@@ -35,12 +37,20 @@ from .test_calc import get_report
 BUY_DAY = datetime.date(2024, 6, 1)
 SALE_DAY = datetime.date(2024, 6, 10)
 SPIN_OFF_DAY = datetime.date(2024, 7, 5)
+# Inside the 30 days before the spin-off, so the 30-day rule reaches its day.
+EARLY_SALE_DAY = datetime.date(2024, 6, 25)
 LATER = datetime.date(2024, 9, 1)
 
 # FOO at £90 and BAR at £10 on the day, with as many BAR as FOO units, puts a
 # tenth of the market value in BAR, so a tenth of the cost goes with it.
 PRICES = {"FOO": {SPIN_OFF_DAY: Decimal(90)}, "BAR": {SPIN_OFF_DAY: Decimal(10)}}
 FLAT = Decimal(1)
+
+
+def _holding(report: CapitalGainsReport, symbol: str) -> tuple[Decimal, Decimal]:
+    """Return the units and pooled cost the report closes with."""
+    (entry,) = (item for item in report.portfolio if item.symbol == symbol)
+    return entry.quantity, round_decimal(entry.amount, 2)
 
 
 def spin_off(
@@ -256,11 +266,17 @@ def test_a_purchase_of_the_new_holding_on_the_day_keeps_its_cost() -> None:
 
 
 def test_selling_the_new_holding_on_the_day_uses_the_corrected_cost() -> None:
-    """A same-day sale of BAR is identified against the corrected acquisition.
+    """A sale on the spin-off day draws on the pool at the corrected cost.
 
     Half of FOO sold at a profit first, so the first pass estimated nothing
     for BAR while the real share is 5. The day's acquisitions are walked
     before its disposals, so the sale must see the 5, not the estimate.
+
+    The spin-off is not an acquisition, so the same-day rule passes it over
+    and the sale takes its Section 104 cost. Here the pool holds nothing but
+    the spun-off shares, so the £5 the sale is given is the whole corrected
+    figure either way; the rule it is matched under is pinned so that a
+    change of route shows up as a change of route.
     """
     _, report = spin_off(
         [
@@ -272,43 +288,187 @@ def test_selling_the_new_holding_on_the_day_uses_the_corrected_cost() -> None:
         after=[transaction(SPIN_OFF_DAY, ActionType.SELL, "BAR", 5, 10, 0, 50, GBP)],
     )
 
-    same_day_sale = report.calculation_log[SPIN_OFF_DAY]["sell$BAR"]
-    assert sum((e.allowable_cost for e in same_day_sale), Decimal(0)) == Decimal(5)
+    (entry,) = report.calculation_log[SPIN_OFF_DAY]["sell$BAR"]
+    assert entry.rule_type is RuleType.SECTION_104
+    assert entry.allowable_cost == Decimal(5)
 
 
-def test_selling_the_new_holding_just_before_the_spin_off_is_refused() -> None:
-    """A sale the B&B rule would match to unpriced spin-off shares is refused.
+def test_selling_the_new_holding_just_before_the_spin_off_uses_its_own_pool() -> None:
+    """A sale shortly before a spin-off is not identified against its shares.
 
     BAR was already held and sold ten days before more arrived by spin-off.
-    Their cost is a share of FOO's pool on the spin-off day, which the walk
-    has not reached, and the first-pass figure is £0 here because FOO was
-    sold at a profit first. There is no right number to use, so say so.
+    Those shares were not acquired: a reorganisation is "not to be treated as
+    involving ... any acquisition of the new holding" (TCGA 1992 s127), and
+    CG51560 says the additional shares are "not treated as acquired within the
+    30 days following the disposal". So the 30-day rule passes them over and
+    the sale takes its own Section 104 cost, which needs nothing from the
+    spin-off day.
     """
-    with pytest.raises(CalculationError, match="run again with this one disposal"):
-        spin_off(
-            [
-                transaction(BUY_DAY, ActionType.BUY, "FOO", 10, 10, 0, -100, GBP),
-                transaction(BUY_DAY, ActionType.BUY, "BAR", 2, 1, 0, -2, GBP),
-                transaction(SALE_DAY, ActionType.SELL, "FOO", 5, 20, 0, 100, GBP),
-                transaction(
-                    datetime.date(2024, 6, 25),
-                    ActionType.SELL,
-                    "BAR",
-                    2,
-                    3,
-                    0,
-                    6,
-                    GBP,
-                ),
-            ],
-            5,
-            {
-                BUY_DAY: {GBP: FLAT},
-                SALE_DAY: {GBP: FLAT},
-                datetime.date(2024, 6, 25): {GBP: FLAT},
-                SPIN_OFF_DAY: {GBP: FLAT},
-            },
-        )
+    _, report = spin_off(
+        [
+            transaction(BUY_DAY, ActionType.BUY, "FOO", 10, 10, 0, -100, GBP),
+            transaction(BUY_DAY, ActionType.BUY, "BAR", 2, 1, 0, -2, GBP),
+            transaction(SALE_DAY, ActionType.SELL, "FOO", 5, 20, 0, 100, GBP),
+            transaction(EARLY_SALE_DAY, ActionType.SELL, "BAR", 2, 3, 0, 6, GBP),
+        ],
+        5,
+        {
+            BUY_DAY: {GBP: FLAT},
+            SALE_DAY: {GBP: FLAT},
+            EARLY_SALE_DAY: {GBP: FLAT},
+            SPIN_OFF_DAY: {GBP: FLAT},
+        },
+    )
+
+    (entry,) = report.calculation_log[EARLY_SALE_DAY]["sell$BAR"]
+    assert entry.rule_type is RuleType.SECTION_104
+    assert entry.allowable_cost == Decimal(2)
+
+
+def test_a_spin_off_on_the_disposal_day_is_not_a_same_day_acquisition() -> None:
+    """The day's only arrival is a reorganisation, so nothing is acquired.
+
+    A reorganisation is "not to be treated as involving ... any acquisition of
+    the new holding" (TCGA 1992 s127), and the same-day rule reads a day's
+    acquisitions as one transaction (s105(1)(a)). With none, the sale takes
+    its Section 104 cost from a pool the spin-off has already joined: 2 units
+    costing £10 plus the 10 that carried £10 across, so £20 over 12 units.
+    """
+    _, report = spin_off(
+        [
+            transaction(BUY_DAY, ActionType.BUY, "FOO", 10, 10, 0, -100, GBP),
+            transaction(BUY_DAY, ActionType.BUY, "BAR", 2, 5, 0, -10, GBP),
+        ],
+        10,
+        {BUY_DAY: {GBP: FLAT}, SPIN_OFF_DAY: {GBP: FLAT}},
+        after=[transaction(SPIN_OFF_DAY, ActionType.SELL, "BAR", 2, 20, 0, 40, GBP)],
+    )
+
+    (entry,) = report.calculation_log[SPIN_OFF_DAY]["sell$BAR"]
+    assert entry.rule_type is RuleType.SECTION_104
+    assert entry.allowable_cost == round_decimal(Decimal(20) * 2 / 12, 10)
+    # What the spin-off carried in is not stranded: the pool keeps the rest.
+    assert _holding(report, "BAR") == (
+        Decimal(10),
+        round_decimal(Decimal(20) * 10 / 12, 2),
+    )
+
+
+def test_a_purchase_beside_a_spin_off_prices_a_same_day_sale_on_its_own() -> None:
+    """The five bought are the day's acquisition; the ten spun in are not.
+
+    Blending them priced the sale at £60 over 15 units. The day's acquisition
+    is the £50 paid for five shares, and the sale of five takes all of it.
+    """
+    _, report = spin_off(
+        [
+            transaction(BUY_DAY, ActionType.BUY, "FOO", 10, 10, 0, -100, GBP),
+            transaction(SPIN_OFF_DAY, ActionType.BUY, "BAR", 5, 10, 0, -50, GBP),
+        ],
+        10,
+        {BUY_DAY: {GBP: FLAT}, SPIN_OFF_DAY: {GBP: FLAT}},
+        after=[transaction(SPIN_OFF_DAY, ActionType.SELL, "BAR", 5, 10, 0, 50, GBP)],
+    )
+
+    (entry,) = report.calculation_log[SPIN_OFF_DAY]["sell$BAR"]
+    assert entry.rule_type is RuleType.SAME_DAY
+    assert entry.allowable_cost == Decimal(50)
+    assert report.total_gain() == Decimal(0)
+    # Only the spin-off's own £10 is left behind for the ten shares still held.
+    assert _holding(report, "BAR") == (Decimal(10), Decimal(10))
+
+
+def test_a_purchase_inside_the_30_days_is_matched_and_a_spin_off_beside_it_is_not() -> (
+    None
+):
+    """Only the purchase is a re-acquisition; the spin-off beside it is not.
+
+    The two sold are identified against two of the five bought, at the £10
+    each they cost, and the pool has to give up exactly that. Priced over
+    everything the day brought in it would give up £8, and the £12 left over
+    would be relieved again on a later sale.
+    """
+    _, report = spin_off(
+        [
+            transaction(BUY_DAY, ActionType.BUY, "FOO", 10, 10, 0, -100, GBP),
+            transaction(BUY_DAY, ActionType.BUY, "BAR", 2, 5, 0, -10, GBP),
+            transaction(EARLY_SALE_DAY, ActionType.SELL, "BAR", 2, 20, 0, 40, GBP),
+            transaction(SPIN_OFF_DAY, ActionType.BUY, "BAR", 5, 10, 0, -50, GBP),
+        ],
+        10,
+        {
+            BUY_DAY: {GBP: FLAT},
+            EARLY_SALE_DAY: {GBP: FLAT},
+            SPIN_OFF_DAY: {GBP: FLAT},
+        },
+    )
+
+    (entry,) = report.calculation_log[EARLY_SALE_DAY]["sell$BAR"]
+    assert entry.rule_type is RuleType.BED_AND_BREAKFAST
+    assert entry.allowable_cost == Decimal(20)
+    # £10 + £50 + £10 of cost went in and £20 was relieved, so £50 remains.
+    assert _holding(report, "BAR") == (Decimal(15), Decimal(50))
+
+
+def test_a_later_day_s_own_sale_reserves_only_what_that_day_bought() -> None:
+    """A day's sale of more than it bought leaves the earlier one nothing.
+
+    The spin-off day buys two and sells five. The same-day rule takes those
+    two first, so there is nothing left for the earlier sale to be identified
+    against, and counting the ten spun in as available would hand it shares
+    that were never acquired.
+    """
+    _, report = spin_off(
+        [
+            transaction(BUY_DAY, ActionType.BUY, "FOO", 10, 10, 0, -100, GBP),
+            transaction(BUY_DAY, ActionType.BUY, "BAR", 4, 5, 0, -20, GBP),
+            transaction(EARLY_SALE_DAY, ActionType.SELL, "BAR", 2, 20, 0, 40, GBP),
+            transaction(SPIN_OFF_DAY, ActionType.BUY, "BAR", 2, 15, 0, -30, GBP),
+        ],
+        10,
+        {
+            BUY_DAY: {GBP: FLAT},
+            EARLY_SALE_DAY: {GBP: FLAT},
+            SPIN_OFF_DAY: {GBP: FLAT},
+        },
+        after=[transaction(SPIN_OFF_DAY, ActionType.SELL, "BAR", 5, 12, 0, 60, GBP)],
+    )
+
+    (entry,) = report.calculation_log[EARLY_SALE_DAY]["sell$BAR"]
+    assert entry.rule_type is RuleType.SECTION_104
+    assert entry.allowable_cost == Decimal(10)
+
+
+def test_a_sale_and_a_transfer_on_a_spin_off_day_do_not_contend() -> None:
+    """Neither can be identified against the day's spin-off, so neither wins.
+
+    A sale and a transfer to a spouse on one day are refused when both could
+    be identified against the same acquisition, because HMRC does not say
+    which one gets it. Shares a reorganisation brought in are not an
+    acquisition either of them can reach, so both simply draw on the pool at
+    the same average and the order between them changes nothing.
+    """
+    _, report = spin_off(
+        [
+            transaction(BUY_DAY, ActionType.BUY, "FOO", 10, 10, 0, -100, GBP),
+            transaction(BUY_DAY, ActionType.BUY, "BAR", 4, 5, 0, -20, GBP),
+        ],
+        10,
+        {BUY_DAY: {GBP: FLAT}, SPIN_OFF_DAY: {GBP: FLAT}},
+        after=[
+            transaction(SPIN_OFF_DAY, ActionType.SELL, "BAR", 2, 20, 0, 40, GBP),
+            transfer_to_spouse_transaction(SPIN_OFF_DAY, "BAR", 2),
+        ],
+    )
+
+    # 4 units costing £20 plus the 10 the spin-off carried £10 into: £30 over
+    # 14 units, and each of the two takes two units of it.
+    pooled = round_decimal(Decimal(30) * 2 / 14, 10)
+    (sale,) = report.calculation_log[SPIN_OFF_DAY]["sell$BAR"]
+    (transfer,) = report.calculation_log[SPIN_OFF_DAY]["transfer-to-spouse$BAR"]
+    assert sale.rule_type is RuleType.SECTION_104
+    assert sale.allowable_cost == pooled
+    assert transfer.allowable_cost == pooled
 
 
 def test_a_spin_off_before_the_period_is_applied_but_not_reported() -> None:


### PR DESCRIPTION
When a company you hold spins off part of itself, you receive shares in the new company without buying them. The calculator was treating those shares as something you had acquired, and identifying disposals against them under the same-day and 30-day rules.

Say you hold 10 shares of `FOO` that cost GBP 100. On the spin-off day:

1. Before the market opens, you receive 10 shares of the new company, `BAR`, through the spin-off. They carry GBP 10 of your original `FOO` cost.
2. `BAR` starts trading when the market opens, and you buy another 5 shares for GBP 50.
3. Later that same day, you sell 5 `BAR` shares for GBP 50.

The sale was priced against all 15 shares blended together (60 over 15 units), for an allowable cost of 20 and a gain of 30. It should be priced against the 5 shares you actually bought, at the 50 they cost, for a gain of nil. Where a spin-off fell inside the 30 days after a disposal, the run was refused outright instead of computing anything.

TCGA 1992 s127 says a reorganisation is "not to be treated as involving ... any acquisition of the new holding or any part of it", and HMRC's CG51560 says the additional shares from one are "not treated as acquired within the 30 days following the disposal". Neither rule should reach them.

Matching now asks for the day's genuine acquisitions and leaves out what a reorganisation brought in. Those shares still join the Section 104 holding at their share of the original cost, and a later disposal reaches them there. The refusal is gone with the reason for it.

Scope: a management fee still counts towards a same-day or 30-day match's cost, unchanged (tracked in #1121). Stock-split shares were already excluded by a different route. A day that both renames a ticker and receives a spin-off now gets the same exclusion too - the same rule applied consistently; full support for combining renames with spin-offs is a separate, later change.
