### PR TITLE
Print a readable transaction when a calculation refuses one

### DIFF
--- a/cgt_calc/ingestion.py
+++ b/cgt_calc/ingestion.py
@@ -49,7 +49,13 @@ from .rename_planning import (
 from .stock_split_planning import plan_stock_splits, source_account
 from .stock_splits import quantity_sign
 from .transaction_log import add_to_list, day_acquisitions
-from .util import approx_equal, normalize_amount, round_decimal, strip_zeros
+from .util import (
+    approx_equal,
+    indent_entry,
+    normalize_amount,
+    round_decimal,
+    strip_zeros,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -1576,7 +1582,7 @@ class TransactionIngester:
                 # row that spent the money, so the day is what to name here.
                 msg += f" at the end of {transaction.date}"
                 msg += " after processing the following transactions:\n"
-                msg += "\n".join(entries) + "\n"
+                msg += "\n".join(indent_entry(entry) for entry in entries) + "\n"
                 msg += "Tip: If your input file is missing deposits/withdrawals use --no-balance-check."
                 raise CalculationError(msg)
             balance[transaction.broker, transaction.currency] = new_balance

--- a/cgt_calc/model.py
+++ b/cgt_calc/model.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Final, NamedTuple, Self, override
 from .exceptions import CalculationError
 from .util import (
     approx_equal,
+    display_str,
     luhn_check_digit,
     normalize_amount,
     round_decimal,
@@ -387,6 +388,16 @@ class ActionType(Enum):
     OPTION_EXPIRY = 29
     OPTION_ASSIGNMENT = 30
 
+    @override
+    def __str__(self) -> str:
+        """Name the action the way a message to the user should say it.
+
+        An enum's default string is its Python name, ``ActionType.BUY``,
+        and several messages interpolate an action straight into text a
+        user reads. Naming it here fixes all of them at once.
+        """
+        return self.name.replace("_", " ").capitalize()
+
 
 class CalculationType(Enum):
     """Calculation type enumeration."""
@@ -451,16 +462,17 @@ class BrokerTransaction:
     # Where this row was read from. Excluded from equality and from any
     # __hash__: parsers deduplicate overlapping exports by comparing
     # transactions, and a field that varies with the file would keep both
-    # copies of every row two exports share. Out of the repr too, which is
-    # printed whole in several errors and is about the transaction, not about
-    # which file on this machine it was read from.
+    # copies of every row two exports share. Out of the repr, which is a
+    # field dump for debugging. Its file and row are in __str__, which is
+    # what the errors print, because they are what let a reader find the row
+    # in their own export.
     source: TransactionSource | None = field(default=None, compare=False, repr=False)
     # This row's count restated into the units in force after a share
     # reorganisation later the same day. The exported quantity, price and
     # amount are left alone: they are what validation, deduplication and
     # diagnostics read, and a restated count paired with the exported price
     # would look like a discrepancy. Set by the calculator, so it takes no
-    # part in equality either, nor in the repr the errors print.
+    # part in equality either, nor in anything printed to the user.
     calculation_quantity: Decimal | None = field(
         default=None, compare=False, repr=False
     )
@@ -475,9 +487,10 @@ class BrokerTransaction:
     # False on a row whose tax event is dated apart from the cash it involves,
     # which another row carries on the date the money really moved. The row
     # still acquires or disposes of the shares; it leaves the cash balance,
-    # and the balance check, to that other row. Out of the repr the errors
-    # print: the balance error lists only rows that did move cash, so the
-    # flag reads True on every one of them.
+    # and the balance check, to that other row. Out of the repr and out of
+    # __str__, so no error prints it: the balance error lists only rows that
+    # did move cash, so the flag reads True on every one of them.
+    # `--dump-transactions` does export it.
     affects_cash_balance: bool = field(default=True, repr=False)
 
     @property
@@ -503,6 +516,77 @@ class BrokerTransaction:
                 code = CurrencyCode(key)
                 coerced[code] = coerced.get(code, Decimal(0)) + fee
             self.foreign_fees = coerced
+
+    @override
+    def __str__(self) -> str:
+        """Describe this row for someone reading an error about it.
+
+        Errors print a whole transaction, and the generated ``__repr__`` is
+        Python syntax carrying every internal field, including several the
+        user never supplied. This says what the export stated and where it
+        was read from, and leaves out what it did not state. ``__repr__``
+        is unchanged, so debugging still has the full dump.
+
+        Figures are shortened only where that is marked, so a figure the
+        export states is printed as it states it.
+
+        Two lines: the row, then the context it was read in. An error can
+        list a row for every holding, and each line spent on one row is a
+        line the next one is pushed down by.
+        """
+        what = [self.date.isoformat(), str(self.action)]
+        if self.quantity is not None:
+            what.append(display_str(self.quantity))
+        if self.ambiguous_quantity is not None:
+            what.append(f"(or {display_str(self.ambiguous_quantity)})")
+        if self.symbol is not None:
+            what.append(self.symbol)
+
+        # The price is labelled and grouped with the other figures rather
+        # than trailing the symbol: an option's symbol already ends in "at a
+        # strike of N", and "at a strike of 50 at 1 USD" reads as one clause.
+        money = []
+        if self.price is not None:
+            money.append(f"price {display_str(self.price)}")
+        if self.amount is not None:
+            money.append(f"amount {display_str(self.amount)}")
+        if self.fees:
+            money.append(f"fees {display_str(self.fees)}")
+        # The transaction's own currency is stated once, against the first
+        # figure in it; a fee paid in another currency carries its own.
+        if money:
+            money[0] = f"{money[0]} {self.currency}"
+        money += [
+            f"fees {display_str(fee)} {code}"
+            for code, fee in sorted(self.foreign_fees.items())
+        ]
+
+        headline = " ".join(what)
+        if money:
+            headline += ", " + ", ".join(money)
+
+        # Never the source's `account`: it is a calculation-local token for
+        # the boundary the user declared, and reads as an account number it
+        # is not.
+        # Broker, description and ISIN are one thing said three ways, so
+        # they read as one phrase. The one comma left is the break that
+        # matters, from what the row is to where it was read from.
+        what_it_is = self.broker
+        if self.description and self.description != self.symbol:
+            what_it_is += f' "{self.description}"'
+        if self.isin is not None:
+            what_it_is += f" (ISIN {self.isin})"
+
+        where = [what_it_is]
+        if self.source is not None and self.source.file is not None:
+            # "row N of the file", not "the file, row N": this is one item in
+            # a comma-separated line, and a trailing ", row 8" reads as
+            # another item rather than as part of the file it belongs to.
+            # Last, so that a long path wraps with nothing after it.
+            place = f"row {self.source.row} of " if self.source.row is not None else ""
+            where.append(f"read from {place}{self.source.file}")
+
+        return f"{headline}\n  {', '.join(where)}"
 
 
 class RuleType(Enum):

--- a/cgt_calc/stock_split_planning.py
+++ b/cgt_calc/stock_split_planning.py
@@ -26,7 +26,7 @@ from .stock_splits import (
     quantity_sign,
     scale_quantity,
 )
-from .util import strip_zeros
+from .util import indent_entry, strip_zeros
 
 if TYPE_CHECKING:
     import datetime
@@ -282,7 +282,7 @@ def _sole_reorganisation(
     broker_changes = [_get_quantity_or_fail(row) for row in broker_rows]
     raw_change = _get_quantity_or_fail(raw_row)
     if event_times := _conflicting_reorganisation_times(broker_rows):
-        listed = "\n".join(f"  {row}" for row in rows)
+        listed = "\n".join(indent_entry(row) for row in rows)
         raise CalculationError(
             f"Cannot use the RAW STOCK_SPLIT row for {symbol} on "
             f"{date_index}: the same source reports reorganisations at "
@@ -294,7 +294,7 @@ def _sole_reorganisation(
     if not raw_change.is_finite():
         return raw_row
     if any(not change.is_finite() for change in broker_changes):
-        listed = "\n".join(f"  {row}" for row in rows)
+        listed = "\n".join(indent_entry(row) for row in rows)
         raise CalculationError(
             f"Cannot use the RAW STOCK_SPLIT row for {symbol} on "
             f"{date_index}: a broker row states a change that cannot be "
@@ -308,7 +308,7 @@ def _sole_reorganisation(
         or any(change * raw_change <= 0 for change in broker_changes)
         or abs(broker_change) > abs(raw_change)
     ):
-        listed = "\n".join(f"  {row}" for row in rows)
+        listed = "\n".join(indent_entry(row) for row in rows)
         raise CalculationError(
             f"Cannot use the RAW STOCK_SPLIT row for {symbol} on "
             f"{date_index}: the broker rows change their holdings by "
@@ -569,7 +569,7 @@ def _two_splits_message(
     rows: list[BrokerTransaction],
 ) -> str:
     """Explain why two reorganisations of one holding cannot be combined."""
-    listed = "\n".join(f"  {row}" for row in rows)
+    listed = "\n".join(indent_entry(row) for row in rows)
     if any(isinstance(row, RawTransaction) for row in rows):
         # A single RAW row settles a day the brokers also reported, so
         # more than one of them is the thing to fix rather than to add.
@@ -621,8 +621,8 @@ def _split_chronology_message(
         f"Cannot apply the reorganisation of {symbol} on {date_index}: "
         f"this row is on the same day and cannot be placed either side of "
         f"it, so there is no telling whether its count is stated in the "
-        f"units before or after:\n  {other}\n"
-        f"The reorganisation is:\n  {row}\n"
+        f"units before or after:\n{indent_entry(other)}\n"
+        f"The reorganisation is:\n{indent_entry(row)}\n"
     )
     stated = other.source is not None and other.source.timestamp is not None
     if len(instants) == 1 and stated:
@@ -651,7 +651,7 @@ def _unresolved_same_day_message(
     assert isinstance(event.ratio, UnresolvedRatio)
     return (
         f"Cannot apply the reorganisation of {event.describe()}: "
-        f"{event.symbol} also changed hands earlier that day:\n  {other}\n"
+        f"{event.symbol} also changed hands earlier that day:\n{indent_entry(other)}\n"
         "That row's count is in the units before the reorganisation, so it "
         "has to be restated into the units after it, and the ratio for "
         f"that cannot be recovered from the export: {event.ratio.describe()}. "

--- a/cgt_calc/util.py
+++ b/cgt_calc/util.py
@@ -6,6 +6,7 @@ import decimal
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 import sys
+import textwrap
 from typing import TextIO
 
 
@@ -53,6 +54,16 @@ def normalize_amount(amount: Decimal) -> Decimal:
     return round_decimal(amount, 10)
 
 
+def indent_entry(entry: object) -> str:
+    """Indent every line of one item in a message that lists several.
+
+    A transaction renders over more than one line, so indenting only the
+    first would leave every line at the same depth and a list of two rows
+    would read as a list of four.
+    """
+    return textwrap.indent(str(entry), "  ")
+
+
 def strip_zeros(value: Decimal) -> str:
     """Strip trailing zeros from Decimal."""
     return f"{value:.10f}".rstrip("0").rstrip(".")
@@ -66,9 +77,52 @@ def exact_str(value: Decimal) -> str:
     has to keep every digit it has, in plain notation so the reader does
     not need to cope with exponents. Formatting never rounds, unlike
     `normalize()`, which applies the context precision.
+
+    Also the fallback for `display_str` when shortening a figure would
+    hide it.
     """
     text = format(value, "f")
     return text.rstrip("0").rstrip(".") if "." in text else text
+
+
+# Past what the brokers here export, so an exported figure is not marked,
+# and the precision the calculation itself normalises to.
+DISPLAY_PLACES = 10
+
+
+def display_str(value: Decimal) -> str:
+    """Format a figure for someone reading it, marking a shortened one.
+
+    Several parsers state no price and divide an amount by a quantity to
+    get one, so the figure carries the full precision of that division: a
+    holding bought for 2381.35 renders a price of
+    99.02666666666666666666666667, which buries the figures either side of
+    it. Shortening it silently would state a figure neither the export nor
+    the calculation holds, so a shortened one is marked.
+
+    A figure that cannot be shortened is printed whole rather than refused,
+    because every caller is an error already naming a row the user has to
+    find. That covers "NaN" and "Infinity", a value with more integer
+    digits than a rounded copy will fit in, and one small enough that
+    shortening would leave "0": a figure the reader cannot check is worse
+    than a long one.
+    """
+    if not value.is_finite():
+        return exact_str(value)
+    if value == 0:
+        # A figure subtracted to nothing keeps the sign it was heading for,
+        # and "amount -0" reads as a fault in the tool rather than a row
+        # that came to nothing.
+        return "0"
+    try:
+        shown = round_decimal(value, DISPLAY_PLACES)
+    except InvalidOperation:
+        return exact_str(value)
+    if shown == value:
+        return exact_str(value)
+    if shown == 0:
+        return exact_str(value)
+    return f"~{exact_str(shown)}"
 
 
 def luhn_check_digit(payload: str) -> int:

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -22,6 +22,13 @@ The external services used are:
 Reports and cache files are saved locally. Store them under the same access, retention and deletion
 controls as your own tax records.
 
+**Error messages can quote your own data.** When cgt-calc refuses a transaction it prints that
+transaction, which can include the path of the file it was read from and the row number within it. A
+path can carry your username. The broker pages ask for the complete error message when you report a
+problem: read it first, and shorten a path or replace a figure you would rather not publish. See the
+[instructions for your broker](brokers/index.md). The `--dump-transactions` export also includes the
+source file path and row number for every transaction.
+
 ## Disclaimer
 
 This tool is a calculation aid, **not tax advice**. It calculates capital gains figures from the

--- a/scripts/import_eri_reports.py
+++ b/scripts/import_eri_reports.py
@@ -22,7 +22,7 @@ from cgt_calc.parsers.eri.importer.invesco import InvescoImporter
 from cgt_calc.parsers.eri.importer.vanguard import VanguardImporter
 from cgt_calc.parsers.eri.importer.xtrackers import XtrackersImporter
 from cgt_calc.parsers.eri.raw import COLUMNS, RAW_DATE_FORMAT, ERIRawParser
-from cgt_calc.util import approx_equal
+from cgt_calc.util import approx_equal, display_str
 
 if TYPE_CHECKING:
     import datetime
@@ -67,10 +67,14 @@ def validate_and_remove_duplicates(
             current_transaction, current_price = transaction_index[key]
             if approx_equal(current_price, price, Decimal("0.0001")):
                 continue
+            # With the currency: two rows for one fund on one day can state
+            # their prices in different currencies, and "1.25 against 0.98"
+            # is a different conflict from "1.25 USD against 0.98 GBP".
             raise InvalidTransactionError(
                 transaction,
-                "Duplicate same day ERI with different price from "
-                f"{current_transaction}",
+                "Duplicate same day ERI with a different price: an earlier "
+                f"row on this date states {display_str(current_price)} "
+                f"{current_transaction.currency}",
             )
         result.append(transaction)
         transaction_index[key] = (transaction, price)

--- a/tests/eri_importers/test_import_eri_reports.py
+++ b/tests/eri_importers/test_import_eri_reports.py
@@ -63,3 +63,27 @@ def test_unusable_eri_price_is_rejected_before_it_is_written(price: Decimal) -> 
 
     with pytest.raises(InvalidTransactionError, match="finite and non-negative"):
         import_eri_reports.validate_and_remove_duplicates([transaction])
+
+
+def test_conflicting_eri_prices_name_the_currency_of_each() -> None:
+    """Two rows for one fund on one day can price it in different currencies.
+
+    Stating only the figures turns a currency mismatch into what looks like
+    a disagreement about the price, so the earlier row's currency is named
+    beside its figure and the refused row prints its own.
+    """
+    date = datetime.date(2024, 6, 30)
+    isin = Isin("IE00B3RBWM25")
+    earlier = ERITransaction(
+        date=date, isin=isin, price=Decimal("1.25"), currency=CurrencyCode("USD")
+    )
+    later = ERITransaction(
+        date=date, isin=isin, price=Decimal("0.98"), currency=CurrencyCode("GBP")
+    )
+
+    with pytest.raises(InvalidTransactionError) as excinfo:
+        import_eri_reports.validate_and_remove_duplicates([earlier, later])
+
+    message = str(excinfo.value)
+    assert "an earlier row on this date states 1.25 USD" in message
+    assert "price 0.98 GBP" in message

--- a/tests/freetrade/test_freetrade.py
+++ b/tests/freetrade/test_freetrade.py
@@ -460,3 +460,17 @@ def test_freetrade_transaction_unsupported_action(
         match="Unsupported Freetrade action 'ADJUSTMENT'",
     ):
         FreetradeTransaction(dict(zip(COLUMNS, row, strict=True)), dummy_file)
+
+
+def test_description_reads_as_words_not_python(tmp_path: Path) -> None:
+    """The description interpolates the action, and errors quote it back.
+
+    An enum's default string is its Python name, so this description used to
+    end in `ActionType.BUY` and carried that into every error naming the row.
+    """
+    path = _write_csv(tmp_path, COLUMNS, [_default_row()])
+
+    transaction = FreetradeParser().load_from_file(path)[0]
+
+    assert transaction.description.endswith(" Buy")
+    assert "ActionType" not in str(transaction)

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -1769,7 +1769,7 @@ def test_a_malformed_purchase_on_a_rename_day_blames_its_own_row(
     with pytest.raises(QuantityNotPositiveError) as excinfo:
         get_report(calculator, transactions)
 
-    assert "symbol='NEW'" in str(excinfo.value)
+    assert f"Buy {quantity} NEW" in str(excinfo.value)
 
 
 def test_a_purchase_under_the_retired_name_is_there_to_sell_later() -> None:
@@ -2283,8 +2283,12 @@ def test_negative_balance_error_shows_only_relevant_transactions() -> None:
 
     message = str(excinfo.value)
     assert message.count("Balance after transaction=") == 3
-    assert "currency='EUR'" not in message
+    assert "amount 5 EUR" not in message
     assert "Split of FOO" not in message
+    # Each listed row is a headline, its own indented second line, and the
+    # running balance, all at the depth of one entry.
+    assert message.count("\n  Balance after transaction=") == 3
+    assert message.count("\n    ") == 3
 
 
 @pytest.mark.parametrize("deposit_first", [True, False])

--- a/tests/general/test_model.py
+++ b/tests/general/test_model.py
@@ -10,7 +10,7 @@ from typing import override
 
 import pytest
 
-from cgt_calc.exceptions import CalculationError
+from cgt_calc.exceptions import CalculationError, InvalidTransactionError
 from cgt_calc.model import (
     ActionType,
     BrokerTransaction,
@@ -311,3 +311,224 @@ def test_source_is_not_part_of_transaction_equality() -> None:
 
     assert first == second
     assert len({first, second}) == 1
+
+
+def _sale(**changes: object) -> BrokerTransaction:
+    """Build a disposal to render, with any field overridden."""
+    transaction = BrokerTransaction(
+        date=datetime.date(2024, 6, 27),
+        action=ActionType.SELL,
+        symbol="FOO",
+        description="FOO INC",
+        quantity=Decimal(10),
+        price=Decimal("12.50"),
+        fees=Decimal("0.02"),
+        amount=Decimal("124.98"),
+        currency=USD,
+        broker="Charles Schwab",
+    )
+    return replace(transaction, **changes)  # type: ignore[arg-type]
+
+
+def test_str_states_the_row_without_python_syntax() -> None:
+    """Errors print this, so it has to read as a transaction, not a dump."""
+    rendered = str(_sale())
+
+    assert rendered.startswith("2024-06-27 Sell 10 FOO, price 12.5 USD")
+    assert "amount 124.98" in rendered
+    assert "fees 0.02" in rendered
+    assert "Charles Schwab" in rendered
+    assert '"FOO INC"' in rendered
+    for python_syntax in ("Decimal(", "datetime.date(", "ActionType.", "<", "="):
+        assert python_syntax not in rendered
+
+
+def test_str_leaves_out_what_the_export_did_not_state() -> None:
+    """An absent field is absent, not None, an empty dict or an empty list."""
+    rendered = str(
+        _sale(
+            symbol=None,
+            description="",
+            quantity=None,
+            price=None,
+            amount=None,
+            fees=Decimal(0),
+        )
+    )
+
+    assert rendered == "2024-06-27 Sell\n  Charles Schwab"
+    for empty in ("None", "{}", "[]", "''"):
+        assert empty not in rendered
+
+
+def test_str_names_the_file_and_row_it_was_read_from() -> None:
+    """The provenance is the one field that says where to look.
+
+    The path is written the way the platform writes one, with backslashes
+    on Windows: it is there for the reader to open, so it has to match what
+    their own tools show them.
+    """
+    path = Path("exports/main.csv")
+
+    rendered = str(_sale(source=TransactionSource(file=path, row=8)))
+
+    assert f"read from row 8 of {path}" in rendered
+
+
+def test_str_states_the_currency_against_the_amount_when_there_is_no_price() -> None:
+    """A dividend states no price, so the currency goes with the amount."""
+    rendered = str(
+        _sale(
+            action=ActionType.DIVIDEND,
+            quantity=None,
+            price=None,
+            fees=Decimal(0),
+            amount=Decimal("3.10"),
+            isin=Isin(VALID_ISIN),
+        )
+    )
+
+    assert rendered.startswith("2024-06-27 Dividend FOO, amount 3.1 USD")
+    assert f"ISIN {VALID_ISIN}" in rendered
+
+
+def test_str_names_a_file_that_states_no_row() -> None:
+    """A parser that tracks the file but not the line still says which file."""
+    rendered = str(_sale(source=TransactionSource(file=Path("main.csv"))))
+
+    assert "read from main.csv" in rendered
+    assert "row" not in rendered
+
+
+def test_str_reads_the_broker_name_and_isin_as_one_phrase() -> None:
+    """Three ways of saying what the row is, so they are not three items.
+
+    The comma that is left marks the break that matters, from what the row
+    is to where it was read from.
+    """
+    transaction = _sale(
+        isin=Isin(VALID_ISIN), source=TransactionSource(file=Path("main.csv"), row=8)
+    )
+
+    rendered = str(transaction)
+
+    assert (
+        f'  Charles Schwab "FOO INC" (ISIN {VALID_ISIN}), read from row 8 of main.csv'
+    ) in rendered
+
+
+def test_str_never_names_the_source_account() -> None:
+    """`account` is a calculation-local token, not a broker account number."""
+    rendered = str(
+        _sale(
+            source=TransactionSource(
+                file=Path("main.csv"), row=8, account="opaque-boundary-token"
+            )
+        )
+    )
+
+    assert "opaque-boundary-token" not in rendered
+
+
+def test_str_states_a_foreign_fee_in_its_own_currency() -> None:
+    """The row's own currency is stated once; another currency carries its own."""
+    rendered = str(_sale(foreign_fees={CurrencyCode("EUR"): Decimal("1.20")}))
+
+    assert "price 12.5 USD" in rendered
+    assert "fees 1.2 EUR" in rendered
+
+
+def test_str_states_the_other_count_an_ambiguous_row_could_mean() -> None:
+    """Where a split leaves the count uncertain, both readings are shown."""
+    rendered = str(_sale(ambiguous_quantity=Decimal(40)))
+
+    assert "10 (or 40) FOO" in rendered
+
+
+def test_str_marks_a_derived_price_it_shortened() -> None:
+    """A price a parser divided out runs long, and shortening it is stated.
+
+    Printing the division in full buries the figures either side of it;
+    printing it short and unmarked states a figure the export does not hold.
+    """
+    price = Decimal("523.6400000971875840180380156")
+    quantity = Decimal("3.130074725274725274725274725")
+
+    rendered = str(_sale(price=price, quantity=quantity))
+
+    assert "~3.1300747253 FOO" in rendered
+    assert "price ~523.6400000972 USD" in rendered
+
+
+def test_str_leaves_an_exported_figure_as_the_export_states_it() -> None:
+    """Eight decimal places is a real Freetrade price, not a division."""
+    rendered = str(_sale(price=Decimal("716.14212813"), quantity=Decimal("0.01475964")))
+
+    assert "0.01475964 FOO" in rendered
+    assert "price 716.14212813 USD" in rendered
+    assert "~" not in rendered
+
+
+def test_str_states_a_figure_too_small_to_shorten_in_full() -> None:
+    """Shortening this one leaves "0", which is worse than a long figure."""
+    rendered = str(_sale(price=Decimal("0.000000000000123")))
+
+    assert "price 0.000000000000123 USD" in rendered
+
+
+def test_str_states_a_figure_too_large_to_shorten_in_full() -> None:
+    """Rounding a copy of this one does not fit, and raising loses the row.
+
+    Absurd for money, and an absurd figure is exactly what the errors
+    calling this exist to report, so the row still has to print.
+    """
+    rendered = str(_sale(amount=Decimal("1E+19")))
+
+    assert "amount 10000000000000000000" in rendered
+
+
+def test_str_states_a_figure_that_is_not_a_number() -> None:
+    """Rounding one raises, and an error about it has to print the row."""
+    rendered = str(_sale(amount=Decimal("Infinity")))
+
+    assert "amount Infinity" in rendered
+
+
+def test_str_states_an_amount_of_nothing_without_a_sign() -> None:
+    """A row that came to nothing reads as an error in the tool as "-0"."""
+    rendered = str(_sale(amount=Decimal("-0.00")))
+
+    assert "amount 0," in rendered
+
+
+def test_action_reads_as_a_word_wherever_it_is_interpolated() -> None:
+    """Messages interpolate an action directly, so its own str has to read."""
+    assert str(ActionType.BUY) == "Buy"
+    assert str(ActionType.STOCK_ACTIVITY) == "Stock activity"
+    assert str(ActionType.DIVIDEND_TAX) == "Dividend tax"
+
+
+def test_str_leaves_out_a_description_that_only_repeats_the_symbol() -> None:
+    """Some exports set the description to the ticker, which says nothing."""
+    assert str(_sale(description="FOO")).endswith("Charles Schwab")
+
+
+def test_repr_still_carries_every_field() -> None:
+    """__str__ is for the reader; __repr__ stays the full dump for debugging."""
+    rendered = repr(_sale())
+
+    assert "Decimal('12.50')" in rendered
+    assert "capital_adjustments=[]" in rendered
+
+
+def test_an_error_about_a_transaction_prints_the_readable_form() -> None:
+    """Every raise site reaches this one message through the base class."""
+    transaction = _sale(source=TransactionSource(file=Path("main.csv"), row=8))
+
+    error = InvalidTransactionError(transaction, "Tried to sell more than the balance")
+
+    assert str(error) == (
+        "Tried to sell more than the balance for the following transaction:\n"
+        "2024-06-27 Sell 10 FOO, price 12.5 USD, amount 124.98, fees 0.02\n"
+        '  Charles Schwab "FOO INC", read from row 8 of main.csv'
+    )

--- a/tests/general/test_stock_splits.py
+++ b/tests/general/test_stock_splits.py
@@ -1777,7 +1777,7 @@ def test_two_raw_rows_for_one_day_are_still_refused() -> None:
     """
     with pytest.raises(
         CalculationError, match="Leave all but one of the RAW STOCK_SPLIT rows out"
-    ):
+    ) as excinfo:
         run(
             [
                 trade(POOL_DAY, ActionType.BUY, "FOO", "10", "10"),
@@ -1785,6 +1785,13 @@ def test_two_raw_rows_for_one_day_are_still_refused() -> None:
                 raw_split(EVENT_DAY, "FOO", "20"),
             ]
         )
+
+    # A row renders over two lines, so both rows are listed at one depth and
+    # each row's own second line one deeper. Indenting only the first line
+    # would show two rows as four items.
+    message = str(excinfo.value)
+    assert message.count(f"\n  {EVENT_DAY.isoformat()} Stock split") == 2
+    assert message.count("\n    ") == 2
 
 
 # ===== a reorganisation row that also states money =====

--- a/tests/schwab/test_schwab_dir.py
+++ b/tests/schwab/test_schwab_dir.py
@@ -97,8 +97,10 @@ def test_split_export_matches_the_whole_file(tmp_path: Path) -> None:
     from_dir = _load(schwab_dir=str(directory))
     from_file = _load(schwab_file=str(whole))
 
-    assert [str(transaction) for transaction in from_dir] == [
-        str(transaction) for transaction in from_file
+    # repr, not str: str names the file each row was read from, which is
+    # exactly what differs between a directory and one whole file.
+    assert [repr(transaction) for transaction in from_dir] == [
+        repr(transaction) for transaction in from_file
     ]
     assert [transaction.date for transaction in from_dir] == sorted(
         transaction.date for transaction in from_dir
@@ -129,8 +131,10 @@ def test_single_file_directory_matches_the_file_through_the_award_path(
     )
 
     assert from_dir
-    assert [str(transaction) for transaction in from_dir] == [
-        str(transaction) for transaction in from_file
+    # repr, not str: str names the file each row was read from, which is
+    # exactly what differs between a directory and one whole file.
+    assert [repr(transaction) for transaction in from_dir] == [
+        repr(transaction) for transaction in from_file
     ]
 
 

--- a/tests/schwab/test_schwab_options.py
+++ b/tests/schwab/test_schwab_options.py
@@ -288,10 +288,10 @@ def test_assigned_put_without_its_funding_deposit_still_errors() -> None:
         _report(rows, balance_check=True)
 
     message = str(error.value)
-    assert "datetime.date(2024, 5, 21)" in message
+    assert "2024-05-21 Transfer" in message
     # The taxable purchase moves no cash, so listing it under a running
     # balance it did not change would only mislead.
-    assert "ActionType.BUY" not in message
+    assert "Buy 100 META" not in message
 
 
 @pytest.mark.parametrize("deposit_first", [True, False])


### PR DESCRIPTION
When cgt-calc refuses a transaction it prints that transaction, and `BrokerTransaction` defined no `__str__`, so it fell back to the dataclass repr. This is the ordinary failure a user meets when their export does not reach back far enough to cover what they later sold:

```
ERROR: Tried to sell more than the available balance(10) for the following transaction:
Trading212Transaction(date=datetime.date(2024, 4, 29), action=<ActionType.SELL: 2>, symbol='FOO', description='Foo Company', quantity=Decimal('24.0000000000'), price=Decimal('130.9670833333333333333333333'), fees=Decimal('4.71'), amount=Decimal('3138.50'), currency='GBP', broker='Trading212', isin='US0000000002', foreign_fees={}, ambiguous_quantity=None, option_contract=None, written_option_tax=None, capital_adjustments=[])
```

Values are in Python syntax, fields the user never supplied are shown, and the file and row are missing, which is the one thing that would let the user find the row. It now reads:

```
ERROR: Tried to sell more than the available balance(10) for the following transaction:
2024-04-29 Sell 24 FOO, price ~130.9670833333 GBP, amount 3138.5, fees 4.71
  Trading212 "Foo Company" (ISIN US0000000002), read from row 7 of transactions.csv
```

That price is not in the export: several parsers state none and divide an amount by a quantity to get one. A shortened figure is marked `~`, and one too small to shorten without leaving `0` is printed in full. `ActionType` gains a `__str__` too, fixing five messages that interpolate an action straight into text, including every Freetrade description: those read `Tesla ActionType.BUY` and reached the `--dump-transactions` export that way. `__repr__` is unchanged.

Since an error can now carry a path from your own machine, `docs/privacy.md` says so.
