### PR TITLE
Read a spin-off's prices under either name a rename gives a holding

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -251,6 +251,7 @@ ty
 tzinfo
 UCITS
 un
+unattributable
 unmapped
 unpriced
 unprovable

--- a/.harper-ignore.txt
+++ b/.harper-ignore.txt
@@ -45,6 +45,9 @@
 ^model\.py:.*Everyone
 # "every one of those decisions" is two words; the Everyone rule misfires.
 ^report_view\.py:.*Everyone
+# "every one of them is claimed by both ends" counts the names one at a time;
+# the Everyone rule misfires.
+^ingestion\.py:.*Everyone
 # "how many candidates there are" is correct; ThereIsAgreement expects the noun
 # after the verb, but this construction puts it first.
 ^trading212\.py:.*ThereIsAgreement

--- a/cgt_calc/ingestion.py
+++ b/cgt_calc/ingestion.py
@@ -373,6 +373,40 @@ class TransactionIngester:
             + f"{symbol} out by hand (consider professional advice)."
         )
 
+    def _end_price(
+        self, symbol: str, date_index: datetime.date, *, other_end: str
+    ) -> Decimal:
+        """Return what one end of a reorganisation was worth on the day.
+
+        A day may rename this end, so the price the run was given can sit
+        under its other name. The two are one security with one market value,
+        so either name answers. Asking only under the spelling this end is
+        recorded by would send the run looking the price up instead, under a
+        ticker the market need not carry at all - or worse, one it carries for
+        somebody else's holding.
+
+        The other end's names are not this end's, the same exclusion
+        `_refuse_disagreeing_alias` makes. Where the day's renames leave both
+        ends under one name, this end has no other name of its own: every one
+        of them is claimed by both ends, which is what
+        `_refuse_unattributable_price` refuses. Only the end's own spelling
+        answers there.
+
+        Two names disagreeing is still refused, not resolved here. That
+        check measures the end's other names against the price this returns,
+        so the end's own name answers first: return another's and the end's
+        own price becomes the one nothing reads, and the disagreement passes.
+        A holding none of whose names was priced is looked up as before.
+        """
+        renames = self.history.rename_list.get(date_index, {})
+        own = connected_names(renames, symbol)
+        aliases = () if other_end in own else sorted(own - {symbol})
+        for name in (symbol, *aliases):
+            known = self.price_fetcher.known_closing_price(name, date_index)
+            if known is not None:
+                return known
+        return self.price_fetcher.get_closing_price(symbol, date_index)
+
     def _refuse_disagreeing_alias(
         self,
         symbol: str,
@@ -641,8 +675,8 @@ class TransactionIngester:
         # holding it creates. Reading a price under a name that depends on
         # where the RENAME row landed would let the export's layout decide
         # how much cost carries across.
-        dst_price = self.price_fetcher.get_closing_price(symbol, transaction.date)
-        src_price = self.price_fetcher.get_closing_price(recorded, transaction.date)
+        dst_price = self._end_price(symbol, transaction.date, other_end=recorded)
+        src_price = self._end_price(recorded, transaction.date, other_end=symbol)
         # The wider question first, so that a day whose two ends close under
         # one name is refused for that rather than for whichever of its names
         # happened to be compared.

--- a/tests/general/test_rename_spin_off.py
+++ b/tests/general/test_rename_spin_off.py
@@ -17,12 +17,13 @@ import datetime
 from decimal import Decimal
 import itertools
 
+import pandas as pd
 import pytest
 
 from cgt_calc.const import RENAME_DESCRIPTION_PREFIX
 from cgt_calc.currency_converter import CurrencyConverter
 from cgt_calc.current_price_fetcher import CurrentPriceFetcher
-from cgt_calc.exceptions import CalculationError
+from cgt_calc.exceptions import CalculationError, MarketDataMissingError
 from cgt_calc.initial_prices import InitialPrices
 from cgt_calc.isin_converter import IsinConverter
 from cgt_calc.main import CapitalGainsCalculator
@@ -717,5 +718,143 @@ def test_a_third_price_against_agreeing_ends_is_still_refused() -> None:
             ],
             "SRCOLD",
             _priced(SRCOLD=40, SRC=25, DST=40),
