### PR TITLE
Export parsed transactions to file or stdout with --dump-transactions

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -100,6 +100,7 @@ GSU
 hashable
 HL
 Hmrc
+html
 I/O
 IBKR
 IBKR's
@@ -127,6 +128,7 @@ lychee
 markdown
 matchable
 matchings
+maxcolwidths
 md
 MiKTeX
 MMM
@@ -226,14 +228,17 @@ StockSplitTransaction
 str
 subrow
 tablefinder
+tablefmt
 TCGA
 toml
+tsv
 Trading212Column
 tranche's
 TransactionDetails
 transferor
 transferor's
 txn
+txt
 ty
 tzinfo
 UCITS

--- a/cgt_calc/args_parser.py
+++ b/cgt_calc/args_parser.py
@@ -6,18 +6,22 @@ import argparse
 import datetime
 
 import shtab
+import tabulate
 
 from .args_validators import (
+    BROKER_TRANSACTION_COLUMNS,
     STDIN_PATH,
     DeprecatedAction,
     VersionAction,
     date_type,
     existing_file_or_stdin_type,
     existing_file_type,
+    maxcolwidths_type,
     optional_cache_file_type,
     output_path_type,
     set_completer,
     ticker_list_type,
+    transaction_columns_type,
     year_type,
 )
 from .const import (
@@ -210,6 +214,63 @@ Environment variables:
         "--no-pdflatex",
         action="store_true",
         help="save LaTeX source instead of generating a PDF",
+    )
+    output_group.add_argument(
+        "--dump-transactions",
+        nargs="?",
+        const="simple",
+        default=None,
+        type=str.lower,
+        choices=[*tabulate.tabulate_formats, "csv"],
+        help=(
+            "dump parsed transactions. Optionally specify a tabulate format or csv (default: %(const)s)"
+        ),
+    )
+    set_completer(
+        output_group.add_argument(
+            "--dump-transactions-output",
+            "--dump-output",
+            dest="dump_transactions_file",
+            metavar="PATH",
+            default=None,
+            help=(
+                "path to save dumped transactions, or '-' for stdout "
+                "(default: parsed_transaction.{ext})"
+            ),
+        ),
+        shtab.FILE,
+    )
+    output_group.add_argument(
+        "--dump-transactions-columns",
+        "--dump-columns",
+        dest="dump_transactions_columns",
+        metavar="COLUMNS",
+        type=transaction_columns_type,
+        default=None,
+        help=(
+            "comma-separated list of columns to include in the dump "
+            f"(valid columns: {', '.join(BROKER_TRANSACTION_COLUMNS)})"
+        ),
+    )
+    output_group.add_argument(
+        "--dump-transactions-exclude-columns",
+        "--dump-exclude-columns",
+        dest="dump_transactions_exclude_columns",
+        metavar="COLUMNS",
+        type=transaction_columns_type,
+        default=None,
+        help="comma-separated list of columns to exclude from the transaction dump",
+    )
+    output_group.add_argument(
+        "--dump-transactions-maxcolwidths",
+        "--dump-transactions-max-col-width",
+        "--dump-max-col-width",
+        "--dump-maxcolwidths",
+        dest="dump_transactions_maxcolwidths",
+        metavar="WIDTHS",
+        type=maxcolwidths_type,
+        default=None,
+        help="limit column width(s) of transaction dump. Provide either a single number (for all columns) or a coma separated list of number (max width of each column). For example, to limit the 3rd column to 10 chars, use ',,10'",
     )
 
     # General Options

--- a/cgt_calc/args_validators.py
+++ b/cgt_calc/args_validators.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import argparse
+import dataclasses
 import datetime
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, override
 
 from .const import INTERNAL_START_DATE
+from .model import BrokerTransaction
 from .version import DISTRIBUTION_NAME, get_version
 
 STDIN_PATH = Path("-")
@@ -51,6 +53,70 @@ def date_type(value: str) -> datetime.date:
 def ticker_list_type(value: str) -> list[str]:
     """Split comma-separated tickers and convert to uppercase list."""
     return [ticker.strip().upper() for ticker in value.split(",") if ticker.strip()]
