### PR TITLE
Read a spin-off's holdings under every name the day renames them to

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -154,6 +154,7 @@ NVDA
 NVIDIA
 OCC
 OCI
+off's
 OpenFIGI
 OPRA
 OptionType

--- a/.harper-ignore.txt
+++ b/.harper-ignore.txt
@@ -51,3 +51,5 @@
 # "Either layout of the price-only export" is a compound noun; Harper
 # reads it as the verb "lay out".
 ^schwab\.md:.*PhrasalVerbAsCompoundNoun
+# "a single hop" is the graph sense, as in this file's own `_one_hop_renames`.
+^rename_planning\.py:.*HopHope

--- a/cgt_calc/current_price_fetcher.py
+++ b/cgt_calc/current_price_fetcher.py
@@ -68,6 +68,15 @@ class CurrentPriceFetcher:
             market_price_decimal, ticker.get("currency"), datetime.datetime.now().date()
         )
 
+    def known_closing_price(self, symbol: str, date: datetime.date) -> Decimal | None:
+        """Return an already-known closing price, or None without fetching.
+
+        For asking about a ticker that may not exist. Only the prices given to
+        this run answer; nothing is looked up, so a name the market never
+        carried costs nothing to ask about and cannot fail the run.
+        """
+        return self.historical_prices_data.get(symbol, {}).get(date)
+
     def get_closing_price(self, symbol: str, date: datetime.date) -> Decimal:
         """Get the price of the share on closing time."""
         with suppress(KeyError):

