### PR TITLE
Stop bare assertions ending runs on ordinary purchases and sales

### DIFF
--- a/cgt_calc/matching.py
+++ b/cgt_calc/matching.py
@@ -94,6 +94,21 @@ class DisposalContext:
     calculation_entries: list[CalculationEntry]
 
 
+def _share_of_cost(units: Decimal, quantity: Decimal, amount: Decimal) -> Decimal:
+    """Return what `units` of an acquisition of `quantity` for `amount` cost.
+
+    Multiplied before dividing, to keep the division's rounding error out of
+    the figure. The result is rounded to ten decimal places, and an amount
+    need not sit on that grid, because a conversion out of any other currency
+    leaves a repeating decimal. A part of it rounded up can then come to more
+    than the whole, and no part of an acquisition costs more than all of it,
+    so the whole is also the cap. Claiming all of it costs all of it exactly.
+    """
+    if units == quantity:
+        return amount
+    return min(normalize_amount(units * amount / quantity), amount)
+
+
 class Matcher:
     """Matches disposals against acquisitions across the whole history."""
 
@@ -239,13 +254,16 @@ class Matcher:
         if identifiable.quantity > 0 and has_key(self.run.bnb_list, date_index, symbol):
             bnb_acquisition = self.run.bnb_list[date_index][symbol]
             assert bnb_acquisition.quantity <= identifiable.quantity