+
+
+BROKER_TRANSACTION_COLUMNS: list[str] = [
+    field.name for field in dataclasses.fields(BrokerTransaction)
+]
+
+
+def transaction_columns_type(value: str) -> list[str]:
+    """Validate and split comma-separated BrokerTransaction column names."""
+    items = [item.strip() for item in value.split(",") if item.strip()]
+    if not items:
+        raise argparse.ArgumentTypeError("list of columns must not be empty")
+
+    valid_fields = {col.lower(): col for col in BROKER_TRANSACTION_COLUMNS}
+    invalid_cols = [col for col in items if col.lower() not in valid_fields]
+    if invalid_cols:
+        invalid_str = ", ".join(f"'{c}'" for c in invalid_cols)
+        valid_str = ", ".join(BROKER_TRANSACTION_COLUMNS)
+        raise argparse.ArgumentTypeError(
+            f"unknown column(s) for BrokerTransaction: {invalid_str}. "
+            f"Valid columns are: {valid_str}"
+        )
+    return [valid_fields[col.lower()] for col in items]
+
+
+def maxcolwidths_type(value: str) -> int | list[int | None]:
+    """Validate and convert maxcolwidths argument.
+
+    It can be either a single positive integer (to apply to all columns),
+    or a coma-separated list of positive integers (max width of each column).
+    """
+    items = [item.strip() for item in value.split(",")]
+    if len(items) == 1:
+        try:
+            val = int(items[0])
+        except ValueError as err:
+            raise argparse.ArgumentTypeError(
+                f"maxcolwidths must be a positive integer or comma-separated integers: '{value}'"
+            ) from err
+        else:
+            if val <= 0:
+                raise argparse.ArgumentTypeError(
+                    f"maxcolwidths must be a positive integer: '{value}'"
+                )
+            return val
+
+    parsed: list[int | None] = []
+    for item in items:
+        if not item or item.lower() == "none":
+            parsed.append(None)
+        else:
+            try:
+                val = int(item)
+            except ValueError as err:
+                raise argparse.ArgumentTypeError(
+                    f"maxcolwidths values must be positive integers or 'none': '{item}'"
+                ) from err
+            else:
+                if val <= 0:
+                    raise argparse.ArgumentTypeError(
+                        f"maxcolwidths values must be positive integers or 'none': '{item}'"
+                    )
+                parsed.append(val)
+    return parsed
 
 
 def output_path_type(value: str) -> Path:

--- a/cgt_calc/cli.py
+++ b/cgt_calc/cli.py
@@ -24,6 +24,7 @@ from .isin_converter import IsinConverter
 from .logging import setup_logging, style_text
 from .parsers.broker_registry import BrokerRegistry
 from .spin_off_handler import SpinOffHandler
+from .transaction_dumper import dump_transactions
 
 if TYPE_CHECKING:
     import argparse
@@ -43,6 +44,33 @@ def calculate_cgt(args: argparse.Namespace) -> None:
     # Read data from input files
     isin_converter = IsinConverter(isin_translation_file)
     broker_transactions = BrokerRegistry.load_all_transactions(args, isin_converter)
+
+    if (
+        args.dump_transactions
+        or args.dump_transactions_file
+        or args.dump_transactions_columns
+        or args.dump_transactions_exclude_columns
+        or args.dump_transactions_maxcolwidths
+    ):
+        tablefmt = args.dump_transactions
+        dest_path = dump_transactions(
+            broker_transactions,
+            tablefmt=tablefmt,
+            output_file=args.dump_transactions_file,
+            columns=args.dump_transactions_columns,
+            exclude_columns=args.dump_transactions_exclude_columns,
+            maxcolwidths=args.dump_transactions_maxcolwidths,
+        )
+        if dest_path is not None:
+            LOGGER.info(
+                style_text(
+                    f"Dumped transactions saved to {dest_path}",
+                    colour=Fore.GREEN,
+                    emoji="📄",
+                    stream=sys.stderr,
+                )
+            )
+
     currency_converter = CurrencyConverter.create(args.exchange_rates_file)
     price_fetcher = CurrentPriceFetcher(currency_converter)
     initial_prices = InitialPrices(args.initial_prices_file)

--- a/cgt_calc/main.py
+++ b/cgt_calc/main.py
@@ -27,6 +27,7 @@ from .model import (
     PortfolioEntry,
     Position,
 )
+from .transaction_dumper import dump_transactions
 from .util import round_decimal
 
 if TYPE_CHECKING:
@@ -42,7 +43,13 @@ if TYPE_CHECKING:
 
 # The CLI entry points live in cgt_calc.cli now; re-exported here so
 # existing imports and `python -m cgt_calc.main` keep working.
-__all__ = ["CapitalGainsCalculator", "calculate_cgt", "init", "main"]
+__all__ = [
+    "CapitalGainsCalculator",
+    "calculate_cgt",
+    "dump_transactions",
+    "init",
+    "main",
+]
 
 LOGGER = logging.getLogger(__name__)
 