--- a/cgt_calc/ingestion.py
+++ b/cgt_calc/ingestion.py
@@ -38,6 +38,8 @@ from .model import (
     SpinOff,
 )
 from .rename_planning import (
+    connected_names,
+    end_name,
     plan_renames,
     reconcile_rename_day,
     rename_day_units,
@@ -47,7 +49,7 @@ from .rename_planning import (
 from .stock_split_planning import plan_stock_splits, source_account
 from .stock_splits import quantity_sign
 from .transaction_log import add_to_list, day_acquisitions
-from .util import approx_equal, normalize_amount, round_decimal
+from .util import approx_equal, normalize_amount, round_decimal, strip_zeros
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -345,6 +347,145 @@ class TransactionIngester:
         if self.run.portfolio[symbol].quantity == 0:
             del self.run.portfolio[symbol]
 
+    @staticmethod
+    def _source_is_the_destination_message(
+        recorded: str, symbol: str, date_index: datetime.date, *, renamed: bool
+    ) -> str:
+        """Say why a holding cannot be spun off from itself."""
+        cause = (
+            f"the day renames {recorded} to {symbol} as well, so {symbol} names"
+            if renamed
+            else f"the spin-offs file gives {symbol} itself as the holding the "
+            f"shares came from, so {symbol} would name"
+        )
+        return (
+            f"Cannot compute the spin-off of {symbol} on {date_index}: {cause} "
+            "both the holding the shares came from and the one they arrived "
+            "in. What a holding was worth that day is read from its ticker, "
+            "and that ticker would have to stand for both at once, so there is "
+            "no price to read. "
+            + (
+                "Put the rename on the day it happened, or work "
+                if renamed
+                else "Name the holding the shares came from in the spin-offs "
+                "file, or work "
+            )
+            + f"{symbol} out by hand (consider professional advice)."
+        )
+
+    def _refuse_disagreeing_alias(
+        self,
+        symbol: str,
+        date_index: datetime.date,
+        price: Decimal,
+        *,
+        other_end: str,
+    ) -> None:
+        """Refuse a second, different price under this end's own other name.
+
+        A day may rename that end, so it has a second name of its own, and the
+        two are the same security and should carry one price. Two different
+        ones would each give a different answer with nothing to choose
+        between them, so a disagreement is refused.
+
+        Every name the day's renames connect to this end is its own, except
+        the other end's: a merge back reaches that one, and its price is not
+        this end's to be measured against. Sibling names that meet only
+        through the other end are its own too - nothing in the rename graph
+        tells a second spelling of this holding from a third holding joining
+        it, so a price under either contradicts this end's just the same.
+
+        Only prices this run was already given take part. A name the market
+        never carried is not looked up, so asking cannot slow a run down or
+        fail it.
+        """
+        renames = self.history.rename_list.get(date_index, {})
+        own = connected_names(renames, symbol)
+        for alias in sorted(own - {symbol, other_end}):
+            known = self.price_fetcher.known_closing_price(alias, date_index)
+            if known is not None and known != price:
+                raise CalculationError(
+                    f"Cannot compute the spin-off of {symbol} on {date_index}: "
+                    f"the day's renames make {symbol} and {alias} one holding, "
+                    f"and they are priced differently "
+                    f"({strip_zeros(price)} and {strip_zeros(known)}). One "
+                    "holding has one market value on a day, and that value "
+                    "decides how much of the cost the reorganisation carries "
+                    "across, so there is no telling what it should be. Correct "
+                    f"whichever price is wrong, or work {symbol} out by hand "
+                    "(consider professional advice)."
+                )
+
+    def _refuse_unattributable_price(
+        self,
+        recorded: str,
+        symbol: str,
+        date_index: datetime.date,
+        src_price: Decimal,
+        dst_price: Decimal,
+    ) -> None:
+        """Refuse a price that could belong to either end of a reorganisation.
+
+        The day's renames can leave the holding the shares came from and the
+        one they arrived in ending under a single name. Where they do, a name
+        in that group which is neither end's own is claimed by both: a price
+        given for it is a third figure for the day, and nothing says which end
+        it belongs to. Picking one would let the spin-offs file's spelling
+        decide how the cost is split.
+
+        Unless there is nothing to decide. Where the two ends are worth the
+        same and the name is priced at that figure too, the day has one
+        market value and no reading of it splits the cost differently. That is
+        the whole of the exception: matching just one end of two that differ
+        proves nothing, because the name may belong to the other, and the
+        price it contradicts is the one that would then be used.
+        """
+        renames = self.history.rename_list.get(date_index, {})
+        merged = connected_names(renames, symbol)
+        if recorded not in merged:
+            return
+        settled = src_price == dst_price
+        for name in sorted(merged - {recorded, symbol}):
+            known = self.price_fetcher.known_closing_price(name, date_index)
+            if known is None or (settled and known == src_price):
+                continue
+            raise CalculationError(
+                f"Cannot compute the spin-off of {symbol} on {date_index}: "
+                f"the day's renames leave {recorded} and {symbol} under one "
+                f"name, and {name} is priced at {strip_zeros(known)} in the "
+                "same group. That figure is neither holding's own, so "
+                "whether it prices the shares the reorganisation came from "
+                "or the ones it created cannot be told, and the two split "
+                f"the cost differently. Price {recorded} and {symbol} "
+                "themselves, or work this day out by hand (consider "
+                "professional advice)."
+            )
+
+    def _source_holding_name(self, ticker: str, date_index: datetime.date) -> str:
+        """Return the name a spin-off's source holding is under right now.
+
+        The spin-offs file records one spelling, and a day that renames the
+        source has two. The pool moves where the RENAME row sits, so which of
+        them holds it here depends on where the export put that row, which is
+        not something the file's author knew. Every name the day's renames
+        connect is checked, and the one holding shares answers.
+
+        The recorded spelling stands when nothing is found, so a source that
+        really is missing, or one spun off later the same day out of order,
+        still reaches the refusal below.
+        """
+        renames = self.history.rename_list.get(date_index, {})
+        reached = connected_names(renames, ticker)
+        held = sorted(
+            name
+            for name in reached
+            if self.run.portfolio.get(name, Position()).quantity > 0
+        )
+        # One name holding shares is the holding. Two means the day merges
+        # two of them, which ``_spin_off_pool`` refuses in the second pass
+        # with the reason; nothing is gained by guessing between them here.
+        return held[0] if len(held) == 1 else ticker
+
     def _pooled_quantity(self, transaction: BrokerTransaction) -> Decimal:
         """Return the count to pool, in the units in force at the day's end."""
         quantity = transaction.pool_quantity
@@ -414,9 +555,53 @@ class TransactionIngester:
         symbol = get_symbol_or_fail(transaction)
         quantity = self._pooled_quantity(transaction)
 
-        ticker = self.spin_off_handler.get_spin_off_source(
+        recorded = self.spin_off_handler.get_spin_off_source(
             symbol, transaction.date, self.run.portfolio
         )
+        renames = self.history.rename_list.get(transaction.date, {})
+        # Which holding a row is about, rather than which spelling it used.
+        holding = end_name(renames, symbol)
+        # Only the source's own ticker becoming the destination's overloads
+        # it. A destination renamed *into* the source merges after the
+        # reorganisation, by which time both have been priced.
+        if symbol in {recorded, renames.get(recorded)}:
+            raise CalculationError(
+                self._source_is_the_destination_message(
+                    recorded, symbol, transaction.date, renamed=recorded != symbol
+                )
+            )
+        # One event's shares must all reach the same acquisition record, and
+        # that record is kept under the ticker each row states. Rows of one
+        # spin-off spelled two ways would be pooled apart and apportioned
+        # twice, each from a source the other had already reduced.
+        #
+        # Only rows of the same event: two holdings can each spin something
+        # off into what the day's renames make one holding, and those are two
+        # reorganisations, settled separately and pooled together at the day's
+        # close.
+        split = next(
+            (
+                spin_off
+                for spin_off in self.history.spin_offs[transaction.date]
+                if end_name(renames, spin_off.dest) == holding
+                and spin_off.dest != symbol
+                and end_name(renames, spin_off.source) == end_name(renames, recorded)
+            ),
+            None,
+        )
+        if split is not None:
+            raise CalculationError(
+                f"Cannot compute the spin-off of {symbol} on {transaction.date}: "
+                f"the day already spins shares from {recorded} into "
+                f"{split.dest}, which its renames make the same holding as "
+                f"{symbol}. One reorganisation splits the value of everything "
+                "it hands over at once, and these rows are recorded under two "
+                "names, so what each is worth cannot be settled separately. "
+                "Record the day's spin-off rows for this holding under one "
+                f"name, or work {symbol} out by hand (consider professional "
+                "advice)."
+            )
+        ticker = self._source_holding_name(recorded, transaction.date)
         # Nothing to apportion from an empty holding, and no proportion of
         # value to work out either. On a day the source is itself created by
         # a spin-off, this is the first sign the rows are out of order, and
@@ -437,7 +622,7 @@ class TransactionIngester:
             (
                 spin_off
                 for spin_off in self.history.spin_offs[transaction.date]
-                if spin_off.source == symbol
+                if end_name(renames, spin_off.source) == holding
             ),
             None,
         )
@@ -451,8 +636,25 @@ class TransactionIngester:
                 f"{symbol} before the one it makes, or work this day out by "
                 "hand (consider professional advice). Do not change the dates."
             )
+        # Each end is priced under the name that does not move with the
+        # RENAME row: the file's name for the source, the row's own for the
+        # holding it creates. Reading a price under a name that depends on
+        # where the RENAME row landed would let the export's layout decide
+        # how much cost carries across.
         dst_price = self.price_fetcher.get_closing_price(symbol, transaction.date)
-        src_price = self.price_fetcher.get_closing_price(ticker, transaction.date)
+        src_price = self.price_fetcher.get_closing_price(recorded, transaction.date)
+        # The wider question first, so that a day whose two ends close under
+        # one name is refused for that rather than for whichever of its names
+        # happened to be compared.
+        self._refuse_unattributable_price(
+            recorded, symbol, transaction.date, src_price, dst_price
+        )
+        self._refuse_disagreeing_alias(
+            symbol, transaction.date, dst_price, other_end=recorded
+        )
+        self._refuse_disagreeing_alias(
+            recorded, transaction.date, src_price, other_end=symbol
+        )
         dst_amount = quantity * dst_price
         src_amount = self.run.portfolio[ticker].quantity * src_price
         original_src_amount = self.run.portfolio[ticker].amount

--- a/cgt_calc/matching.py
+++ b/cgt_calc/matching.py
@@ -27,6 +27,7 @@ from .model import (
     RuleType,
     SpinOff,
 )
+from .rename_planning import end_name
 from .stock_splits import (
     StockSplitDetail,
     StockSplitEvent,
@@ -173,10 +174,15 @@ class Matcher:
             # across brokers, are one reorganisation: the split of value is by
             # the whole of what was received, and the source gives up its
             # share once. Rows from different sources stay separate events,
-            # taken in the order they happened.
+            # taken in the order they happened. Which source a row names is
+            # the holding it names, not the spelling: a rename between two
+            # rows of one event leaves them under two names, and apportioning
+            # each on its own takes a second share of a pool the first has
+            # already reduced.
+            renames = self.history.rename_list.get(date_index, {})
             events: dict[str, list[SpinOff]] = {}
             for row in spin_offs_here:
-                events.setdefault(row.source, []).append(row)
+                events.setdefault(end_name(renames, row.source), []).append(row)
             for source_symbol, rows in events.items():
                 first = rows[0]
                 source = self.run.portfolio[
@@ -308,6 +314,11 @@ class Matcher:
         # that pool into the one the holding ends the day under, which they
         # have by the time a transfer to a spouse is recorded.
         cost_holder = identity.pool_name if no_gain_no_loss else identity.acquired_under
+        if not no_gain_no_loss:
+            # For the same reason, a transfer to a spouse needs nothing
+            # gathering: the day's renames have already put the whole holding
+            # under one name by the time it is recorded.
+            self._pool_todays_reorganisations(identity, date_index)
         pool = self.run.portfolio[identity.pool_name]
         ctx = DisposalContext(
             symbol=symbol,
@@ -342,6 +353,36 @@ class Matcher:
         )
         ctx.chargeable_gain = round_decimal(ctx.chargeable_gain, 2)
         return ctx.chargeable_gain, ctx.calculation_entries
+
+    def _pool_todays_reorganisations(
+        self, identity: DayIdentity, date_index: datetime.date
+    ) -> None:
+        """Put shares today's reorganisations created into the holding's pool.
+
+        A spin-off's new shares go under the ticker its own row spelled, and a
+        rename that day need not leave the holding under that ticker. They are
+        pool shares rather than an acquisition (TCGA 1992 s127), and the
+        rename says the two tickers are one security, so a disposal today is
+        priced against them. The day's renames would bring them together, but
+        only once the day's disposals have priced themselves, so they are
+        brought in here instead. Without this the pool a disposal reads is
+        short of them, and where the day opened holding none it is empty.
+
+        What the day bought stays under the name its row put it under, so the
+        same-day rule can still identify a disposal against it (see
+        `_match_same_day`).
+        """
+        for name in sorted(identity.names - {identity.pool_name}):
+            matchable = self._matchable_acquisition(date_index, name)
+            identifiable = self._identifiable_acquisition(date_index, name)
+            reorganised = Position(
+                matchable.quantity - identifiable.quantity,
+                matchable.amount - identifiable.amount,
+            )
+            if not reorganised.quantity and not reorganised.amount:
+                continue
+            self.run.portfolio[name] -= reorganised
+            self.run.portfolio[identity.pool_name] += reorganised
 
     def _match_same_day(self, ctx: DisposalContext) -> None:
         """Identify the disposal against the same day's acquisitions."""
@@ -1237,51 +1278,17 @@ class Matcher:
         already put them in its pool.
         """
         renames = self.history.rename_list.get(date_index, {})
-        # Follow the day's renames back from the source, a holding renamed
-        # twice in a morning being two hops from its pool. Only renames on
-        # this chain matter; what happened to other symbols that day does not.
-        names = [source]
-        frontier = [source]
-        while frontier:
-            current = frontier.pop()
-            for old, new in renames.items():
-                if new != current:
-                    continue
-                if old in names:
-                    raise CalculationError(
-                        f"Cannot compute the spin-off of {dest} from {source} on "
-                        f"{date_index}: the day's renames go round in a circle "
-                        f"({' -> '.join([*names, old])}), so there is no telling "
-                        f"where the pool is. Work {source} and {dest} out by "
-                        "hand (consider professional advice)."
-                    )
-                names.append(old)
-                frontier.append(old)
-        # The pool sits under whichever of these names holds anything here,
-        # since the day's renames are applied after its acquisitions. Cost
-        # with no shares counts: a fee charged after a holding was sold out
-        # leaves exactly that, and the rename merges it in all the same. Two
-        # of them means two holdings became one that day, and whether the
-        # spin-off applied to both or to one cannot be told from the input.
-        holding = sorted(
-            name
-            for name in names
-            if name in self.run.portfolio
-            and (
-                self.run.portfolio[name].quantity > 0
-                or self.run.portfolio[name].amount != 0
-            )
-        )
-        if len(holding) > 1:
-            raise CalculationError(
-                f"Cannot compute the spin-off of {dest} from {source} on "
-                f"{date_index}: {' and '.join(holding)} were separate holdings "
-                "until renamed into one that day, and whether the spin-off "
-                "applied to both or just one cannot be told from the input. "
-                f"Work {source} and {dest} out by hand (consider professional "
-                "advice)."
-            )
-        pool = holding[0] if holding else source
+        # Every ticker the day's renames say is this holding. A rename changes
+        # what the shares are called and nothing else, so a row under either
+        # spelling is a row of the same holding, and one recorded under the
+        # name the day ends with counts here as much as one under the name it
+        # started under. Walking only one way lets a sale under the other
+        # spelling pass unseen, and the day is then worked out as though the
+        # sale had come after the reorganisation.
+        names = [
+            source,
+            *(other for other, _ in self._renames_reaching(source, renames)),
+        ]
         activity = []
         for name in names:
             if (
@@ -1306,7 +1313,34 @@ class Matcher:
                 f"Work {source} and {dest} out by hand for this period (consider "
                 "professional advice). Do not change the dates."
             )
-        return pool
+        # The pool sits under whichever of these names holds anything here,
+        # since the day's renames are applied after its acquisitions. Cost
+        # with no shares counts: a fee charged after a holding was sold out
+        # leaves exactly that, and the rename merges it in all the same. Two
+        # of them means two holdings became one that day, and whether the
+        # spin-off applied to both or to one cannot be told from the input.
+        # Asked after the day's own rows, so that a purchase or a fee under
+        # the day's other name is reported as the trade it is rather than as
+        # a second holding.
+        holding = sorted(
+            name
+            for name in names
+            if name in self.run.portfolio
+            and (
+                self.run.portfolio[name].quantity > 0
+                or self.run.portfolio[name].amount != 0
+            )
+        )
+        if len(holding) > 1:
+            raise CalculationError(
+                f"Cannot compute the spin-off of {dest} from {source} on "
+                f"{date_index}: {' and '.join(holding)} were separate holdings "
+                "until renamed into one that day, and whether the spin-off "
+                "applied to both or just one cannot be told from the input. "
+                f"Work {source} and {dest} out by hand (consider professional "
+                "advice)."
+            )
+        return holding[0] if holding else source
 
     def _acquisition_order(self, date_index: datetime.date) -> list[str]:
         """Return the day's acquired symbols, each spun-off holding after its source.
@@ -1320,21 +1354,38 @@ class Matcher:
         spun off from the same source take their shares one after another, so
         among themselves they keep the order the spin-offs happened in, which
         is the order the first pass worked them out in.
+
+        Which holding a spin-off names, rather than which of the day's
+        spellings its row used, is what puts one after another: a rename
+        between them would otherwise leave the two ends looking unrelated,
+        and a holding would be apportioned before it had received what it
+        apportions from.
         """
+        renames = self.history.rename_list.get(date_index, {})
         sources: dict[str, list[str]] = defaultdict(list)
         first_event: dict[str, int] = {}
         for index, spin_off in enumerate(self.history.spin_offs.get(date_index, [])):
-            sources[spin_off.dest].append(spin_off.source)
-            first_event.setdefault(spin_off.dest, index)
+            dest = end_name(renames, spin_off.dest)
+            source = end_name(renames, spin_off.source)
+            # A new holding renamed back into the one it came from shares its
+            # closing name, and nothing waits on itself. The two are still
+            # separate while the day's acquisitions are pooled, which is what
+            # this order is for.
+            if source != dest:
+                sources[dest].append(source)
+            first_event.setdefault(dest, index)
 
-        def depth(symbol: str) -> int:
+        def depth(holding: str) -> int:
             # A cycle cannot get here: the first pass refuses a chain that is
             # not in order, and a cycle is never in order.
-            return 1 + max((depth(source) for source in sources[symbol]), default=-1)
+            return 1 + max((depth(source) for source in sources[holding]), default=-1)
 
         return sorted(
             self.history.acquisition_list[date_index],
-            key=lambda symbol: (depth(symbol), first_event.get(symbol, -1)),
+            key=lambda symbol: (
+                depth(end_name(renames, symbol)),
+                first_event.get(end_name(renames, symbol), -1),
+            ),
         )
 
     def _match_across_splits(

--- a/cgt_calc/rename_planning.py
+++ b/cgt_calc/rename_planning.py
@@ -28,7 +28,7 @@ from .stock_splits import quantity_sign
 from .transaction_log import has_key
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterator, Mapping
     import datetime
 
     from .calculator_state import CalculatorState, PreparedHistory
@@ -39,7 +39,6 @@ RENAME_DAY_UNSUPPORTED_ACTIONS: Final = frozenset(
     {
         # Restate or apportion the pool itself, so where the pool sits when
         # the row is read decides what they do.
-        ActionType.SPIN_OFF,
         ActionType.STOCK_SPLIT,
         ActionType.FEE,
         ActionType.EXCESS_REPORTED_INCOME,
@@ -59,17 +58,20 @@ RENAME_DAY_UNSUPPORTED_ACTIONS: Final = frozenset(
 """Actions that keep their component on the existing row-position path."""
 
 
-UNNAMED_HOLDING_ACTIONS: Final = frozenset(
-    {ActionType.SPIN_OFF, ActionType.EXCESS_REPORTED_INCOME}
-)
+UNNAMED_HOLDING_ACTIONS: Final = frozenset({ActionType.EXCESS_REPORTED_INCOME})
 """Rows that change a pool without naming it, so no component can exclude them.
 
-A spin-off row names only the holding it creates: its source is chosen when
-the row is read, out of the portfolio as the day's earlier rows have left it.
 An excess reported income row names no ticker at all, only an ISIN, which is
-resolved to the holdings it adds cost to when that row is read. Neither can be
-matched to a rename component by the ticker on its own row, so a day carrying
-either is left to the row-position pool in its entirety.
+resolved to the holdings it adds cost to when that row is read. It cannot be
+matched to a rename component by anything on its own row, so a day carrying
+one is left to the row-position pool in its entirety.
+
+A spin-off used to be read this way too, because the holding it draws from is
+chosen when the row is read rather than named on it. But the row does name the
+holding it creates, which is the only one whose count it changes, and a
+spin-off leaves the source's count alone. So a component can take a spin-off
+into account like any other row that adds units, and a spin-off elsewhere on
+the day no longer stops an unrelated rename being read as one holding.
 """
 
 
@@ -86,6 +88,43 @@ class RenameComponent:
     names: tuple[str, ...]
     closing_name: str
     capacity: Decimal
+
+
+def end_name(renames: Mapping[str, str], symbol: str) -> str:
+    """Return the name a day's renames leave this holding under.
+
+    A rename changes what a holding is called and nothing else, so two rows
+    spelling it differently are rows of one holding. The name it ends the day
+    under is what they agree on, and is the same answer whichever of the
+    day's spellings is asked about, so it is what tells one holding from
+    another: comparing the spellings themselves makes one holding look like
+    two, and each half is then worked out as if the other were a different
+    security.
+
+    Chains and cycles are refused before any of the day's rows is read, so a
+    single hop reaches the end.
+    """
+    return renames.get(symbol, symbol)
+
+
+def connected_names(renames: Mapping[str, str], symbol: str) -> set[str]:
+    """Return every ticker a day's renames say is this holding.
+
+    Walked in both directions: a holding is reached from the name it is
+    renamed to as well as from the ones renamed into it.
+    """
+    reached = {symbol}
+    frontier = [symbol]
+    while frontier:
+        name = frontier.pop()
+        for old_name, new_name in renames.items():
+            other = (
+                new_name if name == old_name else old_name if name == new_name else None
+            )
+            if other is not None and other not in reached:
+                reached.add(other)
+                frontier.append(other)
+    return reached
 
 
 def rename_pair(transaction: BrokerTransaction) -> tuple[str, str]:
@@ -125,6 +164,13 @@ def plan_renames(
     ]
     for _, renames in components:
         _refuse_rename_chain(renames, date_index)
+    # Which names the day makes one holding, recorded before any of its rows
+    # is read. The pool still moves where the RENAME row sits, but a row that
+    # names either spelling can be resolved to the holding whatever order the
+    # export lists them in, which the row-position record cannot do for a
+    # rename it has not reached yet.
+    for _, renames in components:
+        state.history.rename_list[date_index].update(renames)
     # These rows cannot be assigned to components by ticker alone.
     if any(
         transaction.action in UNNAMED_HOLDING_ACTIONS

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -1839,7 +1839,14 @@ def test_every_action_says_what_a_rename_day_does_with_it() -> None:
 
     Adding an action without classifying it must fail this test.
     """
-    read_as_one_holding = {ActionType.BUY, ActionType.SELL, ActionType.RENAME}
+    read_as_one_holding = {
+        ActionType.BUY,
+        ActionType.SELL,
+        ActionType.RENAME,
+        # A spin-off names the holding it creates, which is the only one whose
+        # count it changes, so a component can take it into account.
+        ActionType.SPIN_OFF,
+    }
     touch_no_holding = {
         ActionType.ADJUSTMENT,
         ActionType.CANCEL_BUY,
@@ -1866,10 +1873,12 @@ def test_every_action_says_what_a_rename_day_does_with_it() -> None:
         RENAME_DAY_UNSUPPORTED_ACTIONS
     )
     # Nothing that moves a share count is read as part of the whole holding
-    # but an ordinary purchase or sale.
+    # but an ordinary purchase or sale, and a spin-off, which adds units to
+    # the holding its own row names.
     assert (QUANTITY_INCREASING_ACTIONS | QUANTITY_DECREASING_ACTIONS) - {
         ActionType.BUY,
         ActionType.SELL,
+        ActionType.SPIN_OFF,
     } <= RENAME_DAY_UNSUPPORTED_ACTIONS
 
 

--- a/tests/general/test_rename_spin_off.py
+++ b/tests/general/test_rename_spin_off.py
@@ -1,0 +1,721 @@
+"""A day that both renames a ticker and spins a holding off it.
+
+A rename changes what shares are called; a spin-off moves cost from one
+holding to another, apportioned at the reorganisation itself (TCGA 1992 s127,
+CG51700, CG51976). So the spelling a row happens to use, and the place an
+export puts the RENAME row, must not change any figure: equivalent inputs give
+the same answer or the same refusal.
+
+`SRC` costs £100 and is worth £90 a unit on the day; `DST` is worth £10, and
+as many are received as `SRC` is held, so a tenth of the value, and a tenth of
+the cost, goes to `DST`.
+"""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+import itertools
+
+import pytest
+
+from cgt_calc.const import RENAME_DESCRIPTION_PREFIX
+from cgt_calc.currency_converter import CurrencyConverter
+from cgt_calc.current_price_fetcher import CurrentPriceFetcher
+from cgt_calc.exceptions import CalculationError
+from cgt_calc.initial_prices import InitialPrices
+from cgt_calc.isin_converter import IsinConverter
+from cgt_calc.main import CapitalGainsCalculator
+from cgt_calc.model import ActionType, BrokerTransaction, CapitalGainsReport
+from cgt_calc.spin_off_handler import SpinOffHandler
+from cgt_calc.util import round_decimal
+
+from .calc_test_data import GBP, transaction, transfer_to_spouse_transaction
+from .test_calc import _gbp_fee, get_report
+
+BUY_DAY = datetime.date(2024, 6, 1)
+DAY = datetime.date(2024, 7, 5)
+FLAT = Decimal(1)
+PRICES = {
+    name: {DAY: Decimal(90) if name.startswith("SRC") else Decimal(10)}
+    for name in ("SRC", "SRCNEW", "DST", "DSTNEW")
+}
+
+
+def rename_row(old: str, new: str) -> BrokerTransaction:
+    """Build a RENAME row moving the pool from one ticker to another."""
+    return BrokerTransaction(
+        date=DAY,
+        action=ActionType.RENAME,
+        symbol=new,
+        description=f"{RENAME_DESCRIPTION_PREFIX}{old}",
+        quantity=Decimal(0),
+        price=None,
+        fees=Decimal(0),
+        amount=Decimal(0),
+        currency=GBP,
+        broker="Testing",
+    )
+
+
+def spin_off_row(symbol: str, units: int = 10) -> BrokerTransaction:
+    """Build the SPIN_OFF row that creates `units` of `symbol`."""
+    return transaction(DAY, ActionType.SPIN_OFF, symbol, units, 10, 0, currency=GBP)
+
+
+def run(
+    rows: list[BrokerTransaction],
+    source: str,
+    prices: dict[str, dict[datetime.date, Decimal]] | None = None,
+    sources: dict[str, str] | None = None,
+) -> CapitalGainsReport:
+    """Run these rows with the spin-offs file naming `source` for every ticker."""
+    converter = CurrencyConverter(None, {BUY_DAY: {GBP: FLAT}, DAY: {GBP: FLAT}})
+    handler = SpinOffHandler()
+    handler.cache = sources or dict.fromkeys(("DST", "DSTNEW"), source)
+    calculator = CapitalGainsCalculator(
+        2024,
+        converter,
+        IsinConverter(),
+        CurrentPriceFetcher(converter, {}, prices if prices is not None else PRICES),
+        handler,
+        InitialPrices(),
+        interest_fund_tickers=[],
+        balance_check=False,
+    )
+    return get_report(calculator, rows)
+
+
+def holding(report: CapitalGainsReport, symbol: str) -> tuple[Decimal, Decimal]:
+    """Return the units and pooled cost the report closes with."""
+    (entry,) = (item for item in report.portfolio if item.symbol == symbol)
+    return entry.quantity, round_decimal(entry.amount, 4)
+
+
+SPELLING = pytest.mark.parametrize("spelling", ["SRC", "SRCNEW"], ids=["old", "new"])
+RENAME_FIRST = pytest.mark.parametrize(
+    "rename_first", [True, False], ids=["rename first", "rename last"]
+)
+
+
+@SPELLING
+@RENAME_FIRST
+def test_a_renamed_source_gives_up_its_share_whichever_name_is_recorded(
+    spelling: str, *, rename_first: bool
+) -> None:
+    """The four ways to write one day all apportion the same cost.
+
+    Two of them used to be refused, with a message saying the source held no
+    shares. It held them under the day's other name.
+    """
+    rename = rename_row("SRC", "SRCNEW")
+    spin = spin_off_row("DST")
+    report = run(
+        [
+            transaction(BUY_DAY, ActionType.BUY, "SRC", 10, 10, 0, -100, GBP),
+            *([rename, spin] if rename_first else [spin, rename]),
+        ],
+        spelling,
+    )
+
+    assert holding(report, "SRCNEW") == (Decimal(10), Decimal(90))
+    assert holding(report, "DST") == (Decimal(10), Decimal(10))
+
+
+@pytest.mark.parametrize("dest_spelling", ["DST", "DSTNEW"], ids=["old", "new"])
+@pytest.mark.parametrize("held", [False, True], ids=["empty", "already held"])
+@RENAME_FIRST
+def test_a_renamed_destination_receives_its_share_under_either_name(
+    dest_spelling: str, *, held: bool, rename_first: bool
+) -> None:
+    """A rename of the destination cannot change what it receives.
+
+    Four units costing £20 held beforehand simply pool with the ten that
+    arrive carrying £10.
+    """
+    rename = rename_row("DST", "DSTNEW")
+    spin = spin_off_row(dest_spelling)
+    report = run(
+        [
+            transaction(BUY_DAY, ActionType.BUY, "SRC", 10, 10, 0, -100, GBP),
+            *(
+                [transaction(BUY_DAY, ActionType.BUY, "DST", 4, 5, 0, -20, GBP)]
+                if held
+                else []
+            ),
+            *([rename, spin] if rename_first else [spin, rename]),
+        ],
+        "SRC",
+    )
+
+    assert holding(report, "SRC") == (Decimal(10), Decimal(90))
+    expected = (Decimal(14), Decimal(30)) if held else (Decimal(10), Decimal(10))
+    assert holding(report, "DSTNEW") == expected
+
+
+def _source_activity(kind: str, symbol: str) -> BrokerTransaction:
+    """Build a row that touches the source holding on the spin-off day."""
+    if kind == "sold":
+        return transaction(DAY, ActionType.SELL, symbol, 2, 95, 0, 190, GBP)
+    if kind == "bought":
+        return transaction(DAY, ActionType.BUY, symbol, 2, 95, 0, -190, GBP)
+    if kind == "transferred to a spouse":
+        return transfer_to_spouse_transaction(DAY, symbol, 2)
+    return _gbp_fee(DAY, symbol, 5)
+
+
+@pytest.mark.parametrize(
+    "kind", ["sold", "bought", "transferred to a spouse", "charged a fee"]
+)
+@SPELLING
+def test_a_source_traded_on_the_spin_off_day_is_refused_under_either_name(
+    kind: str, spelling: str
+) -> None:
+    """Trading the source that day is refused whichever name the row uses.
+
+    The cost is apportioned at the reorganisation (CG51976), so whether the
+    trade came before or after it decides what carries across, and a date
+    carries no time of day. Recorded under the day's other name the trade used
+    to go unseen, and the day was worked out as though it had come after.
+    """
+    rename = rename_row("SRC", "SRCNEW")
+    spin = spin_off_row("DST")
+    activity = _source_activity(kind, spelling)
+    day_rows = (
+        [spin, activity, rename] if spelling == "SRC" else [spin, rename, activity]
+    )
+    with pytest.raises(CalculationError) as excinfo:
+        run(
+            [
+                transaction(BUY_DAY, ActionType.BUY, "SRC", 10, 10, 0, -100, GBP),
+                *day_rows,
+            ],
+            "SRC",
+        )
+
+    assert f"was also {kind} that day" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("sale_spelling", ["OLD", "NEW"], ids=["old", "new"])
+def test_a_rename_elsewhere_on_a_spin_off_day_still_reads_as_one_holding(
+    sale_spelling: str,
+) -> None:
+    """A spin-off does not stop an unrelated rename being read as one holding.
+
+    `OLD` and `NEW` have nothing to do with the spin-off, and a sale of them
+    used to be rejected as a sale of shares not owned whenever a spin-off
+    happened to fall on the same day.
+    """
+    rows = [
+        transaction(BUY_DAY, ActionType.BUY, "SRC", 10, 10, 0, -100, GBP),
+        transaction(BUY_DAY, ActionType.BUY, "OLD", 100, 10, 0, -1000, GBP),
+        spin_off_row("DST"),
+        rename_row("OLD", "NEW"),
+        transaction(DAY, ActionType.SELL, sale_spelling, 50, 20, 0, 1000, GBP),
+    ]
+
+    report = run(rows, "SRC")
+
+    assert report.total_gain() == Decimal(500)
+    assert holding(report, "NEW") == (Decimal(50), Decimal(500))
+    assert holding(report, "DST") == (Decimal(10), Decimal(10))
+
+
+@pytest.mark.parametrize(
+    "sale_spelling", ["DST", "DSTNEW"], ids=["sold old", "sold new"]
+)
+@pytest.mark.parametrize(
+    "dest_spelling", ["DST", "DSTNEW"], ids=["into old", "into new"]
+)
+@pytest.mark.parametrize("held", [True, False], ids=["held", "new holding"])
+@RENAME_FIRST
+def test_a_renamed_destination_is_one_holding_however_it_is_spelled(
+    sale_spelling: str, dest_spelling: str, *, held: bool, rename_first: bool
+) -> None:
+    """Selling the destination that day gives one answer under either name.
+
+    The spin-off's shares are not identified against (see
+    `_identifiable_acquisition`), so the sale draws on the pool. Where the day
+    opened holding the destination that is four units costing £20 plus the ten
+    that carried £10, and two of the fourteen leave; where it did not, the ten
+    the spin-off created are the whole pool.
+
+    The spin-off's row and the sale each state one of the day's two names for
+    the destination, and the RENAME row sits either side of them, so the same
+    holding is written down sixteen ways. Spelling the spin-off's row
+    differently from the day's pool used to leave the new shares stranded
+    under their own name: the sale priced itself against the four units the
+    day opened with, or, with nothing held to open with, against an empty pool
+    that crashed the run.
+    """
+    rename = rename_row("DST", "DSTNEW")
+    spin = spin_off_row(dest_spelling)
+    sale = transaction(DAY, ActionType.SELL, sale_spelling, 2, 20, 0, 40, GBP)
+    opening = [transaction(BUY_DAY, ActionType.BUY, "DST", 4, 5, 0, -20, GBP)]
+    report = run(
+        [
+            transaction(BUY_DAY, ActionType.BUY, "SRC", 10, 10, 0, -100, GBP),
+            *(opening if held else []),
+            *([rename, spin, sale] if rename_first else [spin, sale, rename]),
+        ],
+        "SRC",
+    )
+
+    quantity = Decimal(14 if held else 10)
+    cost = Decimal(30 if held else 10)
+    (entry,) = report.calculation_log[DAY][f"sell${sale_spelling}"]
+    assert entry.allowable_cost == round_decimal(cost * 2 / quantity, 10)
+    assert holding(report, "DSTNEW") == (
+        quantity - 2,
+        round_decimal(cost * (quantity - 2) / quantity, 4),
+    )
+
+
+@RENAME_FIRST
+def test_a_destination_renamed_into_the_source_merges_back(
+    *, rename_first: bool
+) -> None:
+    """The new holding is renamed straight back into the one it came from.
+
+    A tenth of the cost goes to `DST` and the rename puts it back under `SRC`,
+    so the day ends where it started: twenty units carrying the whole £100.
+    """
+    rename = rename_row("DST", "SRC")
+    spin = spin_off_row("DST")
+    report = run(
+        [
+            transaction(BUY_DAY, ActionType.BUY, "SRC", 10, 10, 0, -100, GBP),
+            *([rename, spin] if rename_first else [spin, rename]),
+        ],
+        "SRC",
+    )
+
+    assert holding(report, "SRC") == (Decimal(20), Decimal(100))
+
+
+@RENAME_FIRST
+def test_a_source_renamed_to_the_name_it_spins_off_is_refused(
+    *, rename_first: bool
+) -> None:
+    """One ticker cannot name both ends of the same reorganisation.
+
+    The day says `SRC` is now called `DST` and that `SRC` spins off a new
+    holding called `DST`. What the source was worth is read from its ticker,
+    and that ticker would have to stand for both holdings at once, so there is
+    no price to read. Refused whichever order the rows come in: it used to be
+    refused one way, with a message saying the source held no shares, and
+    computed the other.
+    """
+    rename = rename_row("SRC", "DST")
+    spin = spin_off_row("DST")
+    with pytest.raises(CalculationError, match="names both the holding"):
+        run(
+            [
+                transaction(BUY_DAY, ActionType.BUY, "SRC", 10, 10, 0, -100, GBP),
+                *([rename, spin] if rename_first else [spin, rename]),
+            ],
+            "SRC",
+        )
+
+
+def _priced(**prices: int) -> dict[str, dict[datetime.date, Decimal]]:
+    """Give each named ticker its own closing price on the spin-off day."""
+    return {name: {DAY: Decimal(price)} for name, price in prices.items()}
+
+
+@RENAME_FIRST
+def test_two_prices_for_one_renamed_source_are_refused(*, rename_first: bool) -> None:
+    """A holding cannot be worth two different amounts on one day.
+
+    `SRC` is priced at £75 and `SRCNEW` at £60, and the day's renames say they
+    are one holding. Which of them splits the cost used to depend on where the
+    RENAME row sat: reading `SRC` left `DST` with £36.00 and reading `SRCNEW`
+    left it with £42.35, from the same twelve shares.
+    """
+    rename = rename_row("SRC", "SRCNEW")
+    spin = spin_off_row("DST", 12)
+    with pytest.raises(CalculationError, match="priced differently"):
+        run(
+            [
+                transaction(BUY_DAY, ActionType.BUY, "SRC", 12, 12, 0, -144, GBP),
+                *([rename, spin] if rename_first else [spin, rename]),
+            ],
+            "SRC",
+            _priced(SRC=75, SRCNEW=60, DST=25),
+        )
+
+
+@pytest.mark.parametrize("spelling", ["DST", "DSTNEW"], ids=["old", "new"])
+def test_two_prices_for_one_renamed_destination_are_refused(spelling: str) -> None:
+    """The same, for the holding the shares arrive in.
+
+    Priced as `DST` the new holding took £36.00 and priced as `DSTNEW` it took
+    £50.09, for one twelve-share spin-off written down two ways.
+    """
+    with pytest.raises(CalculationError, match="priced differently"):
+        run(
+            [
+                transaction(BUY_DAY, ActionType.BUY, "SRC", 12, 12, 0, -144, GBP),
+                spin_off_row(spelling, 12),
+                rename_row("DST", "DSTNEW"),
+            ],
+            "SRC",
+            _priced(SRC=75, DST=25, DSTNEW=40),
+        )
+
+
+def test_one_spin_off_recorded_under_two_destination_names_is_refused() -> None:
+    """Rows of one reorganisation spelled two ways cannot be joined.
+
+    Five shares under `DST` and seven under `DSTNEW` are one twelve-share
+    event, but each name keeps its own acquisition record, so they were
+    apportioned separately and the second took a share of a pool the first had
+    already reduced: £38.14 where twelve shares at once take £36.00.
+    """
+    with pytest.raises(CalculationError, match="the same holding as"):
+        run(
+            [
+                transaction(BUY_DAY, ActionType.BUY, "SRC", 12, 12, 0, -144, GBP),
+                spin_off_row("DST", 5),
+                spin_off_row("DSTNEW", 7),
+                rename_row("DST", "DSTNEW"),
+            ],
+            "SRC",
+            _priced(SRC=75, DST=25, DSTNEW=25),
+        )
+
+
+@pytest.mark.parametrize(
+    "rename_position", [0, 1, 2], ids=["before", "between", "after"]
+)
+def test_a_rename_between_two_rows_of_one_spin_off_is_still_one_event(
+    rename_position: int,
+) -> None:
+    """Where the RENAME row sits cannot split one reorganisation in two.
+
+    Both rows name `DST`, so they are one acquisition; the rename only decides
+    whether each row's source was spelled `SRC` or `SRCNEW`. With the RENAME
+    row between them the two used to be apportioned as separate events, giving
+    the new holding £38.14 instead of £36.00.
+    """
+    day_rows = [spin_off_row("DST", 5), spin_off_row("DST", 7)]
+    day_rows.insert(rename_position, rename_row("SRC", "SRCNEW"))
+    report = run(
+        [
+            transaction(BUY_DAY, ActionType.BUY, "SRC", 12, 12, 0, -144, GBP),
+            *day_rows,
+        ],
+        "SRC",
+        _priced(SRC=75, DST=25),
+    )
+
+    assert holding(report, "DST") == (Decimal(12), Decimal("36.00"))
+    assert holding(report, "SRCNEW") == (Decimal(12), Decimal("108.00"))
+
+
+@pytest.mark.parametrize("spelling", ["B", "BNEW"], ids=["old", "new"])
+def test_a_renamed_holding_cannot_spin_off_before_it_is_created(
+    spelling: str,
+) -> None:
+    """An out-of-order chain is refused whichever name its rows use.
+
+    `B` spins off `C` and is itself spun off from `A` the same day, listed the
+    wrong way round, so `C` was worked out on `B` before `B` had `A`'s shares.
+    Spelling the second row `B` while the first had already recorded `BNEW`
+    used to hide the clash, and the day was computed with `C` carrying £66.67
+    where the required order gives about £46.67.
+    """
+    with pytest.raises(CalculationError, match="List the spin-off that creates"):
+        run(
+            [
+                transaction(BUY_DAY, ActionType.BUY, "A", 10, 10, 0, -100, GBP),
+                transaction(BUY_DAY, ActionType.BUY, "B", 10, 20, 0, -200, GBP),
+                rename_row("B", "BNEW"),
+                spin_off_row("C", 10),
+                spin_off_row(spelling, 10),
+            ],
+            "A",
+            _priced(A=90, B=90, BNEW=90, C=10),
+            sources={"C": "B", "B": "A", "BNEW": "A"},
+        )
+
+
+def test_a_spin_offs_file_naming_a_holding_as_its_own_source_says_so() -> None:
+    """No rename happened, so the refusal must not claim one did."""
+    with pytest.raises(CalculationError) as excinfo:
+        run(
+            [
+                transaction(BUY_DAY, ActionType.BUY, "SRC", 12, 12, 0, -144, GBP),
+                spin_off_row("SRC", 12),
+            ],
+            "SRC",
+            sources={"SRC": "SRC"},
+        )
+
+    assert "the spin-offs file gives SRC itself" in str(excinfo.value)
+    assert "renames" not in str(excinfo.value)
+
+
+@RENAME_FIRST
+def test_a_chain_of_spin_offs_across_a_rename_keeps_its_order(
+    *, rename_first: bool
+) -> None:
+    """`A` hands shares to `B`, which is renamed and hands some to `C`.
+
+    `B` must be complete before it is apportioned, and the rename leaves its
+    two spin-off rows naming it differently, so the order they are worked out
+    in cannot be read from the spellings alone.
+    """
+    rename = rename_row("B", "BNEW")
+    rows = [spin_off_row("B", 10), spin_off_row("C", 10)]
+    rows.insert(0 if rename_first else 1, rename)
+    report = run(
+        [
+            transaction(BUY_DAY, ActionType.BUY, "A", 10, 10, 0, -100, GBP),
+            *rows,
+        ],
+        "A",
+        _priced(A=90, B=10, BNEW=10, C=10),
+        sources={"B": "A", "BNEW": "A", "C": "B"},
+    )
+
+    # A is worth nine times what it hands over, so £10 of its £100 goes to B.
+    # B and C are worth the same, so B then halves what it has with C.
+    assert holding(report, "A") == (Decimal(10), Decimal(90))
+    assert holding(report, "BNEW") == (Decimal(10), Decimal(5))
+    assert holding(report, "C") == (Decimal(10), Decimal(5))
+
+
+@pytest.mark.parametrize("spelling", ["SRCOLD", "SRC"], ids=["old", "new"])
+@pytest.mark.parametrize("rename_first", [True, False], ids=["renames first", "last"])
+def test_two_prices_for_a_source_that_merges_with_its_new_holding_are_refused(
+    spelling: str, *, rename_first: bool
+) -> None:
+    """The source's own two names disagree, and the merge must not hide it.
+
+    `SRCOLD` becomes `SRC` and the new `DST` shares are renamed into `SRC` too,
+    so by the day's close everything is one holding. That must not stop the
+    source's own £75 and £60 being read as the contradiction they are: which
+    was used decided whether `DST` carried £36.00 or £42.35.
+    """
+    renames = [rename_row("SRCOLD", "SRC"), rename_row("DST", "SRC")]
+    spin = spin_off_row("DST", 12)
+    with pytest.raises(CalculationError, match="neither holding's own"):
+        run(
+            [
+                transaction(BUY_DAY, ActionType.BUY, "SRCOLD", 12, 12, 0, -144, GBP),
+                *([*renames, spin] if rename_first else [spin, *renames]),
+            ],
+            spelling,
+            _priced(SRCOLD=75, SRC=60, DST=25),
+            sources={"DST": spelling},
+        )
+
+
+@pytest.mark.parametrize("spelling", ["DSTOLD", "DST"], ids=["old", "new"])
+def test_a_third_price_in_a_merged_reorganisation_is_refused(spelling: str) -> None:
+    """A price belonging to neither end of the reorganisation settles nothing.
+
+    Both `DSTOLD` and `DST` are renamed into `SRC`, so the whole day closes
+    under one name. Whichever of them the spin-off row states, the other is
+    priced too, and nothing says whether that £25 or £40 prices the shares the
+    reorganisation came from or the ones it created.
+    """
+    with pytest.raises(CalculationError, match="neither holding's own"):
+        run(
+            [
+                transaction(BUY_DAY, ActionType.BUY, "SRC", 12, 12, 0, -144, GBP),
+                spin_off_row(spelling, 12),
+                rename_row("DSTOLD", "SRC"),
+                rename_row("DST", "SRC"),
+            ],
+            "SRC",
+            _priced(SRC=75, DSTOLD=25, DST=40),
+            sources={"DSTOLD": "SRC", "DST": "SRC"},
+        )
+
+
+def test_two_spin_offs_into_one_renamed_destination_are_two_events() -> None:
+    """Two holdings can each spin something off into one merged destination.
+
+    `A` hands 10 shares to `DST` and `B` hands 20 to `DSTNEW`, and the day's
+    rename makes those one holding. They are two reorganisations, each settled
+    against its own source, and only pooled together at the day's close.
+    """
+    report = run(
+        [
+            transaction(BUY_DAY, ActionType.BUY, "A", 10, 10, 0, -100, GBP),
+            transaction(BUY_DAY, ActionType.BUY, "B", 20, 20, 0, -400, GBP),
+            spin_off_row("DST", 10),
+            spin_off_row("DSTNEW", 20),
+            rename_row("DST", "DSTNEW"),
+        ],
+        "A",
+        _priced(A=90, B=80, DST=10, DSTNEW=10),
+        sources={"DST": "A", "DSTNEW": "B"},
+    )
+
+    assert holding(report, "A") == (Decimal(10), Decimal("90.00"))
+    assert holding(report, "B") == (Decimal(20), Decimal("355.56"))
+    assert holding(report, "DSTNEW") == (Decimal(30), Decimal("54.44"))
+
+
+def test_a_third_price_matching_one_end_is_refused_all_the_same() -> None:
+    """A price that agrees with one end is not thereby that end's price.
+
+    `SRCOLD` becomes `SRC`, and the new `DST` shares are renamed into `SRC`
+    too, so all three end the day as one holding. `SRC` is priced at £25, the
+    same as `DST`. Matching says only that those two do not contradict each
+    other: `SRC` is the source's closing name as much as the destination's,
+    and the source is priced at £75, so the day still has no settled value
+    for either end.
+    """
+    with pytest.raises(CalculationError, match="neither holding's own"):
+        run(
+            [
+                transaction(BUY_DAY, ActionType.BUY, "SRCOLD", 12, 12, 0, -144, GBP),
+                spin_off_row("DST", 12),
+                rename_row("SRCOLD", "SRC"),
+                rename_row("DST", "SRC"),
+            ],
+            "SRCOLD",
+            _priced(SRCOLD=75, SRC=25, DST=25),
+            sources={"DST": "SRCOLD"},
+        )
+
+
+@pytest.mark.parametrize("spelling", ["DSTOLD", "DST"], ids=["old", "new"])
+def test_a_destination_sibling_priced_differently_is_refused(spelling: str) -> None:
+    """Two names that merge into one are one holding, at one price.
+
+    `DSTOLD` and `DST` both become `SRC`, and `DST` is priced at £40, the same
+    as `SRC`. Agreeing with the source's price does not make it the source's:
+    `DST` is a name of the holding the shares arrived in, priced against
+    `DSTOLD`'s £25, and which of the two the row happened to state decided
+    what the reorganisation carried across.
+    """
+    with pytest.raises(CalculationError, match="neither holding's own"):
+        run(
+            [
+                transaction(BUY_DAY, ActionType.BUY, "SRC", 12, 12, 0, -144, GBP),
+                spin_off_row(spelling, 12),
+                rename_row("DSTOLD", "SRC"),
+                rename_row("DST", "SRC"),
+            ],
+            "SRC",
+            _priced(SRC=40, DSTOLD=25, DST=40),
+            sources={"DSTOLD": "SRC", "DST": "SRC"},
+        )
+
+
+@pytest.mark.parametrize("spelling", ["DSTOLD", "DST"], ids=["old", "new"])
+def test_destination_siblings_merging_away_from_the_source_are_one_holding(
+    spelling: str,
+) -> None:
+    """The same, where the merged name is neither end's.
+
+    `DSTOLD` and `DST` become `DSTNEW`, which the source is no part of, so
+    the two ends stay separate holdings all day. The received shares are still
+    spelled two ways and priced two ways, and one of them has to be wrong.
+    """
+    with pytest.raises(CalculationError, match="priced differently"):
+        run(
+            [
+                transaction(BUY_DAY, ActionType.BUY, "SRC", 12, 12, 0, -144, GBP),
+                spin_off_row(spelling, 12),
+                rename_row("DSTOLD", "DSTNEW"),
+                rename_row("DST", "DSTNEW"),
+            ],
+            "SRC",
+            _priced(SRC=75, DSTOLD=25, DST=40),
+            sources={"DSTOLD": "SRC", "DST": "SRC"},
+        )
+
+
+ROW_ORDERS = pytest.mark.parametrize(
+    "order", list(itertools.permutations(range(3))), ids=lambda o: "".join(map(str, o))
+)
+
+
+def _ordered(
+    rows: list[BrokerTransaction], order: tuple[int, ...]
+) -> list[BrokerTransaction]:
+    """Return the day's rows in one of the orders an export might list them."""
+    return [rows[position] for position in order]
+
+
+@ROW_ORDERS
+def test_a_uniformly_priced_merge_computes(order: tuple[int, ...]) -> None:
+    """One price for the whole day settles it, so there is nothing to refuse.
+
+    `SRCOLD` and the new `DST` shares both become `SRC`, and all three names
+    are priced at £40. Whichever of them a figure is read as, the two ends are
+    worth the same, so the cost splits down the middle and the rename puts both
+    halves back together.
+    """
+    rows = [
+        rename_row("SRCOLD", "SRC"),
+        rename_row("DST", "SRC"),
+        spin_off_row("DST", 12),
+    ]
+    report = run(
+        [
+            transaction(BUY_DAY, ActionType.BUY, "SRCOLD", 12, 12, 0, -144, GBP),
+            *_ordered(rows, order),
+        ],
+        "SRCOLD",
+        _priced(SRCOLD=40, SRC=40, DST=40),
+        sources={"DST": "SRCOLD"},
+    )
+
+    assert holding(report, "SRC") == (Decimal(24), Decimal(144))
+
+
+@ROW_ORDERS
+def test_a_uniformly_priced_merge_of_unequal_sides_computes(
+    order: tuple[int, ...],
+) -> None:
+    """One price does not mean an even split: the counts still differ.
+
+    Twenty shares costing £280 hand seven to the new holding, all priced at
+    £40, so the value splits 800 to 280 and the cost with it.
+    """
+    rows = [
+        rename_row("SRCOLD", "SRC"),
+        rename_row("DST", "SRC"),
+        spin_off_row("DST", 7),
+    ]
+    report = run(
+        [
+            transaction(BUY_DAY, ActionType.BUY, "SRCOLD", 20, 14, 0, -280, GBP),
+            *_ordered(rows, order),
+        ],
+        "SRCOLD",
+        _priced(SRCOLD=40, SRC=40, DST=40),
+        sources={"DST": "SRCOLD"},
+    )
+
+    (entry,) = report.calculation_log[DAY]["buy$DST"]
+    assert round_decimal(entry.allowable_cost, 2) == Decimal("72.59")
+    assert holding(report, "SRC") == (Decimal(27), Decimal(280))
+
+
+def test_a_third_price_against_agreeing_ends_is_still_refused() -> None:
+    """Ends that agree do not make every other figure safe.
+
+    `SRCOLD` and `DST` are both worth £40, but `SRC`, which the day's renames
+    make of both of them, is priced at £25. That is a second valuation of the
+    day, and which end it belongs to still decides how the cost splits.
+    """
+    with pytest.raises(CalculationError, match="neither holding's own"):
+        run(
+            [
+                transaction(BUY_DAY, ActionType.BUY, "SRCOLD", 12, 12, 0, -144, GBP),
+                spin_off_row("DST", 12),
+                rename_row("SRCOLD", "SRC"),
+                rename_row("DST", "SRC"),
+            ],
+            "SRCOLD",
+            _priced(SRCOLD=40, SRC=25, DST=40),
+            sources={"DST": "SRCOLD"},
+        )


### PR DESCRIPTION
A day can both rename a ticker and spin a holding off it. A rename says the two tickers are one holding, but the spin-off code still read pool, price, and event identity from whichever literal spelling a row happened to use - so the result depended on ticker spelling and row order rather than the facts.

Example: `SRC` spins off `DST` and is also renamed to `SRCNEW` the same day. Naming the source as `SRC` with the RENAME row first refused ("SRC held no shares"); naming it `SRCNEW` with the RENAME row first computed a figure. Four spellings of one day, two different outcomes.

Renames are now resolved before any row is read, and every place that used a literal ticker now resolves it across the day's rename graph instead:

- **Pool and price**: the spin-off's source and destination are each priced under a name that doesn't move with the RENAME row. Two disagreeing prices for one end (or an unattributable third price) now refuse rather than picking one by spelling.
- **Event grouping**: a multi-row spin-off (shares split across brokers) is grouped by holding, not by spelling, so a RENAME row landing between two of its rows no longer splits it into two events.
- **Dependency order**: the refusal for a holding that spins something off before receiving its own shares now compares holdings, not literal names, so an alias spelling can no longer hide that clash.
- **The new holding's own pool**: a spin-off's shares land under the ticker its row spelled, but a rename only merges names together after the day's disposals have already priced themselves. A same-day sale of the new holding used to price itself against whatever that one name held on its own - understating the gain if other shares were held elsewhere, or crashing with a division error if none were. A disposal now gathers the day's reorganisation shares from every name the renames give the holding before pricing itself, without touching what the day genuinely bought.

Separately, a spin-off on a day used to disable that day's whole rename handling, wrongly rejecting an unrelated sale elsewhere in the file - a spin-off only changes the ticker it names, so it no longer disables handling for holdings it can't touch.

Limits: two spin-off rows into two *different* destination spellings still refuse (their acquisition records can't be united); a source renamed to the very ticker its own spin-off creates still refuses (that ticker would need two prices at once).