-            # Multiply by the B&B quantity before dividing to avoid rounding errors from division
-            bnb_cost_basis = normalize_amount(
-                (bnb_acquisition.quantity * identifiable.amount) / identifiable.quantity
+            bnb_cost_basis = _share_of_cost(
+                bnb_acquisition.quantity, identifiable.quantity, identifiable.amount
             )
             modified_amount -= bnb_cost_basis
             modified_amount += bnb_acquisition.amount
-            assert modified_amount > 0
+            # A repurchase gives up what its own units cost and takes on the
+            # basis the disposal it replaces carried, so shares that cost
+            # nothing leave it holding nothing. Nil is a real cost, not a
+            # broken invariant.
+            assert modified_amount >= 0
             bed_and_breakfast_fees = (
                 identifiable.fees * bnb_acquisition.quantity / identifiable.quantity
             )
@@ -609,12 +627,11 @@ class Matcher:
                     fees = (
                         ctx.disposal.fees * available_quantity / ctx.disposal.quantity
                     )
-                    # Multiply by the consumed quantity before dividing to
-                    # avoid rounding errors from division. Both counts here
-                    # are in the acquisition's own units.
-                    bnb_acquisition_cost = normalize_amount(
-                        (consumed_acquisition_units * acquisition.amount)
-                        / acquisition.quantity
+                    # Both counts here are in the acquisition's own units.
+                    bnb_acquisition_cost = _share_of_cost(
+                        consumed_acquisition_units,
+                        acquisition.quantity,
+                        acquisition.amount,
                     )
                     acquisition_price = bnb_acquisition_cost / available_quantity
                     # No gain/no loss: deemed proceeds equal the allowable cost.
@@ -1926,11 +1943,25 @@ class Matcher:
                             calculated_proceeds += entry.amount + entry.fees
                             calculated_gain += entry.gain
                         assert transaction_quantity == calculated_quantity
-                        assert round_decimal(
-                            transaction_disposal_proceeds, 10
-                        ) == round_decimal(calculated_proceeds, 10), (
-                            f"{transaction_disposal_proceeds} != {calculated_proceeds}"
-                        )
+                        # One side is the amount as recorded, the other is
+                        # rebuilt from the entries' unit prices, so the two
+                        # differ far below the calculator's precision. Rounded
+                        # separately they can land either side of a step, so
+                        # what is measured is the distance between them: less
+                        # than half a ten-decimal-place unit apart and they
+                        # are the same amount.
+                        assert (
+                            round_decimal(
+                                transaction_disposal_proceeds - calculated_proceeds, 10
+                            )
+                            == 0
+                        ), f"{transaction_disposal_proceeds} != {calculated_proceeds}"
+                        # The gain is not the same shape. What is reported has
+                        # already been rounded to the penny, so what is asked
+                        # is whether the raw figure rounds to it. Measuring
+                        # the distance instead would refuse a gain of exactly
+                        # half a penny, which rounds up to a penny and so sits
+                        # half a penny away from what is reported.
                         assert transaction_capital_gain == round_decimal(
                             calculated_gain, 2
                         )

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -595,10 +595,15 @@ class CalculationEntry:
             RuleType.EXCESS_REPORTED_INCOME_DISTRIBUTION,
             RuleType.RENAME,
         }:
-            assert self.gain == self.amount + self.fees - self.allowable_cost, (
-                f"Mismatch: {self.gain} != "
-                f"{self.amount} + {self.fees} - {self.allowable_cost} (for {self})"
-            )
+            # An entry that states a gain has to add up. One that states none
+            # is an acquisition, whose amount is the cost it took on, written
+            # negative. A cost of nothing is written as zero, which the sign
+            # alone reads as proceeds of nothing.
+            if gain is not None:
+                assert self.gain == self.amount + self.fees - self.allowable_cost, (
+                    f"Mismatch: {self.gain} != "
+                    f"{self.amount} + {self.fees} - {self.allowable_cost} (for {self})"
+                )
 
     @override
     def __repr__(self) -> str:

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -880,10 +880,10 @@ def _gbp_trade(
     date: datetime.date,
     action: ActionType,
     symbol: str,
-    quantity: int,
-    amount: int,
+    quantity: Decimal | int,
+    amount: Decimal | int,
 ) -> BrokerTransaction:
-    """Build a whole-pound BUY or SELL of a whole number of shares."""
+    """Build a GBP BUY or SELL, whole numbers or exact decimals."""
     return BrokerTransaction(
         date=date,
         action=action,
@@ -2727,3 +2727,149 @@ def test_calculate_matches_the_two_step_sequence() -> None:
     assert str(combined.calculate(transactions())) == str(
         two_step.calculate_capital_gain()
     )
+
+
+BUY_DAY = datetime.date(2024, 5, 1)
+SELL_DAY = datetime.date(2024, 5, 10)
+REBUY_DAY = datetime.date(2024, 5, 20)
+
+
+def test_a_repurchase_of_shares_that_cost_nothing_computes() -> None:
+    """Shares that cost nothing leave a repurchase holding nothing.
+
+    A repurchase within 30 days of a disposal gives up what its own units
+    cost and takes on the basis the disposal carried. Where the shares sold
+    cost nothing, the two cancel and the pool keeps exactly nothing, which is
+    a real cost rather than a broken invariant. The run used to stop here on a
+    bare assertion with no message.
+    """
+    calculator = create_calculator(tax_year=2024)
+    transactions = [
+        _gbp_trade(BUY_DAY, ActionType.BUY, "FOO", 10, 0),
+        _gbp_trade(SELL_DAY, ActionType.SELL, "FOO", 10, 100),
+        _gbp_trade(REBUY_DAY, ActionType.BUY, "FOO", 10, 50),
+    ]
+
+    report = get_report(calculator, transactions)
+
+    (entry,) = report.calculation_log[SELL_DAY]["sell$FOO"]
+    assert entry.rule_type is RuleType.BED_AND_BREAKFAST
+    assert entry.bed_and_breakfast_date_index == REBUY_DAY
+    assert entry.allowable_cost == Decimal(50)
+    # GBP 100 of proceeds against the GBP 50 the repurchase cost.
+    assert report.total_gain() == Decimal(50)
+    assert calculator.portfolio["FOO"] == Position(Decimal(10), Decimal(0))
+
+
+def test_a_part_of_a_cost_never_comes_to_more_than_the_whole() -> None:
+    """A repurchase's cost is not always on the grid its share is rounded to.
+
+    The share of a repurchase claimed under the 30-day rule is rounded to ten
+    decimal places, and an amount converted out of another currency need not
+    sit on that grid, so the part can round to more than all of it. Here
+    2.9999999999 of the 3 shares repurchased for GBP 1.00000000009 are
+    claimed, and the unrounded share rounds up past the whole. The run used to
+    stop on a bare assertion once the pool went a hundred-billionth of a pound
+    negative.
+    """
+    calculator = create_calculator(tax_year=2024)
+    quantity = Decimal("2.9999999999")
+    transactions = [
+        _gbp_trade(BUY_DAY, ActionType.BUY, "FOO", quantity, 0),
+        _gbp_trade(SELL_DAY, ActionType.SELL, "FOO", quantity, 3),
+        _gbp_trade(REBUY_DAY, ActionType.BUY, "FOO", 3, Decimal("1.00000000009")),
+    ]
+
+    report = get_report(calculator, transactions)
+
+    (entry,) = report.calculation_log[SELL_DAY]["sell$FOO"]
+    assert entry.rule_type is RuleType.BED_AND_BREAKFAST
+    assert entry.allowable_cost == Decimal("1.00000000009")
+    # GBP 3 of proceeds against the whole of what the repurchase cost.
+    assert report.total_gain() == Decimal(2)
+    assert calculator.portfolio["FOO"].amount == Decimal(0)
+
+
+def test_proceeds_sitting_on_a_rounding_step_reconcile() -> None:
+    """The recorded proceeds and the rebuilt ones are compared as one figure.
+
+    A disposal's proceeds are checked against the sum rebuilt from its
+    calculation entries. One side is the amount as recorded, the other comes
+    from a unit price, so they can differ far below the calculator's
+    precision. Rounding each on its own used to send a recorded amount sitting
+    exactly on a rounding step to a different grid point from the rebuilt one,
+    and the run stopped.
+    """
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    quantity = Decimal("0.6245225058")
+    transactions = [
+        _gbp_trade(BUY_DAY, ActionType.BUY, "FOO", quantity, Decimal("6.245225058")),
+        _gbp_trade(
+            SELL_DAY, ActionType.SELL, "FOO", quantity, Decimal("9.40968379635")
+        ),
+    ]
+
+    report = get_report(calculator, transactions)
+
+    # GBP 9.40968379635 of proceeds against a GBP 6.245225058 cost.
+    assert report.total_gain() == Decimal("3.16")
+
+
+def test_claiming_the_whole_of_an_acquisition_costs_the_whole_of_it() -> None:
+    """All of a repurchase costs all of it, down to the last figure.
+
+    The share claimed under the 30-day rule is rounded to ten decimal places,
+    and an amount converted out of another currency need not sit on that grid.
+    Where the whole repurchase is claimed, going through the arithmetic rounds
+    a figure that is already exact, and the relief the disposal is given comes
+    out short of what the repurchase cost, so the whole is handed over as it
+    stands. The pool is normalised as it is written and shows nothing of this;
+    the allowable cost is where it survives.
+    """
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    cost = Decimal("1.00000000001")
+    transactions = [
+        _gbp_trade(BUY_DAY, ActionType.BUY, "FOO", 3, 30),
+        _gbp_trade(SELL_DAY, ActionType.SELL, "FOO", 3, 5),
+        _gbp_trade(REBUY_DAY, ActionType.BUY, "FOO", 3, cost),
+    ]
+
+    report = get_report(calculator, transactions)
+
+    (entry,) = report.calculation_log[SELL_DAY]["sell$FOO"]
+    assert entry.rule_type is RuleType.BED_AND_BREAKFAST
+    assert entry.allowable_cost == cost
+    # GBP 5 of proceeds against the GBP 1.00000000001 the repurchase cost.
+    assert report.total_gain() == Decimal(4)
+    # The repurchase keeps the basis of the shares it replaces, and nothing of
+    # its own cost is left behind.
+    assert calculator.portfolio["FOO"] == Position(Decimal(3), Decimal(30))
+
+
+@pytest.mark.parametrize(
+    ("proceeds", "reported"),
+    [(Decimal("1.005"), Decimal("0.01")), (Decimal("0.995"), Decimal("-0.01"))],
+)
+def test_a_gain_of_exactly_half_a_penny_is_reported_not_rejected(
+    proceeds: Decimal, reported: Decimal
+) -> None:
+    """A gain landing exactly on the half-penny is rounded, not refused.
+
+    What a disposal reports is its gain rounded to the penny, and the walk
+    checks that figure against the entries it was built from. Half a penny
+    rounds up to a whole one, so measuring how far the reported figure moved
+    lands on the same step again and the run stopped. Asking instead whether
+    the raw gain rounds to the figure already reported settles it.
+    """
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    transactions = [
+        _gbp_trade(BUY_DAY, ActionType.BUY, "ABC", 1, 1),
+        _gbp_trade(SELL_DAY, ActionType.SELL, "ABC", 1, proceeds),
+    ]
+
+    report = get_report(calculator, transactions)
+
+    (entry,) = report.calculation_log[SELL_DAY]["sell$ABC"]
+    assert entry.rule_type is RuleType.SECTION_104
+    assert entry.gain == proceeds - 1
+    assert report.total_gain() == reported


### PR DESCRIPTION
Two internal consistency checks in the calculator stopped a run on input that is perfectly ordinary. Both failed as a bare `AssertionError` with no message, no transaction and no advice, and both disappear under `python -O`.

### A repurchase after a disposal was rejected

1. You acquire 10 `FOO` for nothing.
2. On 10 May you sell all 10 for GBP 100.
3. On 20 May you buy 10 back for GBP 50.

The repurchase is matched to the disposal under the 30-day rule, so it gives up the GBP 50 its own units cost and takes on the nil cost the sold shares carried. What stays in the pool is exactly nothing, and the run stopped there because a check required the figure to be above nothing. Nil is a real cost. The gain is now GBP 50: GBP 100 of proceeds against the GBP 50 the repurchase cost, with the nil cost carried into the pool. A cost of nothing is written as zero, which a second check further on read as proceeds of nothing, so that one now applies only to entries that state a gain.

The first check also fired where nothing had cost nothing. The share of a repurchase claimed under the 30-day rule is rounded to ten decimal places, and an amount is not always on that grid, because converting out of any other currency leaves a repeating decimal. A part of such a cost could round to more than the whole of it, which no part of an acquisition ever costs, and the pool went a fraction of a penny negative. The claimed share is now capped at the whole, and claiming all of a repurchase costs all of it exactly rather than a rounded approximation. Both sides of one claim, the relief the disposal gets and the cost the pool gives up, now use the same cost-allocation calculation on the same figures.

### A disposal's proceeds were rejected

Buy `0.6245225058` `FOO` for GBP `6.245225058` and sell all of it at `15.06699561`, for proceeds of GBP `9.40968379635`. The run stopped with:

```
AssertionError: 9.40968379635 != 9.409683796349999999999999998
```

After each disposal the recorded proceeds are checked against the sum rebuilt from the calculation entries. One side is the amount as recorded, the other comes from a unit price, so the two can differ far below the calculator's precision. Each was rounded to ten decimal places on its own, which sends a recorded amount sitting exactly on a rounding step to a different grid point from the rebuilt figure. What is measured now is how far apart they are: less than half a ten-decimal-place unit and they are the same amount.

Fixes #1095. Fixes #1096.