--- a/cgt_calc/transaction_dumper.py
+++ b/cgt_calc/transaction_dumper.py
@@ -1,0 +1,228 @@
+"""Transaction dumper module for formatting and exporting broker transactions."""
+
+from __future__ import annotations
+
+import csv
+import dataclasses
+from enum import Enum
+import io
+from pathlib import Path
+import sys
+from typing import TYPE_CHECKING, TextIO
+
+import tabulate
+
+from .model import BrokerTransaction
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+# Mapping from tablefmt names to commonly recognized file extensions
+TABLEFMT_EXTENSIONS: dict[str, str] = {
+    "csv": "csv",
+    "tsv": "tsv",
+    "html": "html",
+    "unsafehtml": "html",
+    "latex": "tex",
+    "latex_raw": "tex",
+    "latex_booktabs": "tex",
+    "latex_longtable": "tex",
+    "github": "md",
+    "pipe": "md",
+    "rst": "rst",
+    "asciidoc": "adoc",
+    "mediawiki": "wiki",
+    "moinmoin": "moin",
+    "orgtbl": "org",
+    "textile": "textile",
+}
+
+
+def get_dump_extension(tablefmt: str) -> str:
+    """Return the file extension corresponding to the given table format.
+
+    Args:
+        tablefmt: The tabulate table format name or 'csv'.
+
+    Returns:
+        The file extension string without leading dot (e.g. 'tsv', 'csv', 'txt').
+
+    """
+    return TABLEFMT_EXTENSIONS.get(tablefmt.lower(), "txt")
+
+
+def resolve_columns(
+    all_columns: Sequence[str],
+    columns: Sequence[str] | None = None,
+    exclude_columns: Sequence[str] | None = None,
+) -> list[str]:
+    """Resolve and filter column names according to inclusion and exclusion lists.
+
+    Args:
+        all_columns: Sequence of all available column names.
+        columns: Optional sequence of column names to include.
+        exclude_columns: Optional sequence of column names to exclude.
+
+    Returns:
+        Filtered list of column names.
+
+    Raises:
+        ValueError: If any column in columns or exclude_columns does not exist in all_columns.
+
+    """
+    col_map = {c.lower(): c for c in all_columns}
+
+    if columns is not None:
+        invalid_cols = [c for c in columns if c.strip().lower() not in col_map]
+        if invalid_cols:
+            invalid_str = ", ".join(f"'{c.strip()}'" for c in invalid_cols)
+            valid_str = ", ".join(all_columns)
+            raise ValueError(
+                f"unknown column(s) for BrokerTransaction: {invalid_str}. "
+                f"Valid columns are: {valid_str}"
+            )
+        selected: list[str] = []
+        for col in columns:
+            canonical = col_map[col.strip().lower()]
+            if canonical not in selected:
+                selected.append(canonical)
+    else:
+        selected = list(all_columns)
+
+    if exclude_columns is not None:
+        invalid_cols = [c for c in exclude_columns if c.strip().lower() not in col_map]
+        if invalid_cols:
+            invalid_str = ", ".join(f"'{c.strip()}'" for c in invalid_cols)
+            valid_str = ", ".join(all_columns)
+            raise ValueError(
+                f"unknown column(s) for BrokerTransaction: {invalid_str}. "
+                f"Valid columns are: {valid_str}"
+            )
+        exclude_set = {col.strip().lower() for col in exclude_columns}
+        selected = [c for c in selected if c.lower() not in exclude_set]
+
+    return selected
+
+
+def format_transactions(
+    transactions: Sequence[BrokerTransaction],
+    tablefmt: str = "simple",
+    columns: Sequence[str] | None = None,
+    exclude_columns: Sequence[str] | None = None,
+    maxcolwidths: int | Sequence[int | None] | None = None,
+) -> str:
+    """Format broker transactions as a tabular string or CSV.
+
+    Converts each BrokerTransaction into a dictionary and formats the resulting
+    list with tabulate or standard library csv.
+
+    Args:
+        transactions: Sequence of BrokerTransaction instances to format.
+        tablefmt: The output table format ('csv' or any tabulate tablefmt).
+        columns: Optional sequence of column names to include.
+        exclude_columns: Optional sequence of column names to exclude.
+        maxcolwidths: Maximum column width(s) passed to tabulate.
+
+    Returns:
+        The formatted string representing all transactions.
+
+    """
+    all_fieldnames = [field.name for field in dataclasses.fields(BrokerTransaction)]
+    selected_cols = resolve_columns(
+        all_fieldnames,
+        columns=columns,
+        exclude_columns=exclude_columns,
+    )
+
+    rows: list[dict[str, object]] = []
+    for t in transactions:
+        row = dataclasses.asdict(t)
+        if hasattr(t.action, "name"):
+            row["action"] = t.action.name
+        for k, v in row.items():
+            if isinstance(v, Enum):
+                row[k] = v.name
+        filtered_row = {col: row.get(col, "") for col in selected_cols}
+        rows.append(filtered_row)
+
+    if tablefmt.lower() == "csv":
+        buf = io.StringIO()
+        writer = csv.DictWriter(buf, fieldnames=selected_cols)
+        writer.writeheader()
+        writer.writerows(rows)
+        return buf.getvalue()
+
+    if not rows:
+        return tabulate.tabulate(
+            [],
+            headers=selected_cols,
+            tablefmt=tablefmt,
+            maxcolwidths=maxcolwidths,
+        )
+
+    return tabulate.tabulate(
+        rows,
+        headers="keys",
+        tablefmt=tablefmt,
+        maxcolwidths=maxcolwidths,
+    )
+
+
+def dump_transactions(
+    transactions: Sequence[BrokerTransaction],
+    tablefmt: str = "simple",
+    output_file: str | Path | None = None,
+    stream: TextIO | None = None,
+    columns: Sequence[str] | None = None,
+    exclude_columns: Sequence[str] | None = None,
+    maxcolwidths: int | Sequence[int | None] | None = None,
+) -> Path | None:
+    """Dump broker transactions to stdout or a file.
+
+    Args:
+        transactions: Sequence of BrokerTransaction instances to dump.
+        tablefmt: Format name (e.g. 'simple', 'tsv', 'csv', 'html').
+        output_file: Destination path, '-' for stdout, or None for default.
+        stream: Optional stream to write to (overrides output_file if specified).
+        columns: Optional sequence of column names to include.
+        exclude_columns: Optional sequence of column names to exclude.
+        maxcolwidths: Maximum column width(s) passed to tabulate.
+
+    Returns:
+        Path of the output file written, or None if written to stdout/stream.
+
+    """
+    content = format_transactions(
+        transactions,
+        tablefmt=tablefmt,
+        columns=columns,
+        exclude_columns=exclude_columns,
+        maxcolwidths=maxcolwidths,
+    )
+
+    if stream is not None:
+        stream.write(content)
+        if not content.endswith("\n"):
+            stream.write("\n")
+        return None
+
+    if output_file == "-":
+        sys.stdout.write(content)
+        if not content.endswith("\n"):
+            sys.stdout.write("\n")
+        return None
+
+    ext = get_dump_extension(tablefmt)
+    dest_path = (
+        Path(output_file)
+        if output_file is not None
+        else Path(f"parsed_transaction.{ext}")
+    )
+
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    with dest_path.open("w", encoding="utf-8", newline="") as f:
+        f.write(content)
+        if not content.endswith("\n"):
+            f.write("\n")
+
+    return dest_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
   "openpyxl>=3.1.5",
   "xlrd>=2.0.2",
   "shtab>=1.12.1",