+            sources={"DST": "SRCOLD"},
+        )
+
+
+class _NoMarketData:
+    """Stand-in for `yf.Ticker` with no price history for any day."""
+
+    def history(self, **kwargs: str) -> pd.DataFrame:
+        """Return an empty price history."""
+        return pd.DataFrame()
+
+
+@pytest.fixture
+def unlisted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every price the run was not given fail rather than be looked up."""
+    monkeypatch.setattr(
+        "cgt_calc.current_price_fetcher.yf.Ticker", lambda symbol: _NoMarketData()
+    )
+
+
+@pytest.mark.parametrize("priced", ["SRC", "SRCNEW"], ids=["old", "new"])
+@RENAME_FIRST
+@pytest.mark.usefixtures("unlisted")
+def test_a_source_priced_under_its_other_name_keeps_that_price(
+    priced: str, *, rename_first: bool
+) -> None:
+    """One of a holding's two names carrying its price prices the holding.
+
+    The day's renames say `SRC` and `SRCNEW` are one security, so they have
+    one market value between them, and the spin-offs file's spelling is not
+    the one it has to be given under. Where the file named the other, the run
+    used to go to the market for a ticker nobody had priced and stop for want
+    of market data - or, worse, come back with the price of a real holding
+    that happened to share the name.
+    """
+    rename = rename_row("SRC", "SRCNEW")
+    spin = spin_off_row("DST")
+    report = run(
+        [
+            transaction(BUY_DAY, ActionType.BUY, "SRC", 10, 10, 0, -100, GBP),
+            *([rename, spin] if rename_first else [spin, rename]),
+        ],
+        "SRCNEW" if priced == "SRC" else "SRC",
+        _priced(**{priced: 90, "DST": 10}),
+    )
+
+    (entry,) = report.calculation_log[DAY]["buy$DST"]
+    assert entry.allowable_cost == Decimal(10)
+    assert holding(report, "SRCNEW") == (Decimal(10), Decimal(90))
+
+
+@pytest.mark.parametrize("priced", ["DST", "DSTNEW"], ids=["old", "new"])
+@RENAME_FIRST
+@pytest.mark.usefixtures("unlisted")
+def test_a_destination_priced_under_its_other_name_keeps_that_price(
+    priced: str, *, rename_first: bool
+) -> None:
+    """The same, for the holding the shares arrive in.
+
+    Its own name is the spin-off row's, and the day renames it, so the price
+    can as easily have been given under the other spelling.
+    """
+    rename = rename_row("DST", "DSTNEW")
+    spin = spin_off_row("DSTNEW" if priced == "DST" else "DST")
+    report = run(
+        [
+            transaction(BUY_DAY, ActionType.BUY, "SRC", 10, 10, 0, -100, GBP),
+            *([rename, spin] if rename_first else [spin, rename]),
+        ],
+        "SRC",
+        _priced(**{priced: 10, "SRC": 90}),
+    )
+
+    (entry,) = report.calculation_log[DAY][f"buy${spin.symbol}"]
+    assert entry.allowable_cost == Decimal(10)
+    assert holding(report, "DSTNEW") == (Decimal(10), Decimal(10))
+
+
+@pytest.mark.usefixtures("unlisted")
+def test_a_holding_priced_under_none_of_its_names_is_still_looked_up() -> None:
+    """A holding nobody priced is not made up from a name that is.
+
+    `SRC` has two names and neither was priced, so there is nothing to read
+    and the run goes to the market as it always did, saying which ticker it
+    could not price.
+    """
+    with pytest.raises(MarketDataMissingError, match="SRCNEW"):
+        run(
+            [
+                transaction(BUY_DAY, ActionType.BUY, "SRC", 10, 10, 0, -100, GBP),
+                spin_off_row("DST"),
+                rename_row("SRC", "SRCNEW"),
+            ],
+            "SRCNEW",
+            _priced(DST=10),
+        )
+
+
+@pytest.mark.usefixtures("unlisted")
+def test_two_of_a_source_s_other_names_disagreeing_are_refused() -> None:
+    """Reading a price from another name does not excuse it from the check.
+
+    `SRCOLD` and `SRCALT` both become `SRC`, which the spin-offs file names
+    and nobody priced. The two that were priced disagree, £75 against £60,
+    and one holding has one market value on a day.
+    """
+    with pytest.raises(CalculationError, match="priced differently"):
+        run(
+            [
+                transaction(BUY_DAY, ActionType.BUY, "SRCOLD", 12, 12, 0, -144, GBP),
+                spin_off_row("DST", 12),
+                rename_row("SRCOLD", "SRC"),
+                rename_row("SRCALT", "SRC"),
+            ],
+            "SRC",
+            _priced(SRCOLD=75, SRCALT=60, DST=25),
+        )
+
+
+@pytest.mark.usefixtures("unlisted")
+def test_a_merged_day_takes_no_price_from_the_name_it_shares() -> None:
+    """Where both ends close under one name, neither can borrow from it.
+
+    `SRCOLD` becomes `SRC` and the new `DST` shares are renamed into `SRC`
+    too, so `SRC` is claimed by both ends and its £40 says nothing about
+    which. Reading it as the unpriced source's would price that holding at
+    whatever the day's other one was worth.
+    """
+    with pytest.raises(MarketDataMissingError, match="SRCOLD"):
+        run(
+            [
+                transaction(BUY_DAY, ActionType.BUY, "SRCOLD", 12, 12, 0, -144, GBP),
+                spin_off_row("DST", 12),
+                rename_row("SRCOLD", "SRC"),
+                rename_row("DST", "SRC"),
+            ],
+            "SRCOLD",
+            _priced(SRC=40, DST=40),
             sources={"DST": "SRCOLD"},
         )


### PR DESCRIPTION
A day that renames a ticker leaves the holding with two names, and only one of them is written on any given row. Where a price was supplied only under the other one, cgt-calc did not find it - it went to Yahoo Finance for a ticker it had never been priced, and stopped the run.

This applies to prices supplied programmatically to `CurrentPriceFetcher`; the command-line tool has no flag for supplying historical closing prices today (`--initial-prices-file` is a separate mechanism, for stock-plan acquisition cost), so a command-line run still prices each end under its own literal spelling only.

For example:

1. You hold 10 `SRC` costing GBP 100.
2. On 5 July `SRC` is renamed to `SRCNEW`, and the same day spins off 10 `DST`.
3. Your prices give `SRC` GBP 90 and `DST` GBP 10 that day.
4. Your spin-offs file records the source as `SRCNEW`, the name it ends the day under.

The run stopped with "No market data found for SRCNEW around 2024-07-05", although the day's own rename says `SRC` and `SRCNEW` are one security with one market value, and you had given that value. Recording the source as `SRC` instead, or supplying the price under `SRCNEW`, computed fine. The same held for the new holding, whose name comes from the `SPIN_OFF` row rather than from the spin-offs file.

Each end of the reorganisation is now priced from the first of its own names the run was given a price for, and the market is consulted only where none of them carries one. In the example, `DST` takes GBP 10 of the cost and `SRCNEW` keeps GBP 90, whichever name each row uses.

Scope:

- The other end's names never answer for this one. Where the day's renames leave both ends under a single name, neither end has a name of its own: every name in that group is claimed by both, so those days are unchanged, and a price given only for such a name is still not read as either end's.
- Two of a holding's names priced differently are still refused, including where the name a row used carries neither price.
- A holding none of whose names was priced is looked up as before, so a genuinely unpriced ticker still stops the run with the same message.
- No behavior change for command-line runs: with no historical prices supplied, each end is priced exactly as before.
