### PR TITLE
Recognise the Schwab `NRA Withhold` action instead of stopping the import

### DIFF
--- a/cgt_calc/parsers/schwab.py
+++ b/cgt_calc/parsers/schwab.py
@@ -187,7 +187,12 @@ def action_from_str(label: str, file: Path) -> ActionType:
     }:
         return ActionType.DIVIDEND
 
-    if label in {"NRA Tax Adj", "NRA Withholding", "Foreign Tax Paid"}:
+    if label in {
+        "NRA Tax Adj",
+        "NRA Withholding",
+        "NRA Withhold",
+        "Foreign Tax Paid",
+    }:
         return ActionType.DIVIDEND_TAX
 
     if label == "ADR Mgmt Fee":

--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -297,6 +297,7 @@ def action_from_str(label: str, file: Path) -> ActionType:
     if label in {
         "NRA Tax Adj",
         "NRA Withholding",
+        "NRA Withhold",
         "Foreign Tax Paid",
         "Tax Reversal",
         "Tax Withholding",

--- a/docs/brokers/schwab.md
+++ b/docs/brokers/schwab.md
@@ -97,37 +97,37 @@ cgt-calc --year 2025 \
 
 The importer recognises these exact values from the main CSV's `Action` column:
 
-| Exported action                                                    | How cgt-calc handles it                                                             |
-| ------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
-| `Buy`, `Sell`                                                      | A purchase or disposal, including `Fees & Comm`                                     |
-| `Cancel Buy`                                                       | Removes the cancellation and the matching `Buy`                                     |
-| `Stock Plan Activity`                                              | An employer-share acquisition at the exported or Equity Awards price; no cash moves |
-| `Qualified Dividend`, `Cash Dividend`, `Qual Div Reinvest`         | Dividend income                                                                     |
-| `Div Adjustment`, `Special Qual Div`, `Non-Qualified Div`          | Dividend income                                                                     |
-| `NRA Tax Adj`, `NRA Withholding`, `Foreign Tax Paid`               | Tax deducted from a dividend                                                        |
-| `Credit Interest`, `Bond Interest`                                 | Interest income                                                                     |
-| `Short Term Cap Gain`, `Long Term Cap Gain`                        | A fund distribution reported with dividend income                                   |
-| `ADR Mgmt Fee`                                                     | A charge added to the holding's pooled cost and deducted from cash                  |
-| `Adjustment`, `IRS Withhold Adj`, `Wire Funds Adj`                 | A cash-balance correction                                                           |
-| `MoneyLink Transfer`, `MoneyLink Deposit`, `MoneyLink Adj`         | A cash movement only                                                                |
-| `Wire Funds`, `Wire Sent`, `Wire Funds Received`, `Funds Received` | A cash movement only                                                                |
-| `Misc Cash Entry`, `Service Fee`, `Journal`, `Cash In Lieu`        | A cash movement only                                                                |
-| `Visa Purchase`                                                    | A cash movement only                                                                |
-| `Security Transfer`                                                | An `ACH`-related cash movement; an `Amount` is required and no holding is moved     |
-| `Reinvest Shares`                                                  | A purchase of the reinvested shares                                                 |
-| `Reinvest Dividend`                                                | Unsupported; the row is ignored and cgt-calc prints a warning                       |
-| `Stock Split`                                                      | A share reorganisation: the pooled cost is unchanged and spread over the new count  |
-| `Spin-off`                                                         | Adds the new holding and moves part of the old holding's pooled cost to it          |
-| `Cash Merger` followed by `Cash Merger Adj`                        | A disposal for cash, built from the adjacent amount and quantity rows               |
-| `Full Redemption Adj` followed by `Full Redemption`                | A disposal for cash, built from the adjacent amount and quantity rows               |
-| `Sell to Open`                                                     | Writing an equity option: a disposal of the option on the grant date                |
-| `Buy to Close`                                                     | Closing a written option: an allowable cost of the original grant                   |
-| `Expired`                                                          | A written option that lapsed; the grant keeps the premium as its gain               |
-| `Assigned`                                                         | A written option that was assigned; the premium moves into the share transaction    |
+| Exported action                                                      | How cgt-calc handles it                                                             |
+| -------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `Buy`, `Sell`                                                        | A purchase or disposal, including `Fees & Comm`                                     |
+| `Cancel Buy`                                                         | Removes the cancellation and the matching `Buy`                                     |
+| `Stock Plan Activity`                                                | An employer-share acquisition at the exported or Equity Awards price; no cash moves |
+| `Qualified Dividend`, `Cash Dividend`, `Qual Div Reinvest`           | Dividend income                                                                     |
+| `Div Adjustment`, `Special Qual Div`, `Non-Qualified Div`            | Dividend income                                                                     |
+| `NRA Tax Adj`, `NRA Withholding`, `NRA Withhold`, `Foreign Tax Paid` | Tax deducted from a dividend                                                        |
+| `Credit Interest`, `Bond Interest`                                   | Interest income                                                                     |
+| `Short Term Cap Gain`, `Long Term Cap Gain`                          | A fund distribution reported with dividend income                                   |
+| `ADR Mgmt Fee`                                                       | A charge added to the holding's pooled cost and deducted from cash                  |
+| `Adjustment`, `IRS Withhold Adj`, `Wire Funds Adj`                   | A cash-balance correction                                                           |
+| `MoneyLink Transfer`, `MoneyLink Deposit`, `MoneyLink Adj`           | A cash movement only                                                                |
+| `Wire Funds`, `Wire Sent`, `Wire Funds Received`, `Funds Received`   | A cash movement only                                                                |
+| `Misc Cash Entry`, `Service Fee`, `Journal`, `Cash In Lieu`          | A cash movement only                                                                |
+| `Visa Purchase`                                                      | A cash movement only                                                                |
+| `Security Transfer`                                                  | An `ACH`-related cash movement; an `Amount` is required and no holding is moved     |
+| `Reinvest Shares`                                                    | A purchase of the reinvested shares                                                 |
+| `Reinvest Dividend`                                                  | Unsupported; the row is ignored and cgt-calc prints a warning                       |
+| `Stock Split`                                                        | A share reorganisation: the pooled cost is unchanged and spread over the new count  |
+| `Spin-off`                                                           | Adds the new holding and moves part of the old holding's pooled cost to it          |
+| `Cash Merger` followed by `Cash Merger Adj`                          | A disposal for cash, built from the adjacent amount and quantity rows               |
+| `Full Redemption Adj` followed by `Full Redemption`                  | A disposal for cash, built from the adjacent amount and quantity rows               |
+| `Sell to Open`                                                       | Writing an equity option: a disposal of the option on the grant date                |
+| `Buy to Close`                                                       | Closing a written option: an allowable cost of the original grant                   |
+| `Expired`                                                            | A written option that lapsed; the grant keeps the premium as its gain               |
+| `Assigned`                                                           | A written option that was assigned; the premium moves into the share transaction    |
 
-An `NRA Tax Adj`, `NRA Withholding` or `Foreign Tax Paid` row is treated as tax on account interest
-only when its `Symbol` is blank and its `Description` contains `SCHWAB1 INT`. Otherwise, it is
-treated as dividend tax.
+An `NRA Tax Adj`, `NRA Withholding`, `NRA Withhold` or `Foreign Tax Paid` row is treated as tax on
+account interest only when its `Symbol` is blank and its `Description` contains `SCHWAB1 INT`.
+Otherwise, it is treated as dividend tax.
 
 For `Reinvest Dividend`, check the Schwab statement and the finished report. Confirm that the
 dividend income and reinvested purchase were recorded by other rows; do not assume the ignored row

--- a/tests/schwab/test_schwab.py
+++ b/tests/schwab/test_schwab.py
@@ -328,6 +328,7 @@ def _read(content: str) -> list[BrokerTransaction]:
         ("Non-Qualified Div", ActionType.DIVIDEND),
         ("NRA Tax Adj", ActionType.DIVIDEND_TAX),
         ("NRA Withholding", ActionType.DIVIDEND_TAX),
+        ("NRA Withhold", ActionType.DIVIDEND_TAX),
         ("Foreign Tax Paid", ActionType.DIVIDEND_TAX),
         ("ADR Mgmt Fee", ActionType.FEE),
         ("Adjustment", ActionType.ADJUSTMENT),

--- a/tests/schwab/test_schwab_equity_award_json.py
+++ b/tests/schwab/test_schwab_equity_award_json.py
@@ -284,6 +284,7 @@ def test_split_history_demands_a_price_floor_it_can_use() -> None:
         ("Stock Plan Activity", ActionType.STOCK_ACTIVITY),
         ("NRA Tax Adj", ActionType.DIVIDEND_TAX),
         ("NRA Withholding", ActionType.DIVIDEND_TAX),
+        ("NRA Withhold", ActionType.DIVIDEND_TAX),
         ("Foreign Tax Paid", ActionType.DIVIDEND_TAX),
         ("Tax Reversal", ActionType.DIVIDEND_TAX),
         ("Tax Withholding", ActionType.DIVIDEND_TAX),

--- a/tests/schwab/test_schwab_nra_withhold.py
+++ b/tests/schwab/test_schwab_nra_withhold.py
@@ -1,0 +1,151 @@
+"""Tests for the Schwab `NRA Withhold` action.
+
+Schwab writes non-resident-alien withholding on a dividend under several
+labels. `NRA Withhold` is one of them, and until it was recognised a single
+such row stopped the whole import.
+"""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cgt_calc.currency_converter import CurrencyConverter
+from cgt_calc.current_price_fetcher import CurrentPriceFetcher
+from cgt_calc.exceptions import CalculationError
+from cgt_calc.initial_prices import InitialPrices
+from cgt_calc.isin_converter import IsinConverter
+from cgt_calc.main import CapitalGainsCalculator
+from cgt_calc.model import ActionType, CurrencyCode
+from cgt_calc.parsers.schwab import SchwabParser
+from cgt_calc.spin_off_handler import SpinOffHandler
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+HEADER = "Date,Action,Symbol,Description,Price,Quantity,Fees & Comm,Amount\n"
+DIVIDEND_DATE = datetime.date(2024, 6, 27)
+REVERSAL_DATE = datetime.date(2024, 7, 5)
+
+
+def build_calculator(*, balance_check: bool) -> CapitalGainsCalculator:
+    """Build a calculator whose rates need no exchange-rate lookup."""
+    currency_converter = CurrencyConverter(
+        None,
+        {
+            DIVIDEND_DATE: {CurrencyCode("USD"): Decimal(1)},
+            REVERSAL_DATE: {CurrencyCode("USD"): Decimal(1)},
+        },
+    )
+    return CapitalGainsCalculator(
+        2024,
+        currency_converter,
+        IsinConverter(),
+        CurrentPriceFetcher(currency_converter, {}, {}),
+        SpinOffHandler(),
+        InitialPrices(),
+        interest_fund_tickers=[],
+        balance_check=balance_check,
+    )
+
+
+def write_transactions(tmp_path: Path, *rows: str) -> Path:
+    """Write a main transaction CSV holding the given rows."""
+    csv_path = tmp_path / "transactions.csv"
+    csv_path.write_text(HEADER + "".join(rows), encoding="utf-8")
+    return csv_path
+
+
+def tax_at_source(tmp_path: Path, *rows: str) -> Decimal:
+    """Return the tax attributed to the single dividend in these rows."""
+    calculator = build_calculator(balance_check=False)
+    calculator.prepare_history(
+        list(SchwabParser.load_from_file(write_transactions(tmp_path, *rows)))
+    )
+    report = calculator.calculate_capital_gain()
+    dividends = [
+        entry.dividend
+        for day in report.calculation_log_yields.values()
+        for entries in day.values()
+        for entry in entries
+        if entry.dividend is not None
+    ]
+    assert len(dividends) == 1
+    return dividends[0].tax_at_source
+
+
+def test_nra_withhold_is_dividend_tax(tmp_path: Path) -> None:
+    """A row Schwab labels `NRA Withhold` is withholding on a dividend."""
+    transactions = SchwabParser.load_from_file(
+        write_transactions(tmp_path, "06/27/2024,NRA Withhold,FOO,FOO INC,,,,$-1.50\n")
+    )
+
+    assert len(transactions) == 1
+    assert transactions[0].action is ActionType.DIVIDEND_TAX
+    assert transactions[0].amount == Decimal("-1.50")
+
+
+def test_nra_withhold_is_deducted_from_the_dividend(tmp_path: Path) -> None:
+    """The withheld amount is attributed to the payment it was taken from."""
+    assert tax_at_source(
+        tmp_path,
+        "06/27/2024,Cash Dividend,FOO,FOO INC,,,,$10.00\n",
+        "06/27/2024,NRA Withhold,FOO,FOO INC,,,,$-1.50\n",
+    ) == Decimal("-1.50")
+
+
+def test_positive_nra_withhold_nets_against_the_earlier_deduction(
+    tmp_path: Path,
+) -> None:
+    """A later positive row returns part of the tax, as `NRA Tax Adj` does.
+
+    The sign carries the meaning for every label in this set, so a reversal
+    needs no special handling: it leaves the difference as the tax paid.
+
+    The reversal is dated well inside `DIVIDEND_TAX_MATCH_DAYS` of the
+    payment. Outside that window nothing nets, because no single payment can
+    be shown to be the one the tax came from.
+    """
+    assert tax_at_source(
+        tmp_path,
+        "06/27/2024,Cash Dividend,FOO,FOO INC,,,,$10.00\n",
+        "06/27/2024,NRA Withhold,FOO,FOO INC,,,,$-1.50\n",
+        "07/05/2024,NRA Withhold,FOO,FOO INC,,,,$0.50\n",
+    ) == Decimal("-1.00")
+
+
+def test_nra_withhold_reduces_the_cash_balance(tmp_path: Path) -> None:
+    """Withholding takes cash out of the account, so an unfunded one overdraws."""
+    calculator = build_calculator(balance_check=True)
+
+    with pytest.raises(CalculationError, match="Reached a negative balance"):
+        calculator.prepare_history(
+            list(
+                SchwabParser.load_from_file(
+                    write_transactions(
+                        tmp_path, "06/27/2024,NRA Withhold,FOO,FOO INC,,,,$-1.50\n"
+                    )
+                )
+            )
+        )
+
+
+def test_account_interest_withholding_still_bypasses_dividends(
+    tmp_path: Path,
+) -> None:
+    """The `SCHWAB1 INT` reroute covers this label like the other three.
+
+    Withholding on account cash interest states no symbol, so it is interest
+    tax and never looks for a dividend to attach to.
+    """
+    transactions = SchwabParser.load_from_file(
+        write_transactions(
+            tmp_path, "06/27/2024,NRA Withhold,,SCHWAB1 INT 05/30-06/26,,,,$-0.88\n"
+        )
+    )
+
+    assert len(transactions) == 1
+    assert transactions[0].action is ActionType.INTEREST_TAX


### PR DESCRIPTION
A Schwab main transaction CSV holding a single `NRA Withhold` row stops the whole import:

```
While parsing transactions.csv, row 8: Unknown action: 'NRA Withhold'
```

Nothing is calculated. The reader knows `NRA Tax Adj`, `NRA Withholding` and `Foreign Tax Paid` but not this spelling, so one row of it makes years of history uncalculable, and there is no way round it short of editing the export by hand.

`NRA Withhold` records the same event as `NRA Withholding`: non-resident-alien withholding on a dividend. The row moves cash and no shares, and it names the symbol the dividend was paid on. It now joins the other three in the set of actions read as tax deducted from a dividend, in both the main CSV reader and the Equity Awards JSON reader.

The amount is carried through with the sign the export states, as it already is for `NRA Tax Adj`: a negative amount is tax withheld, and a positive one nets against earlier withholding on the same symbol. Netting follows the rule cgt-calc already applies to every withholding row, which this PR does not change. A row dated on a dividend belongs to that dividend. Otherwise it needs exactly one dividend of the same broker and symbol in the 30 days before it or the 5 days after; where none is in range, or two are, cgt-calc warns and leaves the amount out of the dividend report rather than guess which payment it belongs to. A reversal posted more than 30 days after its payment is therefore either left out of the dividend report, leaving the withholding it corrects unreduced, or netted against a different dividend that happens to be in range, because nothing in the export marks it as a reversal. Narrowing that by telling a reversal from an ordinary withholding is #1003.

Adding the label to the Equity Awards JSON reader is for consistency with the other three rather than from evidence: no Equity Awards export carrying it is on record.