+  "tabulate>=0.9.0",
   # zoneinfo needs a tz database where the OS does not ship one.
   "tzdata>=2026.3; sys_platform == 'win32' or sys_platform == 'emscripten'",
 ]
@@ -82,6 +83,7 @@ dev = [
   "types-python-dateutil>=2.9.0.20250822",
   "types-reportlab>=4.5.1.20260827",
   "types-requests>=2.33.0.20260712",
+  "types-tabulate>=0.9.0.20240106",
 ]
 docs = [
   "zensical>=0.0.57",

--- a/tests/general/test_args_parser.py
+++ b/tests/general/test_args_parser.py
@@ -22,6 +22,7 @@ from cgt_calc.args_parser import (
     resolve_reporting_period,
 )
 from cgt_calc.args_validators import (
+    BROKER_TRANSACTION_COLUMNS,
     STDIN_PATH,
     existing_directory_type,
     existing_file_or_stdin_type,
@@ -985,3 +986,159 @@ def test_autoconvert_currency_is_opt_in() -> None:
 
     assert parser.parse_args([]).autoconvert_currency is False
     assert parser.parse_args(["--autoconvert-currency"]).autoconvert_currency is True
+
+
+@pytest.mark.parametrize(
+    ("arg", "expected"),
+    [
+        ("simple", "simple"),
+        ("grid", "grid"),
+        ("tsv", "tsv"),
+        ("csv", "csv"),
+        ("html", "html"),
+        ("github", "github"),
+        ("latex", "latex"),
+        ("CSV", "csv"),
+        ("TSV", "tsv"),
+        ("HTML", "html"),
+        ("Grid", "grid"),
+    ],
+)
+def test_dump_transactions_accepted_formats(arg: str, expected: str) -> None:
+    """--dump-transactions accepts valid table formats case-insensitively."""
+    parser = create_parser()
+    args = parser.parse_args(["--dump-transactions", arg])
+    assert args.dump_transactions == expected
+
+
+def test_dump_transactions_rejects_invalid_format() -> None:
+    """--dump-transactions rejects unknown formats."""
+    parser = create_parser()
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["--dump-transactions", "invalid_format_xyz"])
+
+    assert exc_info.value.code == 2
+
+
+@pytest.mark.parametrize(
+    "flag",
+    [
+        "--dump-transactions-output",
+        "--dump-output",
+    ],
+)
+def test_dump_transactions_file_aliases(flag: str) -> None:
+    """All aliases for --dump-transactions-output populate the destination."""
+    parser = create_parser()
+    args = parser.parse_args([flag, "output.tsv"])
+    assert args.dump_transactions_file == "output.tsv"
+
+
+def test_dump_transactions_output_stdout_dash() -> None:
+    """--dump-transactions-output accepts '-' for stdout."""
+    parser = create_parser()
+    args = parser.parse_args(["--dump-transactions-output", "-"])
+    assert args.dump_transactions_file == "-"
+
+
+@pytest.mark.parametrize(
+    "flag",
+    [
+        "--dump-transactions-columns",
+        "--dump-columns",
+    ],
+)
+def test_dump_transactions_columns_aliases(flag: str) -> None:
+    """All aliases for --dump-transactions-columns parse comma-separated columns."""
+    parser = create_parser()
+    args = parser.parse_args([flag, "date,action,symbol,amount"])
+    assert args.dump_transactions_columns == ["date", "action", "symbol", "amount"]
+
+
+def test_dump_transactions_columns_empty_rejected() -> None:
+    """--dump-transactions-columns rejects empty argument."""
+    parser = create_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["--dump-transactions-columns", "   "])
+    assert exc_info.value.code == 2
+
+
+def test_dump_transactions_columns_rejects_unknown_field() -> None:
+    """--dump-transactions-columns rejects columns not in BrokerTransaction."""
+    parser = create_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["--dump-transactions-columns", "date,not_a_field,amount"])
+    assert exc_info.value.code == 2
+
+
+def test_dump_transactions_columns_case_insensitive() -> None:
+    """--dump-transactions-columns normalizes column names case-insensitively."""
+    parser = create_parser()
+    args = parser.parse_args(["--dump-transactions-columns", "DATE,Action,SYMBOL"])
+    assert args.dump_transactions_columns == ["date", "action", "symbol"]
+
+
+def test_dump_transactions_columns_help_includes_columns() -> None:
+    """Help message for --dump-transactions-columns includes all valid columns."""
+    help_text = " ".join(create_parser().format_help().split())
+    assert "--dump-transactions-columns" in help_text
+    for col in BROKER_TRANSACTION_COLUMNS:
+        assert col in help_text
+
+
+@pytest.mark.parametrize(
+    "flag",
+    [
+        "--dump-transactions-exclude-columns",
+        "--dump-exclude-columns",
+    ],
+)
+def test_dump_transactions_exclude_columns_aliases(flag: str) -> None:
+    """All aliases for --dump-transactions-exclude-columns parse comma-separated columns."""
+    parser = create_parser()
+    args = parser.parse_args([flag, "source,foreign_fees"])
+    assert args.dump_transactions_exclude_columns == ["source", "foreign_fees"]
+
+
+def test_dump_transactions_exclude_columns_rejects_unknown_field() -> None:
+    """--dump-transactions-exclude-columns rejects columns not in BrokerTransaction."""
+    parser = create_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["--dump-transactions-exclude-columns", "invalid_field"])
+    assert exc_info.value.code == 2
+
+
+@pytest.mark.parametrize(
+    "flag",
+    [
+        "--dump-transactions-maxcolwidths",
+        "--dump-transactions-max-col-width",
+        "--dump-max-col-width",
+        "--dump-maxcolwidths",
+    ],
+)
+def test_dump_transactions_maxcolwidths_aliases(flag: str) -> None:
+    """All aliases for --dump-transactions-maxcolwidths parse single integer."""
+    parser = create_parser()
+    args = parser.parse_args([flag, "20"])
+    assert args.dump_transactions_maxcolwidths == 20
+
+
+@pytest.mark.parametrize("none_value", ["", "none"])
+def test_dump_transactions_maxcolwidths_sequence(none_value: str) -> None:
+    """--dump-transactions-maxcolwidths parses comma-separated sequence of integers and None."""
+    parser = create_parser()
+    args = parser.parse_args(
+        ["--dump-transactions-maxcolwidths", f"10,{none_value},25"]
+    )
+    assert args.dump_transactions_maxcolwidths == [10, None, 25]
+
+
+@pytest.mark.parametrize("invalid", ["0", "-5", "abc", "10,invalid"])
+def test_dump_transactions_maxcolwidths_invalid(invalid: str) -> None:
+    """--dump-transactions-maxcolwidths rejects invalid width values."""
+    parser = create_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["--dump-transactions-maxcolwidths", invalid])
+    assert exc_info.value.code == 2

