### PR TITLE
Read a repurchase under either name a day's rename gives a holding

### DIFF
--- a/.harper-ignore.txt
+++ b/.harper-ignore.txt
@@ -56,3 +56,6 @@
 ^schwab\.md:.*PhrasalVerbAsCompoundNoun
 # "a single hop" is the graph sense, as in this file's own `_one_hop_renames`.
 ^rename_planning\.py:.*HopHope
+# "at least three to list" is the ordinary quantifier; the
+# QuantifierNumeralConflict rule expects the two to disagree.
+^matching\.py:.*QuantifierNumeralConflict

--- a/cgt_calc/matching.py
+++ b/cgt_calc/matching.py
@@ -27,7 +27,7 @@ from .model import (
     RuleType,
     SpinOff,
 )
-from .rename_planning import end_name
+from .rename_planning import connected_names, end_name
 from .stock_splits import (
     StockSplitDetail,
     StockSplitEvent,
@@ -523,6 +523,10 @@ class Matcher:
                 transformation = day_splits.get(effective_symbol) or day_splits.get(
                     renamed_symbol
                 )
+                # The name the holding enters the day under, which is its own
+                # and no other holding's, whatever else the day's renames pool
+                # it with by the close.
+                opening_symbol = effective_symbol
                 effective_symbol = renamed_symbol
                 if transformation is not None:
                     if transformation.ratio is None:
@@ -544,13 +548,51 @@ class Matcher:
                 eri = self.get_eri(effective_symbol, search_index)
                 if eri:
                     eris.append(eri)
+                # The shares are the same holding under either spelling, so
+                # reading only the name the day ends with would let a row's
+                # spelling decide whether this disposal is identified against it.
+                day_names, merged = self._search_day_names(effective_symbol, renames)
+                bought_under = [
+                    name
+                    for name in day_names
+                    if self._unclaimed_acquisition(search_index, name) > 0
+                ]
+                # A merge leaves the day's other names claimed by more than
+                # one holding: they were separate until the renames, and a
+                # purchase under one of them may belong to either. That
+                # includes the name they all end under. Only the name this
+                # holding opened the day with is nobody else's, so a purchase
+                # under it is still this holding's repurchase.
+                if merged:
+                    unattributable = [
+                        name for name in bought_under if name != opening_symbol
+                    ]
+                    if unattributable:
+                        raise CalculationError(
+                            self._merged_repurchase_message(
+                                ctx.symbol,
+                                ctx.date_index,
+                                search_index,
+                                day_names,
+                                unattributable,
+                            )
+                        )
+                if len(bought_under) > 1:
+                    raise CalculationError(
+                        self._split_repurchase_message(
+                            ctx.symbol, ctx.date_index, search_index, bought_under
+                        )
+                    )
+                # With nothing spare under any of them the name the walk
+                # carries stands in, and the day falls out at the checks below.
+                acquired_symbol = bought_under[0] if bought_under else effective_symbol
                 acquisition = self._identifiable_acquisition(
-                    search_index, effective_symbol
+                    search_index, acquired_symbol
                 )
                 if acquisition.quantity > 0:
                     bnb_acquisition = (
-                        self.run.bnb_list[search_index][effective_symbol]
-                        if has_key(self.run.bnb_list, search_index, effective_symbol)
+                        self.run.bnb_list[search_index][acquired_symbol]
+                        if has_key(self.run.bnb_list, search_index, acquired_symbol)
                         else HmrcTransactionData()
                     )
                     assert bnb_acquisition.quantity <= acquisition.quantity
@@ -689,7 +731,7 @@ class Matcher:
                     add_to_list(
                         self.run.bnb_list,
                         search_index,
-                        effective_symbol,
+                        acquired_symbol,
                         consumed_acquisition_units,
                         amount_delta + total_dist_amount,
                         Decimal(0),
@@ -893,6 +935,43 @@ class Matcher:
                 frontier.append(other)
                 yield other, (old_name, new_name)
 
+    @staticmethod
+    def _search_day_names(
+        symbol: str, renames: dict[str, str]
+    ) -> tuple[list[str], bool]:
+        """Return a day's names for this holding, and whether the day merges it.
+
+        Used walking forward from a disposal, where the day's pools are not
+        known yet, so this reads the renames the first pass recorded and
+        nothing else. Chains are refused before any of them, so every name of
+        a holding ends the day under one closing name.
+
+        Two or more names renamed to that closing name is a merge: holdings
+        that were separate until this day end it under a single spelling, and
+        nothing in the renames tells a second spelling of this holding from
+        another holding joining it. The names are still returned; what may be
+        done with a row under them is the flag's business.
+
+        Counting the renames that arrive at the closing name catches the shape
+        where two names are retired into a third. It does not catch a rename
+        onto a ticker a second holding is already keeping, because only one
+        rename arrives there and the day reads as an ordinary ticker change.
+        That is deliberate, not an oversight: this fix supports a ticker
+        change to a holding's own new name, and a rename onto a name already
+        in use is read the same way, as one security continuing under a
+        spelling it shares. Telling that apart from two genuinely distinct
+        securities colliding on one ticker (which this position-keyed-by-
+        string model cannot represent either way) would need a record of
+        what every ticker had held before the day, which is a great deal of
+        machinery for a collision no single broker's own export would ever
+        produce. A hand-built history representing two distinct securities
+        under one ticker is computed under the same-security assumption
+        instead of refused, and may give an incorrect matching or pool cost.
+        """
+        closing = end_name(renames, symbol)
+        merged = sum(1 for new in renames.values() if new == closing) > 1
+        return sorted(connected_names(renames, symbol)), merged
+
     def _rename_pooling_with(
         self,
         symbol: str,
@@ -992,6 +1071,23 @@ class Matcher:
                 if has_key(claims, date_index, name):
                     claimed = claimed + claims[date_index][name]
         return claimed
+
+    def _unclaimed_acquisition(self, date_index: datetime.date, symbol: str) -> Decimal:
+        """Return what a day's purchases under this name still have to give.
+
+        The same-day rule comes first (CG51560) and an earlier disposal's own
+        30-day claim is already settled, so neither is left for the disposal
+        being identified here. A purchase with nothing spare is not a
+        repurchase this disposal could reach, so it is not one of the day's
+        names for the walk to choose between.
+        """
+        acquisition = self._identifiable_acquisition(date_index, symbol)
+        if acquisition.quantity <= 0:
+            return Decimal(0)
+        claimed = self._same_day_claims(date_index, symbol).quantity
+        if has_key(self.run.bnb_list, date_index, symbol):
+            claimed += self.run.bnb_list[date_index][symbol].quantity
+        return acquisition.quantity - claimed
 
     def _day_identity(
         self, symbol: str, date_index: datetime.date, *, after_renames: bool = False
@@ -1277,6 +1373,55 @@ class Matcher:
             "two counts are in different units. Converting one to the other "
             "needs the corporate ratio, and that cannot be recovered from the "
             f"export: {event.ratio.describe()}. Work this disposal out by hand "
+            "(consider professional advice)."
+        )
+
+    @staticmethod
+    def _merged_repurchase_message(
+        symbol: str,
+        date_index: datetime.date,
+        search_index: datetime.date,
+        names: list[str],
+        bought_under: list[str],
+    ) -> str:
+        """Explain why a merge inside the window blocks a 30-day match."""
+        # A merge renames two or more names to one, so there are always at
+        # least three to list.
+        listed = f"{', '.join(names[:-1])} and {names[-1]}"
+        return (
+            f"Cannot compute the disposal of {symbol} on {date_index}: the "
+            f"renames on {search_index} make {listed} one "
+            f"holding, and shares were bought under "
+            f"{' and '.join(bought_under)} there, within 30 days of this "
+            "disposal. A rename says two tickers are one security, but "
+            "holdings renamed into one name that day were separate until "
+            "then, and the input does not say whether those shares were ever "
+            "the same holding as the ones disposed of here. Whether this "
+            "disposal is identified against that purchase or against its "
+            "Section 104 pool cannot be established, and the two give "
+            "different figures. Record the purchase under the ticker the "
+            "holding was bought as, or work these holdings out by hand "
+            "(consider professional advice)."
+        )
+
+    @staticmethod
+    def _split_repurchase_message(
+        symbol: str,
+        date_index: datetime.date,
+        search_index: datetime.date,
+        bought_under: list[str],
+    ) -> str:
+        """Explain why a day's purchases under two names block a 30-day match."""
+        return (
+            f"Cannot compute the disposal of {symbol} on {date_index}: shares "
+            f"were bought under {' and '.join(bought_under)} on "
+            f"{search_index}, within 30 days of it, and that day's renames "
+            "make them one holding. The day's purchases are one acquisition "
+            "at one blended cost (TCGA 1992 s105(1)(a)), and this tool cannot "
+            "split that cost back across the names the shares were bought "
+            "under, so which of them this disposal is identified against "
+            "would be decided by the spelling on the rows. Record that day's "
+            "purchases under one name, or work this disposal out by hand "
             "(consider professional advice)."
         )
 
@@ -1579,12 +1724,17 @@ class Matcher:
             dates.append(date_index)
         for i in range(BED_AND_BREAKFAST_DAYS):
             search_index = date_index + datetime.timedelta(days=i + 1)
-            # HMRC treats renames as the same security for B&B purposes.
-            effective_symbol = self.history.rename_list.get(search_index, {}).get(
-                effective_symbol, effective_symbol
-            )
-            if has_shares_going_spare(
-                search_index, effective_symbol, is_disposal_day=False
+            # HMRC treats renames as the same security for B&B purposes, and a
+            # rename that day leaves the purchase under either spelling, so
+            # every name the day connects is asked. Reading one name here
+            # while the 30-day walk reads them all would let a repurchase be
+            # matched that this check reported nothing to argue over.
+            renames = self.history.rename_list.get(search_index, {})
+            effective_symbol = end_name(renames, effective_symbol)
+            day_names, _ = self._search_day_names(effective_symbol, renames)
+            if any(
+                has_shares_going_spare(search_index, name, is_disposal_day=False)
+                for name in day_names
             ):
                 dates.append(search_index)
         return dates

--- a/tests/general/test_calc.py
+++ b/tests/general/test_calc.py
@@ -1703,6 +1703,182 @@ def test_a_day_buying_under_both_names_of_one_holding_is_refused() -> None:
     )
 
 
+# A rename inside the 30-day window rather than on the disposal day itself.
+WINDOW_SALE_DAY = datetime.date(2024, 5, 5)
+WINDOW_RENAME_DAY = datetime.date(2024, 5, 20)
+
+
+@pytest.mark.parametrize("repurchase_spelling", ["OLD", "NEW"])
+def test_a_repurchase_under_either_of_the_day_s_names_is_bed_and_breakfasted(
+    repurchase_spelling: str,
+) -> None:
+    """A rename on the repurchase day does not change what the sale is matched to.
+
+    The rename is neither a disposal nor an acquisition (TCGA 1992 s127), so
+    the shares bought back are the ones that were sold whichever of the day's
+    two tickers the row states, and the 30-day rule reaches them either way.
+    Searching only under the name the day ends with found the repurchase
+    spelled NEW and missed the one spelled OLD, taking the sale to the
+    Section 104 pool and a GBP 1,500 gain on the same facts.
+    """
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    transactions = [
+        _gbp_trade(datetime.date(2024, 5, 1), ActionType.BUY, "OLD", 100, 500),
+        _gbp_trade(WINDOW_SALE_DAY, ActionType.SELL, "OLD", 100, 2000),
+        _gbp_trade(WINDOW_RENAME_DAY, ActionType.BUY, repurchase_spelling, 100, 800),
+        _rename_transaction(WINDOW_RENAME_DAY, "OLD", "NEW"),
+    ]
+
+    report = get_report(calculator, transactions)
+
+    (entry,) = report.calculation_log[WINDOW_SALE_DAY]["sell$OLD"]
+    assert entry.rule_type is RuleType.BED_AND_BREAKFAST
+    assert entry.bed_and_breakfast_date_index == WINDOW_RENAME_DAY
+    assert entry.allowable_cost == Decimal(800)
+    # GBP 2,000 of proceeds against the GBP 800 the repurchase cost.
+    assert report.total_gain() == Decimal(1200)
+    # The repurchase gives up the 800 its own units cost and takes on the 500
+    # the sold shares carried, which only happens if the claim was reserved
+    # under the ticker the purchase row states.
+    assert calculator.portfolio["NEW"] == Position(Decimal(100), Decimal(500))
+
+
+@pytest.mark.parametrize("new_first", [True, False], ids=["new first", "old first"])
+def test_a_repurchase_split_across_the_day_s_two_names_is_refused(
+    *, new_first: bool
+) -> None:
+    """One acquisition at one blended cost cannot be split back up by ticker.
+
+    Both rows buy the one holding (TCGA 1992 s105(1)(a)). Identifying the sale
+    against either on its own prices it differently, and the day gives nothing
+    to choose between them by, so neither reading is established.
+    """
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    purchases = [
+        _gbp_trade(WINDOW_RENAME_DAY, ActionType.BUY, "NEW", 50, 500),
+        _gbp_trade(WINDOW_RENAME_DAY, ActionType.BUY, "OLD", 50, 300),
+    ]
+    transactions = [
+        _gbp_trade(datetime.date(2024, 5, 1), ActionType.BUY, "OLD", 100, 500),
+        _gbp_trade(WINDOW_SALE_DAY, ActionType.SELL, "OLD", 100, 2000),
+        *(purchases if new_first else purchases[::-1]),
+        _rename_transaction(WINDOW_RENAME_DAY, "OLD", "NEW"),
+    ]
+
+    with pytest.raises(CalculationError) as excinfo:
+        get_report(calculator, transactions)
+
+    assert str(excinfo.value).startswith(
+        f"Cannot compute the disposal of OLD on {WINDOW_SALE_DAY}: shares were "
+        f"bought under NEW and OLD on {WINDOW_RENAME_DAY}, within 30 days of "
+        "it, and that day's renames make them one holding."
+    )
+
+
+def _merged_window_rows(repurchase_spelling: str) -> list[BrokerTransaction]:
+    """Sell OLD, then buy back the day OLD and OTHER are renamed into MERGED."""
+    return [
+        _gbp_trade(datetime.date(2024, 5, 1), ActionType.BUY, "OLD", 100, 500),
+        _gbp_trade(datetime.date(2024, 5, 1), ActionType.BUY, "OTHER", 100, 700),
+        _gbp_trade(WINDOW_SALE_DAY, ActionType.SELL, "OLD", 100, 2000),
+        _gbp_trade(WINDOW_RENAME_DAY, ActionType.BUY, repurchase_spelling, 100, 800),
+        _rename_transaction(WINDOW_RENAME_DAY, "OLD", "MERGED"),
+        _rename_transaction(WINDOW_RENAME_DAY, "OTHER", "MERGED"),
+    ]
+
+
+@pytest.mark.parametrize("repurchase_spelling", ["MERGED", "OTHER"])
+def test_a_repurchase_under_a_merged_holding_s_name_is_refused(
+    repurchase_spelling: str,
+) -> None:
+    """Two holdings ending under one name leave a purchase belonging to either.
+
+    OTHER was a separate holding until the renames, so a purchase under its
+    name, or under the name both end up with, may be a repurchase of the
+    shares sold here or a purchase of the other holding. The two give
+    different figures and nothing in the input chooses between them.
+    """
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+
+    with pytest.raises(CalculationError) as excinfo:
+        get_report(calculator, _merged_window_rows(repurchase_spelling))
+
+    assert str(excinfo.value).startswith(
+        f"Cannot compute the disposal of OLD on {WINDOW_SALE_DAY}: the renames "
+        f"on {WINDOW_RENAME_DAY} make MERGED, OLD and OTHER one holding, and "
+        f"shares were bought under {repurchase_spelling} there, within 30 days "
+        "of this disposal."
+    )
+
+
+def test_a_repurchase_under_the_disposal_s_own_name_survives_a_merge() -> None:
+    """The name the holding entered the day under is nobody else's.
+
+    OTHER only shares a name with this holding from the close of the day, so
+    a purchase recorded under OLD is a repurchase of the shares sold here
+    whatever else the day pools them with, and the 30-day rule reaches it.
+    """
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+
+    report = get_report(calculator, _merged_window_rows("OLD"))
+
+    (entry,) = report.calculation_log[WINDOW_SALE_DAY]["sell$OLD"]
+    assert entry.rule_type is RuleType.BED_AND_BREAKFAST
+    assert entry.allowable_cost == Decimal(800)
+    assert report.total_gain() == Decimal(1200)
+
+
+def test_an_unrelated_rename_on_the_same_day_is_not_a_merge() -> None:
+    """A second rename elsewhere on the day says nothing about this holding.
+
+    A boundary pin rather than a fix: counting the day's renames instead of
+    the ones ending under this holding's own closing name would read two
+    unconnected ticker changes as two holdings becoming one, and refuse a
+    repurchase that is not in doubt at all.
+    """
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    transactions = [
+        _gbp_trade(datetime.date(2024, 5, 1), ActionType.BUY, "OLD", 100, 500),
+        _gbp_trade(datetime.date(2024, 5, 1), ActionType.BUY, "FOO", 50, 250),
+        _gbp_trade(WINDOW_SALE_DAY, ActionType.SELL, "OLD", 100, 2000),
+        _gbp_trade(WINDOW_RENAME_DAY, ActionType.BUY, "NEW", 100, 800),
+        _rename_transaction(WINDOW_RENAME_DAY, "OLD", "NEW"),
+        _rename_transaction(WINDOW_RENAME_DAY, "FOO", "BAR"),
+    ]
+
+    report = get_report(calculator, transactions)
+
+    (entry,) = report.calculation_log[WINDOW_SALE_DAY]["sell$OLD"]
+    assert entry.rule_type is RuleType.BED_AND_BREAKFAST
+    assert report.total_gain() == Decimal(1200)
+    assert calculator.portfolio["BAR"] == Position(Decimal(50), Decimal(250))
+
+
+def test_a_purchase_under_the_retired_name_after_the_rename_is_a_new_holding() -> None:
+    """The 30-day walk does not keep looking under names the holding has left.
+
+    A boundary pin rather than a fix: the rename takes effect at the close of
+    its own day and the pool moves with it, so a row under the retired ticker
+    on a later day opens a holding of its own and is not a repurchase of what
+    was sold.
+    """
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+    transactions = [
+        _gbp_trade(datetime.date(2024, 5, 1), ActionType.BUY, "OLD", 100, 500),
+        _gbp_trade(WINDOW_SALE_DAY, ActionType.SELL, "OLD", 100, 2000),
+        _rename_transaction(RENAME_DAY, "OLD", "NEW"),
+        _gbp_trade(WINDOW_RENAME_DAY, ActionType.BUY, "OLD", 100, 800),
+    ]
+
+    report = get_report(calculator, transactions)
+
+    (entry,) = report.calculation_log[WINDOW_SALE_DAY]["sell$OLD"]
+    assert entry.rule_type is RuleType.SECTION_104
+    assert entry.allowable_cost == Decimal(500)
+    assert report.total_gain() == Decimal(1500)
+    assert calculator.portfolio["OLD"] == Position(Decimal(100), Decimal(800))
+
+
 @pytest.mark.parametrize("rename_first", [True, False], ids=["rename first", "last"])
 def test_a_rename_day_refuses_more_units_than_the_whole_holding_has(
     *, rename_first: bool

--- a/tests/general/test_transfer_to_spouse.py
+++ b/tests/general/test_transfer_to_spouse.py
@@ -1667,6 +1667,36 @@ def test_a_later_day_s_transfer_to_a_spouse_reserves_its_purchase_too() -> None:
     assert report.total_gain() == Decimal(375)
 
 
+@pytest.mark.parametrize("purchase_spelling", ["X", "Z"])
+def test_a_later_day_s_purchase_is_contended_under_either_of_its_names(
+    purchase_spelling: str,
+) -> None:
+    """A rename that day does not put the purchase beyond one of the two.
+
+    The 20 June purchase is the same holding whichever of the day's tickers
+    it is written under, so the sale and the transfer of 10 June both have a
+    claim on it either way. Looking only under the name the day ends with
+    found it spelled Z and missed it spelled X, and the two were then
+    computed with nothing said, whichever ran first taking the whole
+    purchase.
+    """
+    calculator = create_calculator(tax_year=2024, balance_check=False)
+
+    with pytest.raises(CalculationError, match="does not say how to split") as err:
+        get_report(
+            calculator,
+            _contention_history(
+                [
+                    _gbp_trade(
+                        CONTENTION_LATER_DAY, ActionType.BUY, purchase_spelling, 30, 600
+                    )
+                ]
+            ),
+        )
+
+    assert str(CONTENTION_LATER_DAY) in str(err.value)
+
+
 def _free_shares(date: datetime.date, symbol: str, quantity: int) -> BrokerTransaction:
     """Build a purchase of shares that cost nothing."""
     return BrokerTransaction(


### PR DESCRIPTION
A sale matched against a repurchase within 30 days reported a different gain depending only on which of two ticker names the repurchase row used.

1. Buy 100 `X` for GBP 500.
2. On 10 May, sell all 100 for GBP 2,000.
3. On 20 May, buy 100 back for GBP 800. The same day, `X` is renamed to `Z`.

Spelled `Z`, the tool reports GBP 1,200 (bed-and-breakfast, cost GBP 800). Spelled `X`, it reports GBP 1,500 (Section 104 instead). A rename is neither a disposal nor an acquisition (TCGA 1992 s127), so the repurchased shares are the ones sold whichever ticker the row states, and GBP 1,200 is right under both spellings.

The 30-day search resolved at most one rename per day and looked only under the name the day ends with, so a purchase written under the name the holding entered the day with was invisible. It now reads every name the day's renames connect, and reserves its claim under the ticker the purchase row itself states, so the purchase gives up the right cost. The sale/spouse-transfer contention check had the same blind spot and gets the same fix - otherwise a sale could quietly take a repurchase the check exists to refuse.

Two shapes are refused rather than guessed at: purchases of the holding split across two of its names on one day (one blended acquisition at one cost - TCGA 1992 s105(1)(a) - can't be split back by spelling), and a purchase under a name that day's renames leave shared with another holding (nothing in the input says the shares were ever the same holding, except under the disposal's own opening name, which no other holding can answer to at the same moment).

Scope: this fix supports a ticker change to a holding's own new name. It doesn't detect a rename onto a ticker a second, distinct holding already keeps - only one rename arrives at that name, so it reads as an ordinary ticker change. A hand-built history where they really are separate securities computes under the same-security assumption instead of refusing. ERI under the day's other spelling, splits, and spin-offs are unchanged - separate fixes.

Fixes #1119.
