### PR TITLE
Name the row when an Equity Awards date cannot be read

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -237,6 +237,7 @@ stdout
 StockPlan
 StockSplitTransaction
 str
+strptime
 subrow
 tablefinder
 TCGA
@@ -271,3 +272,4 @@ worktree
 Xetra
 xtrackers
 yfinance
+YYYY

--- a/cgt_calc/parsers/schwab_equity_award_json.py
+++ b/cgt_calc/parsers/schwab_equity_award_json.py
@@ -555,6 +555,62 @@ def _espp_net_shares(
     return deposited * multiplier
 
 
+def _row_where(row: JsonRowType, names: FieldNames, *, with_date: bool) -> str:
+    """Say which row an error is about, using what the row itself states.
+
+    An Equity Awards export gives its transactions no identifier, so the only
+    way to point at one is to describe what a reader would search the file
+    for. The stated date is left out where it is the field being read, and is
+    what locates the row when the unreadable date is inside a lot or grant.
+    """
+    where = f"The {row.get(names.action) or 'transaction'}"
+    symbol = row.get(names.symbol)
+    if symbol:
+        where += f" of {symbol}"
+    date = row.get(names.date)
+    if with_date and date:
+        where += f" on {date}"
+    return where
+
+
+def _row_date(
+    container: JsonRowType, field: str, where: str, file_path: Path
+) -> datetime.date:
+    """Read one date, naming the row and the field where it cannot be read.
+
+    Every date this module reads comes through here. A bare `strptime` answers
+    a hand-edited or hand-combined export with `time data '2023-06-12' does
+    not match format '%m/%d/%Y'`, or with `KeyError` where the field is
+    absent, and neither says which of several hundred rows to go and look at.
+
+    `MM/DD/YYYY` stays the only form accepted. A file stating dates in some
+    other form may have been through a conversion, and a spreadsheet that
+    reads `06/12/2023` as 6 December writes back a date months out; refusing
+    sends the reader to the export rather than to a copy of it. What this
+    establishes is only that a value cannot be read, never how it came to be
+    that way, and a swap landing on a valid date passes: `12/06/2023` is read
+    as 6 December whatever it was meant to be.
+    """
+    stated = container.get(field)
+    if stated is None or stated == "":
+        raise ParsingError(
+            file_path,
+            f"{where} states no {field}. Equity Awards exports state MM/DD/YYYY.",
+        )
+    try:
+        # A JSON export can state a date as a bare number, which the decoder
+        # hands over as a Decimal and `strptime` refuses outright. The row
+        # does state something, so it is quoted back like any other value
+        # that cannot be read.
+        return datetime.datetime.strptime(stated, "%m/%d/%Y").date()
+    except (TypeError, ValueError) as err:
+        raise ParsingError(
+            file_path,
+            f"{where} states {field} as {stated!r}, which is not a date "
+            "cgt-calc reads. Equity Awards exports state MM/DD/YYYY.",
+        ) from err
+
+
 def _number_error(
     err: _UnparseableNumber, row: JsonRowType, names: FieldNames, file_path: Path
 ) -> ParsingError:
@@ -625,7 +681,9 @@ def _check_one_lapse(row: JsonRowType, file_path: Path, names: FieldNames) -> No
     if deposited is None or withheld is None:
         return
 
-    date = datetime.datetime.strptime(row[names.date], "%m/%d/%Y").date()
+    date = _row_date(
+        row, names.date, _row_where(row, names, with_date=False), file_path
+    )
     multiplier = _detail_counts_multiplier(symbol, date)
     expected = (deposited + withheld) * multiplier
 
@@ -976,6 +1034,11 @@ class SchwabAwardTransaction(BrokerTransaction):
         quantity = _row_decimal(row, names.quantity, names, self.raw_action, file)
         amount = _row_decimal(row, names.amount, names, self.raw_action, file)
         fees = _row_decimal(row, names.fees, names, self.raw_action, file)
+        # The row a date error names. A date inside a lot or grant is
+        # located by the transaction's own stated date; the transaction's own
+        # date is not, because that is the field being read.
+        where = _row_where(row, names, with_date=False)
+        dated_where = _row_where(row, names, with_date=True)
         if row[names.action] == "Deposit":
             if len(row[names.transac_details]) != 1:
                 raise ParsingError(
@@ -995,9 +1058,7 @@ class SchwabAwardTransaction(BrokerTransaction):
                 # discount is taxed as employment income through payroll.
                 # Using the price paid understates the basis roughly tenfold
                 # on the older purchases.
-                date = datetime.datetime.strptime(
-                    details[names.purchase_date], "%m/%d/%Y"
-                ).date()
+                date = _row_date(details, names.purchase_date, dated_where, file)
                 price = _decimal_from_str(
                     details[names.purchase_fair_market_value],
                     names.purchase_fair_market_value,
@@ -1028,9 +1089,7 @@ class SchwabAwardTransaction(BrokerTransaction):
                 amount = price * quantity
                 description = f"ESPP purchase on {details[names.purchase_date]}"
             else:
-                date = datetime.datetime.strptime(
-                    details[names.vest_date], "%m/%d/%Y"
-                ).date()
+                date = _row_date(details, names.vest_date, dated_where, file)
                 # Schwab only provides this one as a string:
                 price = _parse_vest_price(details, names, date, file)
                 if amount == Decimal(0):
@@ -1041,7 +1100,7 @@ class SchwabAwardTransaction(BrokerTransaction):
                     f"(ID {details[names.award_id]})"
                 )
         elif row[names.action] in {"Sale", "Forced Quick Sell"}:
-            date = datetime.datetime.strptime(row[names.date], "%m/%d/%Y").date()
+            date = _row_date(row, names.date, where, file)
 
             if _restates_acquisitions_only(symbol):
                 # Derive the price from the money rather than from the per-lot
@@ -1087,7 +1146,7 @@ class SchwabAwardTransaction(BrokerTransaction):
                 )
 
         elif action is ActionType.UNCLASSIFIED_GIFT:
-            date = datetime.datetime.strptime(row[names.date], "%m/%d/%Y").date()
+            date = _row_date(row, names.date, where, file)
             price = None
             # A gift moves shares, not money. Anything in these fields means
             # the row is not what this branch assumes it is.
@@ -1103,7 +1162,7 @@ class SchwabAwardTransaction(BrokerTransaction):
             # proceeds of the autosale programme.
             ActionType.TRANSFER,
         }:
-            date = datetime.datetime.strptime(row[names.date], "%m/%d/%Y").date()
+            date = _row_date(row, names.date, where, file)
             price = None
             amount = _parse_cash_amount(row, names, self.raw_action, date, file)
             description = self.raw_action
@@ -1354,15 +1413,7 @@ def _lapse_price(
     # under the old spelling would never be found.
     symbol = TICKER_RENAMES.get(symbol, symbol)
 
-    stated_date = row.get(names.date)
-    try:
-        date = datetime.datetime.strptime(stated_date, "%m/%d/%Y").date()
-    except (TypeError, ValueError) as err:
-        raise ParsingError(
-            file_path,
-            f"{where}.{names.date} is not a date cgt-calc reads: "
-            f"{stated_date!r}. Equity Awards exports state MM/DD/YYYY.",
-        ) from err
+    date = _row_date(row, names.date, where, file_path)
 
     detail_rows = row.get(names.transac_details) or []
     if not isinstance(detail_rows, list):
@@ -1503,8 +1554,6 @@ def _csv_row_errors(row_index: int | None, file_path: Path) -> Iterator[None]:
             f"{err.args[0]} is missing from this transaction",
             row_index=row_index,
         ) from err
-    except ValueError as err:
-        raise ParsingError(file_path, str(err), row_index=row_index) from err
 
 
 def _csv_aware_transaction(

--- a/docs/brokers/schwab.md
+++ b/docs/brokers/schwab.md
@@ -532,6 +532,26 @@ This complete-export error means the purchased share count does not equal the sh
 withheld and sold for tax after any known split. Compare those figures with the ESPP confirmation
 and split history. Do not change a quantity merely to make the import continue.
 
+### `is not a date cgt-calc reads` or `states no ...Date`
+
+Equity Awards exports write every date as MM/DD/YYYY, and cgt-calc reads only that form. The error
+names the transaction and the field, spelled as your export spells it: `Date` for a transaction's
+own date, and `VestDate` or `PurchaseDate` for one inside a vest or an ESPP purchase. Where the
+export states a value, the error quotes it so that you can search the file for it.
+
+Re-export from Schwab and use the file unchanged. If you need to look inside it, open it in a text
+editor rather than a spreadsheet: a spreadsheet can reinterpret a date column according to its own
+settings, so `06/12/2023` may be read as 6 December where Schwab means 12 June, and written back in
+a form cgt-calc does not read.
+
+This check catches only a date it cannot read at all. A swapped day and month that is still a valid
+MM/DD/YYYY date passes it: `12/06/2023` is read as 6 December whatever it was meant to be. That is
+why working from an unedited export matters more than correcting dates by hand.
+
+If an unchanged export still fails, open a
+[GitHub issue](https://github.com/cgt-calc/capital-gains-calculator/issues/new) with the complete
+error and a sanitised copy of the row.
+
 ### An export overlaps another one
 
 Two files in the `--schwab-dir` directory have earliest-to-latest transaction-date spans that

--- a/tests/schwab/test_schwab_award_dates.py
+++ b/tests/schwab/test_schwab_award_dates.py
@@ -1,0 +1,247 @@
+"""Unreadable dates in a Schwab Equity Awards export name the row they are in.
+
+Every date the parser reads goes through one guard, so that a hand-edited or
+hand-combined export answers with the row to go and look at instead of a bare
+``ValueError`` or ``KeyError``. Each case here is one field that guard is
+reached by, mutated in an export that parses otherwise.
+"""
+
+from __future__ import annotations
+
+import copy
+import io
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cgt_calc.exceptions import ParsingError
+from cgt_calc.parsers.schwab_equity_award_json import (
+    JsonRowType,
+    SchwabEquityAwardsParser,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from cgt_calc.parsers.schwab_equity_award_json import SchwabAwardTransaction
+
+EQUITY_AWARD = Path("tests") / "schwab" / "data" / "equity_award"
+JSON_FIXTURE = EQUITY_AWARD / "nvda_synthetic.json"
+CSV_FIXTURE = EQUITY_AWARD / "nvda_synthetic.csv"
+
+# An ISO date rather than a nonsense string: it is the form a reader is most
+# likely to write by hand, and what a converted export tends to hold.
+NOT_A_DATE = "2023-06-12"
+
+
+def _rows() -> list[JsonRowType]:
+    """Return the synthetic NVDA export's transactions, safe to mutate."""
+    export = json.loads(JSON_FIXTURE.read_text(encoding="utf-8"))
+    rows: list[JsonRowType] = export["Transactions"]
+    return copy.deepcopy(rows)
+
+
+def _parse(rows: list[JsonRowType]) -> list[SchwabAwardTransaction]:
+    """Read those transactions back as the export they came from."""
+    content = json.dumps({"Transactions": rows})
+    return SchwabEquityAwardsParser.read_transactions(
+        io.StringIO(content), JSON_FIXTURE
+    )
+
+
+def _find(rows: list[JsonRowType], action: str, description: str) -> JsonRowType:
+    """Return the first transaction stating that action and description."""
+    for row in rows:
+        if row["Action"] == action and row["Description"] == description:
+            return row
+    raise AssertionError(f"no {action} / {description} row in {JSON_FIXTURE}")
+
+
+def _row(row: JsonRowType) -> JsonRowType:
+    """Return the transaction itself."""
+    return row
+
+
+def _details(row: JsonRowType) -> JsonRowType:
+    """Return the single lot or grant the transaction states."""
+    details: JsonRowType = row["TransactionDetails"][0]["Details"]
+    return details
+
+
+# Every date field the parser reads, named by the row that states it. The
+# expected wording is the whole point of the test, so it is spelled out
+# rather than derived from the row.
+DATE_FIELDS = [
+    pytest.param(
+        "Lapse", "Restricted Stock Lapse", _row, "Date", "The Lapse of NVDA", id="lapse"
+    ),
+    pytest.param(
+        "Deposit",
+        "ESPP",
+        _details,
+        "PurchaseDate",
+        "The Deposit of NVDA on 02/26/2021",
+        id="espp-purchase",
+    ),
+    pytest.param(
+        "Deposit",
+        "RS",
+        _details,
+        "VestDate",
+        "The Deposit of NVDA on 09/15/2021",
+        id="vest",
+    ),
+    pytest.param("Sale", "Share Sale", _row, "Date", "The Sale of NVDA", id="sale"),
+    pytest.param(
+        "Dividend", "Credit", _row, "Date", "The Dividend of NVDA", id="dividend"
+    ),
+]
+
+PARAMETRISED = pytest.mark.parametrize(
+    ("action", "description", "container", "field", "where"), DATE_FIELDS
+)
+
+
+@PARAMETRISED
+def test_a_date_that_cannot_be_read_names_the_row_and_the_value(
+    action: str,
+    description: str,
+    container: Callable[[JsonRowType], JsonRowType],
+    field: str,
+    where: str,
+) -> None:
+    """The stated value is what a reader searches the export for."""
+    rows = _rows()
+    container(_find(rows, action, description))[field] = NOT_A_DATE
+
+    with pytest.raises(ParsingError) as err:
+        _parse(rows)
+
+    assert (
+        f"{where} states {field} as '{NOT_A_DATE}', which is not a date "
+        "cgt-calc reads" in str(err.value)
+    )
+
+
+@PARAMETRISED
+def test_a_date_field_that_is_absent_names_the_row_and_the_field(
+    action: str,
+    description: str,
+    container: Callable[[JsonRowType], JsonRowType],
+    field: str,
+    where: str,
+) -> None:
+    """There is no value to quote, so the row has to carry the message."""
+    rows = _rows()
+    del container(_find(rows, action, description))[field]
+
+    with pytest.raises(ParsingError) as err:
+        _parse(rows)
+
+    assert f"{where} states no {field}" in str(err.value)
+
+
+def test_a_date_field_holding_nothing_reads_as_one_that_is_absent() -> None:
+    """A blank cell states no date, and saying so beats quoting an empty one."""
+    rows = _rows()
+    _find(rows, "Sale", "Share Sale")["Date"] = ""
+
+    with pytest.raises(ParsingError, match="The Sale of NVDA states no Date"):
+        _parse(rows)
+
+
+def test_a_gift_with_a_date_that_cannot_be_read_names_the_row() -> None:
+    """A gift moves shares rather than money, and is named the same way."""
+    content = json.dumps(
+        {
+            "Transactions": [
+                {
+                    "Date": NOT_A_DATE,
+                    "Action": "Gift",
+                    "Symbol": "GOOG",
+                    "Quantity": "2",
+                    "Description": "Share Transfer",
+                    "FeesAndCommissions": None,
+                    "Amount": None,
+                    "TransactionDetails": [],
+                }
+            ]
+        }
+    )
+
+    with pytest.raises(ParsingError, match="The Gift of GOOG states Date as"):
+        SchwabEquityAwardsParser.read_transactions(io.StringIO(content), JSON_FIXTURE)
+
+
+def test_the_csv_layout_names_the_row_the_date_is_on() -> None:
+    """The CSV form is read by the same code, and adds its own row number."""
+    lines = CSV_FIXTURE.read_text(encoding="utf-8").splitlines(keepends=True)
+    # The lot of the ESPP purchase on the row above it, which is where that
+    # purchase states the date it is priced on.
+    lines[2] = lines[2].replace("02/26/2021", NOT_A_DATE, 1)
+    assert NOT_A_DATE in lines[2]
+
+    with pytest.raises(ParsingError) as err:
+        SchwabEquityAwardsParser.read_transactions(
+            io.StringIO("".join(lines)), CSV_FIXTURE
+        )
+
+    assert err.value.row_index == 2
+    assert (
+        "The Deposit of NVDA on 02/26/2021 states PurchaseDate as "
+        f"'{NOT_A_DATE}'" in str(err.value)
+    )
+
+
+def test_an_award_date_that_cannot_be_read_still_parses() -> None:
+    """AwardDate is quoted into a description and never read as a date.
+
+    Guarding it would refuse an export cgt-calc can calculate from, so the
+    harmless case stays harmless.
+    """
+    rows = _rows()
+    vest = _find(rows, "Deposit", "RS")
+    _details(vest)["AwardDate"] = NOT_A_DATE
+    award_id = _details(vest)["AwardId"]
+
+    descriptions = [transaction.description for transaction in _parse(rows)]
+
+    assert f"Vest from Award Date {NOT_A_DATE} (ID {award_id})" in descriptions
+
+
+def test_a_date_stated_as_a_bare_number_is_quoted_back() -> None:
+    """The JSON decoder hands a bare number over as a Decimal, not a string.
+
+    The row does state something, so the message quotes it rather than
+    saying the field is not there.
+    """
+    rows = _rows()
+    _find(rows, "Sale", "Share Sale")["Date"] = 6122023
+
+    with pytest.raises(ParsingError, match="The Sale of NVDA states Date as Decimal"):
+        _parse(rows)
+
+
+def test_a_cash_row_with_no_symbol_is_named_by_its_action_alone() -> None:
+    """A wire out of the account states no symbol, and still names its row."""
+    content = json.dumps(
+        {
+            "Transactions": [
+                {
+                    "Date": NOT_A_DATE,
+                    "Action": "Forced Disbursement",
+                    "Symbol": None,
+                    "Quantity": None,
+                    "Description": "Debit",
+                    "FeesAndCommissions": None,
+                    "Amount": "-$2,490.13",
+                    "TransactionDetails": [],
+                }
+            ]
+        }
+    )
+
+    with pytest.raises(ParsingError, match="The Forced Disbursement states Date as"):
+        SchwabEquityAwardsParser.read_transactions(io.StringIO(content), JSON_FIXTURE)

--- a/tests/schwab/test_schwab_equity_award_json.py
+++ b/tests/schwab/test_schwab_equity_award_json.py
@@ -1850,7 +1850,33 @@ def test_csv_deposit_missing_its_vest_date_names_the_row() -> None:
         _parse(content)
 
     assert exc_info.value.row_index == 2
-    assert "VestDate is missing from this transaction" in str(exc_info.value)
+    assert "The Deposit of GOOG on 12/30/2025 states no VestDate" in str(exc_info.value)
+
+
+def test_csv_deposit_missing_its_award_id_names_the_row() -> None:
+    """A detail with no guard of its own is still answered with its row."""
+    content = _csv_text(
+        [
+            {
+                "Date": "12/30/2025",
+                "Action": "Deposit",
+                "Symbol": "GOOG",
+                "Description": "RS",
+                "Quantity": "10",
+            },
+            {
+                "VestDate": "12/25/2025",
+                "VestFairMarketValue": "$315.67",
+                "AwardDate": "03/05/2025",
+            },
+        ]
+    )
+
+    with pytest.raises(ParsingError) as exc_info:
+        _parse(content)
+
+    assert exc_info.value.row_index == 2
+    assert "AwardId is missing from this transaction" in str(exc_info.value)
 
 
 def test_csv_blank_lines_between_transactions_are_ignored() -> None:

--- a/tests/schwab/test_schwab_lapse_pricing.py
+++ b/tests/schwab/test_schwab_lapse_pricing.py
@@ -289,6 +289,14 @@ def test_a_lapse_with_an_unreadable_date_fails(tmp_path: Path) -> None:
         _load(schwab_file=str(MAIN_HISTORY), schwab_award_file=award_file)
 
 
+def test_a_lapse_stating_no_date_fails(tmp_path: Path) -> None:
+    """A price with no date cannot be matched to the vest it prices."""
+    award_file = _export(tmp_path, _lapse(date=""))
+
+    with pytest.raises(ParsingError, match=r"Transactions\[0\] states no Date"):
+        _load(schwab_file=str(MAIN_HISTORY), schwab_award_file=award_file)
+
+
 def test_a_lapse_stating_two_grants_in_one_row_fails(tmp_path: Path) -> None:
     """One lapse prices one vest, and cgt-calc will not pick between two."""
     detail_rows = [


### PR DESCRIPTION
A single unreadable date anywhere in a Schwab Equity Awards export stopped cgt-calc with a Python traceback naming neither the file, the row, nor the field:

```
ValueError: time data '2023-06-12' does not match format '%m/%d/%Y'
```

Where the field was absent rather than malformed it was worse, `KeyError: 'Date'`. That is the JSON export. The CSV one already carried the file and row, but reported the failure as the Python format string. Neither named the field, and a real export runs to several hundred rows.

The same input now says which transaction to look at and what was found there:

```
While parsing EquityAwardsCenter_Transactions.json: The Sale of NVDA states Date as '2023-06-12', which is not a date cgt-calc reads. Equity Awards exports state MM/DD/YYYY.
```

An absent or empty field reads `The Sale of NVDA states no Date` instead of raising `KeyError`. A field holding something that is not a string at all is still quoted back rather than called absent, because the JSON decoder hands a bare number over as a `Decimal` and the row does state something to search for. The CSV layout keeps its physical row number. Both layouts are decoded into the same rows and read by the same code, so one guard covers both.

Seven call sites all did the same `strptime`, and only the one on the vest-price path guarded it. That guard is now the helper `_row_date` and every site goes through it. Guarding them leaves `_csv_row_errors` with an `except ValueError` clause nothing reachable can raise, so it goes rather than stay behind as an untested line.

`MM/DD/YYYY` stays the only form accepted, and `docs/brokers/schwab.md` now says what that does and does not establish. It establishes only that a value cannot be read, never how it came to be that way. What it cannot catch is a swapped day and month that lands on a valid date: `12/06/2023` reads as 6 December whatever it was meant to be. That limit is the reason to work from an unedited export rather than correct dates by hand, so the troubleshooting entry states it.

Two further limitations, both unchanged by this PR. A `decimal.Overflow` or `decimal.InvalidOperation` from a number field still escapes the CSV wrapper without naming the file or row. And the row number a CSV error carries is the transaction's own row, not the physical line a bad detail field sits on, so an unreadable `PurchaseDate` on line 3 is reported against row 2; the transaction name and the quoted value still identify it.

`AwardDate` is quoted into a transaction's description and never parsed, so it keeps no guard.