--- a/tests/general/test_dump_transactions.py
+++ b/tests/general/test_dump_transactions.py
@@ -1,0 +1,440 @@
+"""Unit and integration tests for transaction dumping functionality."""
+
+from __future__ import annotations
+
+import csv
+import datetime
+from decimal import Decimal
+import io
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from cgt_calc.model import ActionType, BrokerTransaction, CurrencyCode
+from cgt_calc.transaction_dumper import (
+    dump_transactions,
+    format_transactions,
+    get_dump_extension,
+    resolve_columns,
+)
+from tests.utils import build_cmd, report_path
+
+
+def _sample_transactions() -> list[BrokerTransaction]:
+    """Generate sample transactions for testing."""
+    return [
+        BrokerTransaction(
+            date=datetime.date(2023, 4, 25),
+            action=ActionType.STOCK_ACTIVITY,
+            symbol="GOOG",
+            description="RS Vest",
+            quantity=Decimal("10.5"),
+            price=Decimal("100.25"),
+            fees=Decimal("1.50"),
+            amount=Decimal("1054.125"),
+            currency=CurrencyCode("USD"),
+            broker="Test Broker",
+        ),
+        BrokerTransaction(
+            date=datetime.date(2023, 5, 1),
+            action=ActionType.DIVIDEND,
+            symbol=None,
+            description="Cash Dividend",
+            quantity=None,
+            price=None,
+            fees=Decimal(0),
+            amount=Decimal("50.00"),
+            currency=CurrencyCode("GBP"),
+            broker="",
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("tablefmt", "expected_ext"),
+    [
+        ("csv", "csv"),
+        ("tsv", "tsv"),
+        ("html", "html"),
+        ("unsafehtml", "html"),
+        ("latex", "tex"),
+        ("latex_raw", "tex"),
+        ("latex_booktabs", "tex"),
+        ("latex_longtable", "tex"),
+        ("github", "md"),
+        ("pipe", "md"),
+        ("rst", "rst"),
+        ("asciidoc", "adoc"),
+        ("mediawiki", "wiki"),
+        ("simple", "txt"),
+        ("grid", "txt"),
+        ("plain", "txt"),
+        ("pretty", "txt"),
+        ("psql", "txt"),
+    ],
+)
+def test_get_dump_extension(tablefmt: str, expected_ext: str) -> None:
+    """Verify file extension resolution for various table formats."""
+    assert get_dump_extension(tablefmt) == expected_ext
+    # Check case-insensitivity
+    assert get_dump_extension(tablefmt.upper()) == expected_ext
+
+
+def test_format_transactions_csv() -> None:
+    """CSV output generates valid comma-separated values with headers."""
+    txs = _sample_transactions()
+    output = format_transactions(txs, tablefmt="csv")
+
+    reader = list(csv.reader(io.StringIO(output)))
+    assert len(reader) == 3  # header + 2 rows
+    assert "date" in reader[0]
+    assert "action" in reader[0]
+    assert "symbol" in reader[0]
+    assert "quantity" in reader[0]
+
+    # Check Row 1
+    date_idx = reader[0].index("date")
+    action_idx = reader[0].index("action")
+    symbol_idx = reader[0].index("symbol")
+    amount_idx = reader[0].index("amount")
+    assert reader[1][date_idx] == "2023-04-25"
+    assert reader[1][action_idx] == "STOCK_ACTIVITY"
+    assert "ActionType." not in output
+    assert reader[1][symbol_idx] == "GOOG"
+    assert reader[1][amount_idx] == "1054.125"
+
+    # Check Row 2 (None fields are empty strings in CSV)
+    assert reader[2][date_idx] == "2023-05-01"
+    assert reader[2][action_idx] == "DIVIDEND"
+    assert reader[2][symbol_idx] == ""
+
+
+def test_format_transactions_action_excludes_classname() -> None:
+    """Action field values do not include ActionType class prefix in dumped output."""
+    txs = _sample_transactions()
+    output = format_transactions(txs, tablefmt="simple")
+    assert "ActionType" not in output
+    assert "STOCK_ACTIVITY" in output
+    assert "DIVIDEND" in output
+
+
+def test_format_transactions_columns_filter() -> None:
+    """Only requested columns are included in output, in specified order."""
+    txs = _sample_transactions()
+    output = format_transactions(
+        txs, tablefmt="csv", columns=["symbol", "amount", "date"]
+    )
+    reader = list(csv.reader(io.StringIO(output)))
+
+    assert reader[0] == ["symbol", "amount", "date"]
+    assert reader[1] == ["GOOG", "1054.125", "2023-04-25"]
+
+
+def test_format_transactions_exclude_columns() -> None:
+    """Excluded columns are omitted from output."""
+    txs = _sample_transactions()
+    output = format_transactions(
+        txs, tablefmt="csv", exclude_columns=["source", "foreign_fees", "action"]
+    )
+    reader = list(csv.reader(io.StringIO(output)))
+
+    assert "source" not in reader[0]
+    assert "foreign_fees" not in reader[0]
+    assert "action" not in reader[0]
+    assert "date" in reader[0]
+    assert "symbol" in reader[0]
+
+
+def test_format_transactions_columns_and_exclude_columns() -> None:
+    """When both columns and exclude_columns are specified, exclusions are removed."""
+    txs = _sample_transactions()
+    output = format_transactions(
+        txs,
+        tablefmt="csv",
+        columns=["date", "action", "symbol", "amount"],
+        exclude_columns=["action"],
+    )
+    reader = list(csv.reader(io.StringIO(output)))
+
+    assert reader[0] == ["date", "symbol", "amount"]
+
+
+def test_resolve_columns_rejects_unknown_columns() -> None:
+    """resolve_columns raises ValueError when unknown column is passed in columns."""
+    all_cols = ["date", "action", "symbol"]
+    with pytest.raises(ValueError, match=r"unknown column.*invalid_col"):
+        resolve_columns(all_cols, columns=["date", "invalid_col"])
+
+
+def test_resolve_columns_rejects_unknown_exclude_columns() -> None:
+    """resolve_columns raises ValueError when unknown column is passed in exclude_columns."""
+    all_cols = ["date", "action", "symbol"]
+    with pytest.raises(ValueError, match=r"unknown column.*invalid_col"):
+        resolve_columns(all_cols, exclude_columns=["invalid_col"])
+
+
+def test_format_transactions_rejects_unknown_columns() -> None:
+    """format_transactions raises ValueError when unknown column is passed."""
+    txs = _sample_transactions()
+    with pytest.raises(ValueError, match=r"unknown column.*non_existent_column"):
+        format_transactions(txs, columns=["non_existent_column"])
+
+
+def test_format_transactions_rejects_unknown_exclude_columns() -> None:
+    """format_transactions raises ValueError when unknown column is passed in exclude_columns."""
+    txs = _sample_transactions()
+    with pytest.raises(ValueError, match=r"unknown column.*non_existent_column"):
+        format_transactions(txs, exclude_columns=["non_existent_column"])
+
+
+def test_format_transactions_maxcolwidths_int() -> None:
+    """Passing an integer maxcolwidths wraps long text in table output."""
+    txs = _sample_transactions()
+    output = format_transactions(
+        txs,
+        tablefmt="simple",
+        columns=["date", "description"],
+        maxcolwidths=5,
+    )
+    # The description 'RS Vest' should be wrapped
+    lines = output.splitlines()
+    assert "date" in lines[0]
+    assert "descr" in lines[0]
+
+
+def test_format_transactions_maxcolwidths_list() -> None:
+    """Passing a sequence maxcolwidths sets width per column in table output."""
+    txs = _sample_transactions()
+    output = format_transactions(
+        txs,
+        tablefmt="simple",
+        columns=["date", "description", "amount"],
+        maxcolwidths=[10, 5, 10],
+    )
+    assert "date" in output
+
+
+def test_format_transactions_empty_csv() -> None:
+    """Empty transaction list still emits CSV headers."""
+    output = format_transactions([], tablefmt="csv")
+    reader = list(csv.reader(io.StringIO(output)))
+    assert len(reader) == 1
+    assert "date" in reader[0]
+    assert "symbol" in reader[0]
+
+
+def test_format_transactions_tsv() -> None:
+    """TSV output uses tab characters to separate columns."""
+    txs = _sample_transactions()
+    output = format_transactions(txs, tablefmt="tsv")
+    lines = output.splitlines()
+
+    assert len(lines) == 3  # header + 2 rows
+    assert "\t" in lines[0]
+    assert "GOOG" in lines[1]
+
+
+def test_format_transactions_html() -> None:
+    """HTML table format produces table markup."""
+    txs = _sample_transactions()
+    output = format_transactions(txs, tablefmt="html")
+
+    assert "<table>" in output
+    assert "date" in output
+    assert "<td>2023-04-25</td>" in output
+    assert "GOOG" in output
+
+
+def test_format_transactions_simple() -> None:
+    """Simple format produces text table with header underlines."""
+    txs = _sample_transactions()
+    output = format_transactions(txs, tablefmt="simple")
+    lines = output.splitlines()
+
+    assert len(lines) == 4  # header + underline + 2 rows
+    assert "date" in lines[0]
+    assert "---" in lines[1]
+    assert "GOOG" in lines[2]
+
+
+def test_dump_transactions_to_stream() -> None:
+    """dump_transactions writes to a custom stream when provided."""
+    txs = _sample_transactions()
+    buf = io.StringIO()
+    result = dump_transactions(txs, tablefmt="csv", stream=buf)
+
+    assert result is None
+    assert "date,action,symbol" in buf.getvalue()
+
+
+def test_dump_transactions_to_stdout(capsys: pytest.CaptureFixture[str]) -> None:
+    """dump_transactions writes to stdout when output_file is '-'."""
+    txs = _sample_transactions()
+    result = dump_transactions(txs, tablefmt="tsv", output_file="-")
+
+    assert result is None
+    captured = capsys.readouterr()
+    assert "\t" in captured.out
+    assert "GOOG" in captured.out
+
+
+def test_dump_transactions_to_file(tmp_path: Path) -> None:
+    """dump_transactions writes to specified file path."""
+    txs = _sample_transactions()
+    out_file = tmp_path / "subdir" / "dump.csv"
+    result = dump_transactions(txs, tablefmt="csv", output_file=out_file)
+
+    assert result == out_file
+    assert out_file.exists()
+    content = out_file.read_text(encoding="utf-8")
+    assert "date,action,symbol" in content
+    assert "GOOG" in content
+
+
+def test_dump_transactions_default_filename(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """dump_transactions defaults to parsed_transaction.{ext} in current directory."""
+    monkeypatch.chdir(tmp_path)
+    txs = _sample_transactions()
+    result = dump_transactions(txs, tablefmt="html")
+
+    expected_path = Path("parsed_transaction.html")
+    assert result == expected_path
+    assert expected_path.exists()
+    assert "<table>" in expected_path.read_text(encoding="utf-8")
+
+
+def test_cli_dump_transactions_default_file(
+    request: pytest.FixtureRequest,
+) -> None:
+    """CLI creates parsed_transaction.txt by default and completes calculation."""
+    cmd = build_cmd(
+        "--year",
+        "2023",
+        "--schwab-equity-award-json",
+        "tests/schwab/data/equity_award/schwab_equity_award_v2.json",
+        "--dump-transactions",
+        "--output",
+        report_path(request),
+    )
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+    dump_file = Path("parsed_transaction.txt")
+    try:
+        assert result.returncode == 0, (
+            f"STDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+        )
+        assert dump_file.exists()
+        content = dump_file.read_text(encoding="utf-8")
+        assert "GOOG" in content
+        assert "Tax summary for 2023/2024" in result.stdout
+    finally:
+        dump_file.unlink(missing_ok=True)
+
+
+def test_cli_dump_transactions_csv_format(
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+) -> None:
+    """CLI creates parsed_transaction.csv when format is csv."""
+    dump_file = tmp_path / "custom.csv"
+    cmd = build_cmd(
+        "--year",
+        "2023",
+        "--schwab-equity-award-json",
+        "tests/schwab/data/equity_award/schwab_equity_award_v2.json",
+        "--dump-transactions",
+        "csv",
+        "--dump-transactions-output",
+        str(dump_file),
+        "--output",
+        report_path(request),
+    )
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0
+    assert dump_file.exists()
+    content = dump_file.read_text(encoding="utf-8")
+    assert "date,action,symbol" in content
+    assert "GOOG" in content
+
+
+def test_cli_dump_transactions_to_stdout(
+    request: pytest.FixtureRequest,
+) -> None:
+    """CLI writes table to stdout when --dump-transactions-output is '-'."""
+    cmd = build_cmd(
+        "--year",
+        "2023",
+        "--schwab-equity-award-json",
+        "tests/schwab/data/equity_award/schwab_equity_award_v2.json",
+        "--dump-transactions",
+        "tsv",
+        "--dump-transactions-output",
+        "-",
+        "--output",
+        report_path(request),
+    )
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0
+    assert "date" in result.stdout
+    assert "\t" in result.stdout
+    assert "GOOG" in result.stdout
+    assert "Tax summary for 2023/2024" in result.stdout
+
+
+def test_cli_dump_transactions_columns_filter(
+    request: pytest.FixtureRequest,
+) -> None:
+    """CLI --dump-transactions-columns limits columns in dumped output."""
+    cmd = build_cmd(
+        "--year",
+        "2023",
+        "--schwab-equity-award-json",
+        "tests/schwab/data/equity_award/schwab_equity_award_v2.json",
+        "--dump-transactions",
+        "csv",
+        "--dump-transactions-columns",
+        "date,action,amount",
+        "--dump-transactions-output",
+        "-",
+        "--output",
+        report_path(request),
+    )
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0
+    assert "date,action,amount" in result.stdout
+    assert "symbol" not in result.stdout
+    assert "ActionType" not in result.stdout
+    assert "STOCK_ACTIVITY" in result.stdout
+
+
+def test_cli_dump_transactions_exclude_columns(
+    request: pytest.FixtureRequest,
+) -> None:
+    """CLI --dump-transactions-exclude-columns omits columns in dumped output."""
+    cmd = build_cmd(
+        "--year",
+        "2023",
+        "--schwab-equity-award-json",
+        "tests/schwab/data/equity_award/schwab_equity_award_v2.json",
+        "--dump-transactions",
+        "csv",
+        "--dump-transactions-exclude-columns",
+        "source,foreign_fees,calculation_quantity,option_contract,written_option_tax,capital_adjustments",
+        "--dump-transactions-output",
+        "-",
+        "--output",
+        report_path(request),
+    )
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0
+    assert "source" not in result.stdout
+    assert "foreign_fees" not in result.stdout
+    assert "date" in result.stdout
+    assert "symbol" in result.stdout

--- a/uv.lock
+++ b/uv.lock
@@ -170,6 +170,7 @@ dependencies = [
     { name = "pyrate-limiter" },
     { name = "requests" },
     { name = "shtab" },
+    { name = "tabulate" },
     { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
     { name = "xlrd" },
     { name = "yfinance" },
@@ -196,6 +197,7 @@ dev = [
     { name = "types-python-dateutil" },
     { name = "types-reportlab" },
     { name = "types-requests" },
+    { name = "types-tabulate" },
 ]
 docs = [
     { name = "zensical" },
@@ -215,6 +217,7 @@ requires-dist = [
     { name = "pyrate-limiter", specifier = ">=4.0.0" },
     { name = "requests", specifier = ">=2.27.1" },
     { name = "shtab", specifier = ">=1.12.1" },
+    { name = "tabulate", specifier = ">=0.9.0" },
     { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'", specifier = ">=2026.3" },
     { name = "xlrd", specifier = ">=2.0.2" },
     { name = "yfinance", specifier = ">=1.7.0" },
@@ -241,6 +244,7 @@ dev = [
     { name = "types-python-dateutil", specifier = ">=2.9.0.20250822" },
     { name = "types-reportlab", specifier = ">=4.5.1.20260827" },
     { name = "types-requests", specifier = ">=2.33.0.20260712" },
+    { name = "types-tabulate", specifier = ">=0.9.0.20240106" },
 ]
 docs = [{ name = "zensical", specifier = ">=0.0.57" }]
 links = [{ name = "lychee-bin", specifier = ">=0.24.2" }]
@@ -1559,6 +1563,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1674,6 +1687,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/db/51/703318f7b7be8bee126ec13bf615050f932d0179b8784420f3a0199cc769/types_requests-2.33.0.20260712.tar.gz", hash = "sha256:2141b67ab534a5c5cd2dac5034f2a35f42e699c5bf185eee608c5246a069d7fb", size = 25084, upload-time = "2026-07-12T05:14:20.455Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/e7/010c87f559e216d83f9dc51e939633fd0d0ead3377340181ab0e223cd3b5/types_requests-2.33.0.20260712-py3-none-any.whl", hash = "sha256:de027e28c171d3da529689cbfa023b0b4eab188c8dfa22fd834eebd2cee6e7bb", size = 21392, upload-time = "2026-07-12T05:14:19.616Z" },
+]
+
+[[package]]
+name = "types-tabulate"
+version = "0.10.0.20260508"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/af/c100d86897d3fdb010d8f813569fa80355b5cb553f51080e37d4f3c451bb/types_tabulate-0.10.0.20260508.tar.gz", hash = "sha256:8e51f159e8b24976849706ae2ed1dc9adba8ebbd080b17e494ebb66a8cc92c74", size = 8395, upload-time = "2026-05-08T04:47:58.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/36/443b700f54a585cf8ed4e76d8ad08b12df6914f8782a2788ecd0d8491519/types_tabulate-0.10.0.20260508-py3-none-any.whl", hash = "sha256:b1e1a2d0456fbd655a71690b09a7aaeffdf2978d32049184ea436492aa51d20a", size = 8137, upload-time = "2026-05-08T04:47:57.872Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Control:
- where to output: a file, or stdout
- the format (human-readable formatting, TSV, CSV)
- which columns to include or exclude 