### PR TITLE
Check links to this repository's files against the checkout

### DIFF
--- a/scripts/check_links.sh
+++ b/scripts/check_links.sh
@@ -8,10 +8,11 @@
 #   external - everything, including third party sites. Can fail for reasons
 #              unrelated to the change under review.
 #
-# Shared settings live in lychee.toml. The remap resolves cgt-calc.uk URLs
-# against the local docs sources, so a link to a page added in the same change
-# is checked before the site is deployed. lychee requires an absolute file://
-# target for a remap, hence the interpolation of the repository root below.
+# Shared settings live in lychee.toml. The remaps resolve cgt-calc.uk URLs
+# against the local docs sources and this repository's own file URLs against
+# the checkout, so a link to a page or file added in the same change is checked
+# before it reaches main. lychee requires an absolute file:// target for a
+# remap, hence the interpolation of the repository root below.
 #
 # The offline pass also reads the package sources, where the error messages
 # print documentation URLs. lychee treats any file it does not recognise as
@@ -27,11 +28,16 @@ set -uo pipefail
 root="$(git rev-parse --show-toplevel)" || exit 1
 cd "$root" || exit 1
 
-# Single quotes around the pattern keep the backslash and lychee's own $1
+# Single quotes around the patterns keep the backslash and lychee's own $1
 # capture reference literal; only the repository root is interpolated.
 remap='https://cgt-calc\.uk/(.*) file://'"$root"'/docs/$1'
 
-lychee=(uv run --only-group links lychee --remap "$remap")
+# Only blob URLs, which name a file. A tree URL names a directory, which lychee
+# resolves through the index_files setting, so remapping one would look for an
+# index.md inside the target and report the link as broken.
+repo_remap='https://github\.com/cgt-calc/capital-gains-calculator/blob/main/(.*) file://'"$root"'/$1'
+
+lychee=(uv run --only-group links lychee --remap "$remap" --remap "$repo_remap")
 
 status=0
 


### PR DESCRIPTION
A documentation link to a file in this repository is written as a `blob/main` URL, so it 404s until the change that adds the file is merged. Every pull request adding a bundled resource has had to ignore a red link check for links that were never actually broken. The reverse case is worse: a link left pointing at a file that has since been renamed or deleted only fails after it reaches `main`, and only in the external pass, where a failure is often unrelated to the change under review.

`scripts/check_links.sh` already remaps `cgt-calc.uk` URLs onto the local docs sources for the same reason. This adds a second `--remap` for this repository's own `blob/main` URLs, so both are checked in the deterministic offline pass against the files the change actually contains.

Twenty links that were previously only checked over the network are now checked locally, and a link to a file that does not exist fails immediately:

```
[ERROR] file://.../cgt_calc/resources/eri/does_not_exist.csv | File not found.
        Remaps: https://github.com/cgt-calc/capital-gains-calculator/blob/main/cgt_calc/resources/eri/does_not_exist.csv
```

Only `blob` URLs are remapped. A `tree` URL names a directory, which lychee resolves through the `index_files` setting, so remapping one would look for an `index.md` inside the target and report the link as broken. The five `tree/main` links in the documentation are left to the external pass.

This checks that the path exists in the checkout, not on `main`. That is the intended behaviour here: the branch content is what a squash merge puts on `main`, and it is the same trade-off the existing `cgt-calc.uk` remap makes.
